### PR TITLE
[FEAT] JWT 토큰 재발급 (#147)

### DIFF
--- a/DATEROAD-iOS/DATEROAD-iOS.xcodeproj/project.pbxproj
+++ b/DATEROAD-iOS/DATEROAD-iOS.xcodeproj/project.pbxproj
@@ -195,6 +195,8 @@
 		CAA30AEB2C37DCE300835DE3 /* ProfileViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = CAA30AEA2C37DCE300835DE3 /* ProfileViewModel.swift */; };
 		CAA30AED2C37E57400835DE3 /* String+.swift in Sources */ = {isa = PBXBuildFile; fileRef = CAA30AEC2C37E57400835DE3 /* String+.swift */; };
 		CAA76AD32C65FE0100821E3E /* SplashViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = CAA76AD22C65FE0100821E3E /* SplashViewModel.swift */; };
+		CAA76AD52C665E8B00821E3E /* PatchReissueResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = CAA76AD42C665E8B00821E3E /* PatchReissueResponse.swift */; };
+		CAA76AD72C6664B100821E3E /* Serviceable.swift in Sources */ = {isa = PBXBuildFile; fileRef = CAA76AD62C6664B100821E3E /* Serviceable.swift */; };
 		CABDCE6E2C47D6E600631FB3 /* AuthTargetType.swift in Sources */ = {isa = PBXBuildFile; fileRef = CABDCE6D2C47D6E600631FB3 /* AuthTargetType.swift */; };
 		CABDCE712C47D8F400631FB3 /* PostSignUpRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = CABDCE702C47D8F400631FB3 /* PostSignUpRequest.swift */; };
 		CABDCE732C47FA5C00631FB3 /* AuthService.swift in Sources */ = {isa = PBXBuildFile; fileRef = CABDCE722C47FA5C00631FB3 /* AuthService.swift */; };
@@ -444,6 +446,8 @@
 		CAA30AEA2C37DCE300835DE3 /* ProfileViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfileViewModel.swift; sourceTree = "<group>"; };
 		CAA30AEC2C37E57400835DE3 /* String+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "String+.swift"; sourceTree = "<group>"; };
 		CAA76AD22C65FE0100821E3E /* SplashViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SplashViewModel.swift; sourceTree = "<group>"; };
+		CAA76AD42C665E8B00821E3E /* PatchReissueResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PatchReissueResponse.swift; sourceTree = "<group>"; };
+		CAA76AD62C6664B100821E3E /* Serviceable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Serviceable.swift; sourceTree = "<group>"; };
 		CABDCE6D2C47D6E600631FB3 /* AuthTargetType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthTargetType.swift; sourceTree = "<group>"; };
 		CABDCE702C47D8F400631FB3 /* PostSignUpRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostSignUpRequest.swift; sourceTree = "<group>"; };
 		CABDCE722C47FA5C00631FB3 /* AuthService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthService.swift; sourceTree = "<group>"; };
@@ -1365,6 +1369,7 @@
 				CA78FE482C3866FC001B1403 /* DRErrorType.swift */,
 				CAC80FE22C3EC06200658EA6 /* MainSectionLayout.swift */,
 				CA80C0D62C4523A2002CAA9B /* DRBottomSheetAction.swift */,
+				CAA76AD62C6664B100821E3E /* Serviceable.swift */,
 			);
 			path = Protocols;
 			sourceTree = "<group>";
@@ -1473,6 +1478,7 @@
 				CABDCE742C47FAFD00631FB3 /* PostSignUpResponse.swift */,
 				CABDCE7A2C48498200631FB3 /* PostSignInRequest.swift */,
 				CABDCE842C489C7B00631FB3 /* DeleteWithdrawalRequest.swift */,
+				CAA76AD42C665E8B00821E3E /* PatchReissueResponse.swift */,
 			);
 			path = DTO;
 			sourceTree = "<group>";
@@ -1927,6 +1933,7 @@
 				0D0DA3DE2C3AF37C004210EE /* PointCollectionViewCell.swift in Sources */,
 				9E754CEF2C483ED100E2CA91 /* AddScheduleBottomSheetView.swift in Sources */,
 				9E754CE72C48389200E2CA91 /* AddScheduleSecondViewController.swift in Sources */,
+				CAA76AD52C665E8B00821E3E /* PatchReissueResponse.swift in Sources */,
 				CA0A963E2C2B131300F39EBE /* BaseViewController.swift in Sources */,
 				CA3D0CDD2C29A2F300735097 /* SceneDelegate.swift in Sources */,
 				745547692C3C8D3200B526F3 /* DateDetailContentView.swift in Sources */,
@@ -1971,6 +1978,7 @@
 				CABDCEB72C4A695E00631FB3 /* BannerDetailModel.swift in Sources */,
 				CA4EF3BD2C3285A1003B02B6 /* ScreenUtils.swift in Sources */,
 				CAC80FF32C3F203800658EA6 /* EmptyTicketView.swift in Sources */,
+				CAA76AD72C6664B100821E3E /* Serviceable.swift in Sources */,
 				CAA30AE02C3733DF00835DE3 /* ProfileView.swift in Sources */,
 				CAC80FCE2C3D2FD800658EA6 /* BottomControlView.swift in Sources */,
 				CA4EF3CB2C3287DA003B02B6 /* Config.swift in Sources */,

--- a/DATEROAD-iOS/DATEROAD-iOS/Global/Protocols/Serviceable.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Global/Protocols/Serviceable.swift
@@ -1,0 +1,8 @@
+//
+//  Serviceable.swift
+//  DATEROAD-iOS
+//
+//  Created by 윤희슬 on 8/9/24.
+//
+
+import Foundation

--- a/DATEROAD-iOS/DATEROAD-iOS/Global/Protocols/Serviceable.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Global/Protocols/Serviceable.swift
@@ -6,3 +6,29 @@
 //
 
 import Foundation
+
+protocol Serviceable: AnyObject {
+    func patchReissue() -> Bool
+}
+
+extension Serviceable {
+    func patchReissue() -> Bool {
+        var isSuccess: Bool = false
+        let access = UserDefaults.standard.string(forKey: "accessToken") ?? ""
+        let token = UserDefaults.standard.string(forKey: "refreshToken") ?? ""
+
+        NetworkService.shared.authService.patchReissue() { response in
+            switch response {
+            case .success(let data):
+                UserDefaults.standard.setValue(data.accessToken, forKey: "accessToken")
+                UserDefaults.standard.setValue(data.refreshToken, forKey: "refreshToken")
+                UserDefaults.standard.setValue(data.userID, forKey: "userID")
+                isSuccess = true
+            default:
+                print("Failed to fetch patch reissue")
+                isSuccess = false
+            }
+        }
+        return isSuccess
+    }
+}

--- a/DATEROAD-iOS/DATEROAD-iOS/Network/Auth/AuthService.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Network/Auth/AuthService.swift
@@ -15,6 +15,7 @@ protocol AuthServiceProtocol {
     func deleteLogout(completion: @escaping (NetworkResult<EmptyResponse>) -> ())
     func postSignIn(requestBody: PostSignInRequest, completion: @escaping (NetworkResult<PostSignUpResponse>) -> ())
     func deleteWithdrawal(requestBody: DeleteWithdrawalRequest, completion: @escaping (NetworkResult<EmptyResponse>) -> ())
+    func patchReissue(completion: @escaping (NetworkResult<PatchReissueResponse>) -> ())
 }
 
 final class AuthService: BaseService, AuthServiceProtocol {
@@ -74,6 +75,18 @@ final class AuthService: BaseService, AuthServiceProtocol {
             switch result {
             case .success(let response):
                 let networkResult: NetworkResult<EmptyResponse> = self.judgeStatus(statusCode: response.statusCode, data: response.data)
+                completion(networkResult)
+            case .failure(let err):
+                print(err)
+            }
+        }
+    }
+    
+    func patchReissue(completion: @escaping (NetworkResult<PatchReissueResponse>) -> ()) {
+        provider.request(.patchReissue) { result in
+            switch result {
+            case .success(let response):
+                let networkResult: NetworkResult<PatchReissueResponse> = self.judgeStatus(statusCode: response.statusCode, data: response.data)
                 completion(networkResult)
             case .failure(let err):
                 print(err)

--- a/DATEROAD-iOS/DATEROAD-iOS/Network/Auth/AuthTargetType.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Network/Auth/AuthTargetType.swift
@@ -15,6 +15,7 @@ enum AuthTargetType {
     case deleteLogout
     case postSignIn(requestBody: PostSignInRequest)
     case deleteWithdrawal(requestBody: DeleteWithdrawalRequest)
+    case patchReissue
 }
 
 extension AuthTargetType: BaseTargetType {
@@ -31,6 +32,8 @@ extension AuthTargetType: BaseTargetType {
             return .get
         case .deleteLogout, .deleteWithdrawal:
             return .delete
+        case .patchReissue:
+            return .patch
         }
     }
     
@@ -46,6 +49,8 @@ extension AuthTargetType: BaseTargetType {
             return utilPath + "/signin"
         case .deleteWithdrawal:
             return utilPath + "/withdraw"
+        case .patchReissue:
+            return utilPath + "/reissue"
         }
     }
 
@@ -112,6 +117,10 @@ extension AuthTargetType: BaseTargetType {
             return headers
         case .postSignIn:
             let token = UserDefaults.standard.string(forKey: "Token") ?? ""
+            let headers = ["Content-Type" : "application/json", "Authorization" : token]
+            return headers
+        case .patchReissue:
+            let token = UserDefaults.standard.string(forKey: "refreshToken") ?? ""
             let headers = ["Content-Type" : "application/json", "Authorization" : token]
             return headers
         default:

--- a/DATEROAD-iOS/DATEROAD-iOS/Network/Auth/DTO/PatchReissueResponse.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Network/Auth/DTO/PatchReissueResponse.swift
@@ -1,0 +1,18 @@
+//
+//  PatchReissueResponse.swift
+//  DATEROAD-iOS
+//
+//  Created by 윤희슬 on 8/9/24.
+//
+
+import Foundation
+
+struct PatchReissueResponse: Codable {
+    let userID: Int
+    let accessToken, refreshToken: String
+
+    enum CodingKeys: String, CodingKey {
+        case userID = "userId"
+        case accessToken, refreshToken
+    }
+}

--- a/DATEROAD-iOS/DATEROAD-iOS/Network/Base/BaseService.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Network/Base/BaseService.swift
@@ -13,6 +13,8 @@ class BaseService {
         switch statusCode {
         case 200..<205:
             return isValidData(data: data, responseType: T.self, statusCode: statusCode)
+        case 401:
+            return .reIssueJWT
         case 400..<500:
             return .requestErr
         case 500:

--- a/DATEROAD-iOS/DATEROAD-iOS/Network/Base/NetworkResult.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Network/Base/NetworkResult.swift
@@ -14,4 +14,5 @@ enum NetworkResult<T> {
     case pathErr                  // 경로 에러 발생했을 때,
     case serverErr                // 서버의 내부적 에러가 발생했을 때,
     case networkFail              // 네트워크 연결 실패했을 때
-} 
+    case reIssueJWT             // 토큰 재발급 필요할 때
+}

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/AddCourse/ViewModels/AddCourseViewModel.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/AddCourse/ViewModels/AddCourseViewModel.swift
@@ -7,8 +7,10 @@
 
 import UIKit
 
-final class AddCourseViewModel {
-   
+final class AddCourseViewModel: Serviceable {
+    
+    var onReissueSuccess: ObservablePattern<Bool> = ObservablePattern(nil)
+
    var pastDateDetailData: DateDetailModel?
    var ispastDateVaild: ObservablePattern<Bool> = ObservablePattern(false)
    
@@ -325,6 +327,8 @@ extension AddCourseViewModel {
          switch result {
          case .success(let response):
             print("Success: \(response)")
+         case .reIssueJWT:
+             self.onReissueSuccess.value = self.patchReissue()
          default:
             print("Failed to fetch user profile")
             return

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/AddCourse/Views/AddCourseFirst/AddCourseFirstViewController.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/AddCourse/Views/AddCourseFirst/AddCourseFirstViewController.swift
@@ -94,6 +94,13 @@ private extension AddCourseFirstViewController {
    }
    
    func bindViewModel() {
+       self.viewModel.onReissueSuccess.bind { [weak self] onSuccess in
+           guard let onSuccess else { return }
+           if onSuccess {
+               self?.navigationController?.pushViewController(SplashViewController(splashViewModel: SplashViewModel()), animated: false)
+           }
+       }
+       
       viewModel.ispastDateVaild.bind { date in
          self.viewModel.fetchPastDate()
          self.addCourseFirstView.addFirstView.tendencyTagCollectionView.reloadData()

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/AddCourse/Views/AddCourseSecond/AddCourseSecondViewController.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/AddCourse/Views/AddCourseSecond/AddCourseSecondViewController.swift
@@ -117,6 +117,13 @@ private extension AddCourseSecondViewController {
    }
    
    func bindViewModel() {
+       self.viewModel.onReissueSuccess.bind { [weak self] onSuccess in
+           guard let onSuccess else { return }
+           if onSuccess {
+               self?.navigationController?.pushViewController(SplashViewController(splashViewModel: SplashViewModel()), animated: false)
+           }
+       }
+       
       viewModel.isDataSourceNotEmpty()
       
       viewModel.editBtnEnableState.bind { [weak self] date in

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/AddCourse/Views/AddCourseThird/AddCourseThirdViewController.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/AddCourse/Views/AddCourseThird/AddCourseThirdViewController.swift
@@ -131,6 +131,13 @@ extension AddCourseThirdViewController {
    }
    
    private func bindViewModel() {
+       self.viewModel.onReissueSuccess.bind { [weak self] onSuccess in
+           guard let onSuccess else { return }
+           if onSuccess {
+               self?.navigationController?.pushViewController(SplashViewController(splashViewModel: SplashViewModel()), animated: false)
+           }
+       }
+       
       viewModel.contentTextCount.bind { [weak self] date in
 //         self?.viewModel.contentText.text = date
          self?.addCourseThirdView.addThirdView.updateContentTextCount(textCnt: date ?? 0)

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/AddSchedule/ViewModels/AddScheduleViewModel.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/AddSchedule/ViewModels/AddScheduleViewModel.swift
@@ -7,7 +7,7 @@
 
 import UIKit
 
-final class AddScheduleViewModel {
+final class AddScheduleViewModel: Serviceable {
    var isImporting = false
    var viewedDateCourseByMeData: CourseDetailViewModel?
    var ispastDateVaild: ObservablePattern<Bool> = ObservablePattern(false)
@@ -69,6 +69,9 @@ final class AddScheduleViewModel {
    var isChange: (() -> Void)?
    
    var isEditMode: Bool = false
+    
+    var onReissueSuccess: ObservablePattern<Bool> = ObservablePattern(nil)
+
    
    init() {
       fetchTagData()
@@ -311,6 +314,8 @@ extension AddScheduleViewModel {
             switch result {
             case .success(let response):
                print("Success: \(response)")
+            case .reIssueJWT:
+                self.onReissueSuccess.value = self.patchReissue()
             default:
                print("Failed to fetch user profile")
                return

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/AddSchedule/Views/AddScheduleFirst/AddScheduleFirstViewController.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/AddSchedule/Views/AddScheduleFirst/AddScheduleFirstViewController.swift
@@ -85,6 +85,13 @@ extension AddScheduleFirstViewController {
    }
    
    func bindViewModel() {
+       self.viewModel.onReissueSuccess.bind { [weak self] onSuccess in
+           guard let onSuccess else { return }
+           if onSuccess {
+               self?.navigationController?.pushViewController(SplashViewController(splashViewModel: SplashViewModel()), animated: false)
+           }
+       }
+       
       viewModel.ispastDateVaild.bind { [weak self] isValid in
          guard let self = self else { return }
          self.viewModel.fetchPastDate {

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/AddSchedule/Views/AddScheduleSecond/AddScheduleSecondViewController.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/AddSchedule/Views/AddScheduleSecond/AddScheduleSecondViewController.swift
@@ -115,6 +115,13 @@ private extension AddScheduleSecondViewController {
    }
    
    func bindViewModel() {
+       self.viewModel.onReissueSuccess.bind { [weak self] onSuccess in
+           guard let onSuccess else { return }
+           if onSuccess {
+               self?.navigationController?.pushViewController(SplashViewController(splashViewModel: SplashViewModel()), animated: false)
+           }
+       }
+       
       viewModel.isDataSourceNotEmpty()
       
       viewModel.editBtnEnableState.bind { [weak self] date in

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/CourseDetail/ViewModels/CourseDetailViewModel.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/CourseDetail/ViewModels/CourseDetailViewModel.swift
@@ -20,7 +20,7 @@ enum CourseDetailSection {
     }
 }
 
-class CourseDetailViewModel {
+class CourseDetailViewModel: Serviceable {
     
     var courseId: Int
     
@@ -63,6 +63,9 @@ class CourseDetailViewModel {
     var bannerDetailData: ObservablePattern<BannerDetailModel> = ObservablePattern(nil)
     
     var bannerHeaderData: ObservablePattern<BannerHeaderModel> = ObservablePattern(nil)
+    
+    var onReissueSuccess: ObservablePattern<Bool> = ObservablePattern(nil)
+
     
 
     var advertisementId: Int = 0
@@ -171,8 +174,9 @@ extension CourseDetailViewModel {
                 self.isUserLiked.value = data.isUserLiked
                 
                 self.isSuccessGetData.value = true
-                
-                
+            case .reIssueJWT:
+                self.onReissueSuccess.value = self.patchReissue()
+
             default:
                 self.isSuccessGetData.value = false
                 print("Failed to fetch course data")
@@ -188,6 +192,8 @@ extension CourseDetailViewModel {
             case .success(let response):
                 self.isAccess.value = true
                 print("Successfully used points:", response)
+            case .reIssueJWT:
+                self.onReissueSuccess.value = self.patchReissue()
             default:
                 self.isSuccessGetData.value = false
                 print("Failed to post course data")
@@ -241,7 +247,8 @@ extension CourseDetailViewModel {
                 self.mainContentsData.value = MainContentsModel(description: data.description)
                 
                 self.isSuccessGetBannerData.value = true
-
+            case .reIssueJWT:
+                self.onReissueSuccess.value = self.patchReissue()
             default:
                 self.isSuccessGetBannerData.value = false
                 print("Failed to fetch banner detail data")

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/CourseDetail/Views/CourseDetailViewController.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/CourseDetail/Views/CourseDetailViewController.swift
@@ -101,6 +101,12 @@ final class CourseDetailViewController: BaseViewController, DRCustomAlertDelegat
 //        self.courseDetailViewModel.isChange = { [weak self] in
 //            self?.courseDetailView.mainCollectionView.reloadData()
 //        }
+        self.courseDetailViewModel.onReissueSuccess.bind { [weak self] onSuccess in
+            guard let onSuccess else { return }
+            if onSuccess {
+                self?.navigationController?.pushViewController(SplashViewController(splashViewModel: SplashViewModel()), animated: false)
+            }
+        }
         
         courseDetailViewModel.currentPage.bind { [weak self] currentPage in
             guard let self = self else { return }

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/DateSchedule/View/PastDateDetailViewController.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/DateSchedule/View/PastDateDetailViewController.swift
@@ -104,6 +104,13 @@ extension PastDateDetailViewController {
 //    }
     
     func bindViewModel() {
+        self.pastDateDetailViewModel?.onReissueSuccess.bind { [weak self] onSuccess in
+            guard let onSuccess else { return }
+            if onSuccess {
+                self?.navigationController?.pushViewController(SplashViewController(splashViewModel: SplashViewModel()), animated: false)
+            }
+        }
+        
         self.pastDateDetailViewModel?.isSuccessGetDateDetailData.bind { [weak self] isSuccess in
             guard let isSuccess, let data = self?.pastDateDetailViewModel?.dateDetailData.value else { return }
             if isSuccess {

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/DateSchedule/View/PastDateViewController.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/DateSchedule/View/PastDateViewController.swift
@@ -88,6 +88,13 @@ private extension PastDateViewController {
 
     
     func bindViewModel() {
+        self.pastDateScheduleViewModel.onReissueSuccess.bind { [weak self] onSuccess in
+            guard let onSuccess else { return }
+            if onSuccess {
+                self?.navigationController?.pushViewController(SplashViewController(splashViewModel: SplashViewModel()), animated: false)
+            }
+        }
+        
         self.pastDateScheduleViewModel.isSuccessGetPastDateScheduleData.bind { [weak self] isSuccess in
             guard let isSuccess else { return }
             if isSuccess {

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/DateSchedule/View/UpcomingDateDetailViewController.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/DateSchedule/View/UpcomingDateDetailViewController.swift
@@ -63,6 +63,13 @@ class UpcomingDateDetailViewController: BaseNavBarViewController {
 
 extension UpcomingDateDetailViewController {
     func bindViewModel() {
+        self.upcomingDateDetailViewModel?.onReissueSuccess.bind { [weak self] onSuccess in
+            guard let onSuccess else { return }
+            if onSuccess {
+                self?.navigationController?.pushViewController(SplashViewController(splashViewModel: SplashViewModel()), animated: false)
+            }
+        }
+        
         self.upcomingDateDetailViewModel?.isSuccessGetDateDetailData.bind { [weak self] isSuccess in
             guard let isSuccess, let data = self?.upcomingDateDetailViewModel?.dateDetailData.value else { return }
             if isSuccess {

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/DateSchedule/View/UpcomingDateScheduleViewController.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/DateSchedule/View/UpcomingDateScheduleViewController.swift
@@ -104,6 +104,13 @@ private extension UpcomingDateScheduleViewController {
     }
     
     func bindViewModel() {
+        self.upcomingDateScheduleViewModel.onReissueSuccess.bind { [weak self] onSuccess in
+            guard let onSuccess else { return }
+            if onSuccess {
+                self?.navigationController?.pushViewController(SplashViewController(splashViewModel: SplashViewModel()), animated: false)
+            }
+        }
+        
         self.upcomingDateScheduleViewModel.isSuccessGetUpcomingDateScheduleData.bind { [weak self] isSuccess in
             guard let isSuccess else { return }
             if isSuccess == true {

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/DateSchedule/ViewModel/DateDetailViewModel.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/DateSchedule/ViewModel/DateDetailViewModel.swift
@@ -13,7 +13,10 @@ import KakaoSDKCommon
 import KakaoSDKAuth
 import KakaoSDKUser
 
-class DateDetailViewModel {
+class DateDetailViewModel: Serviceable {
+
+    var onReissueSuccess: ObservablePattern<Bool> = ObservablePattern(nil)
+
    
 //
 //    var upcomingDateDetailDummyData = DateDetailModel(
@@ -79,6 +82,8 @@ class DateDetailViewModel {
                 self.dateDetailData.value = DateDetailModel(dateID: data.dateID, title: data.title, startAt: data.startAt, city: data.city, tags: tagsInfo, date: data.date.formatDateFromString(inputFormat: "yyyy.MM.dd", outputFormat: "yyyy년 M월 d일") ?? "", places: datePlaceInfo, dDay: data.dDay)
                 self.isSuccessGetDateDetailData.value = true
                 print("@log ----------dsijflskdjfla", self.dateDetailData.value)
+            case .reIssueJWT:
+                self.onReissueSuccess.value = self.patchReissue()
             case .requestErr:
                 print("requestError")
             case .decodedErr:
@@ -100,6 +105,8 @@ class DateDetailViewModel {
                 print(data)
                 self.isSuccessDeleteDateScheduleData.value = true
                 print("success", self.isSuccessDeleteDateScheduleData.value)
+            case .reIssueJWT:
+                self.onReissueSuccess.value = self.patchReissue()
             default:
                 self.isSuccessDeleteDateScheduleData.value = false
             }

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/DateSchedule/ViewModel/DateScheduleViewModel.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/DateSchedule/ViewModel/DateScheduleViewModel.swift
@@ -7,7 +7,9 @@
 
 import Foundation
 
-class DateScheduleViewModel {
+class DateScheduleViewModel: Serviceable {
+    
+    var onReissueSuccess: ObservablePattern<Bool> = ObservablePattern(nil)
     
     let dateScheduleService = DateScheduleService()
     
@@ -45,6 +47,8 @@ class DateScheduleViewModel {
                 
                 self.pastDateScheduleData.value = dateScheduleInfo
                 self.isSuccessGetPastDateScheduleData.value = true
+            case .reIssueJWT:
+                self.onReissueSuccess.value = self.patchReissue()
             default:
                 self.isSuccessGetPastDateScheduleData.value = false
             }
@@ -69,6 +73,8 @@ class DateScheduleViewModel {
                 self.upcomingDateScheduleData.value = dateScheduleInfo
                 print("zz sched", self.upcomingDateScheduleData.value)
                 self.isSuccessGetUpcomingDateScheduleData.value = true
+            case .reIssueJWT:
+                self.onReissueSuccess.value = self.patchReissue()
             default:
                 self.isSuccessGetUpcomingDateScheduleData.value = false
             }

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/Login/ViewModels/LoginViewModel.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/Login/ViewModels/LoginViewModel.swift
@@ -12,7 +12,7 @@ import KakaoSDKAuth
 import KakaoSDKCommon
 import KakaoSDKUser
 
-final class LoginViewModel {
+final class LoginViewModel: Serviceable {
     
     var isKaKaoLogin: ObservablePattern<Bool> = ObservablePattern(nil)
     
@@ -27,6 +27,8 @@ final class LoginViewModel {
     var isSignIn: ObservablePattern<Bool> = ObservablePattern(nil)
     
     var onLoginSuccess: ObservablePattern<Bool> = ObservablePattern(nil)
+    
+    var onReissueSuccess: ObservablePattern<Bool> = ObservablePattern(nil)
     
 }
 
@@ -126,13 +128,13 @@ extension LoginViewModel {
                 self.isSignIn.value = true
             case .requestErr:
                 self.isSignIn.value = false
-                
+            case .reIssueJWT:
+                self.onReissueSuccess.value = self.patchReissue()
             default:
                 print("Failed to fetch post signin")
                 self.onLoginSuccess.value = false
                 return
             }
-            
         }
     }
 }

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/Login/Views/LoginViewController.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/Login/Views/LoginViewController.swift
@@ -52,6 +52,13 @@ extension LoginViewController {
             guard let isSignIn else { return }
             self?.pushToNextVC(isSignIn: isSignIn)
         }
+        
+        self.loginViewModel.onReissueSuccess.bind { [weak self] onSuccess in
+            guard let onSuccess else { return }
+            if onSuccess {
+                self?.navigationController?.pushViewController(SplashViewController(splashViewModel: SplashViewModel()), animated: false)
+            }
+        }
     }
     
     func setAddTarget() {

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/Main/ViewModels/MainViewModel.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/Main/ViewModels/MainViewModel.swift
@@ -14,16 +14,7 @@ import UIKit
 //    let courseId: Int
 //}
 
-final class MainViewModel {
-   
-
-//   var bannerData: [BannerData] = [
-//           BannerData(image: UIImage(resource: .bOne), courseId: 1),
-//           BannerData(image: UIImage(resource: .bTwo), courseId: 2),
-//           BannerData(image: UIImage(resource: .bThree), courseId: 3),
-//           BannerData(image: UIImage(resource: .bFour), courseId: 4),
-//           BannerData(image: UIImage(resource: .bFive), courseId: 5)
-//       ]
+final class MainViewModel: Serviceable {
     
     var isSuccessGetUserInfo: ObservablePattern<Bool> = ObservablePattern(false)
     
@@ -51,10 +42,8 @@ final class MainViewModel {
 
     let sectionData: [MainSection] = MainSection.dataSource
     
-    
-//    init() {
-//        fetchSectionData()
-//    }
+    var onReissueSuccess: ObservablePattern<Bool> = ObservablePattern(nil)
+
     
 }
 
@@ -77,6 +66,8 @@ extension MainViewModel {
                UserDefaults.standard.setValue(data.name, forKey: "userName")
                 UserDefaults.standard.setValue(data.point, forKey: "userPoint")
                 self.isSuccessGetUserInfo.value = true
+            case .reIssueJWT:
+                self.onReissueSuccess.value = self.patchReissue()
             default:
                 print("Failed to fetch user profile")
                 return
@@ -107,6 +98,8 @@ extension MainViewModel {
                                                                                   duration: $0.duration.formatFloatTime()) }
                     self.isSuccessGetNewDate.value = true
                 }
+            case .reIssueJWT:
+                self.onReissueSuccess.value = self.patchReissue()
             default:
                 print("Failed to fetch filtered date course")
                 return
@@ -125,6 +118,8 @@ extension MainViewModel {
                                                             day: data.day,
                                                             startAt: data.startAt)
                 self.isSuccessGetUpcomingDate.value = true
+            case .reIssueJWT:
+                self.onReissueSuccess.value = self.patchReissue()
             default:
                 print("Failed to fetch upcoming date course")
                 return
@@ -139,6 +134,8 @@ extension MainViewModel {
                 self.bannerData.value = data.advertisementDtoResList.map { BannerModel(advertisementId: $0.advertisementID, imageUrl: $0.thumbnail)
                 }
                 self.isSuccessGetBanner.value = true
+            case .reIssueJWT:
+                self.onReissueSuccess.value = self.patchReissue()
             default:
                 print("Failed to fetch get banner data")
                 return

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/Main/Views/MainViewController.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/Main/Views/MainViewController.swift
@@ -69,6 +69,13 @@ final class MainViewController: BaseViewController {
 extension MainViewController {
     
     func bindViewModel() {
+        self.mainViewModel.onReissueSuccess.bind { [weak self] onSuccess in
+            guard let onSuccess else { return }
+            if onSuccess {
+                self?.navigationController?.pushViewController(SplashViewController(splashViewModel: SplashViewModel()), animated: false)
+            }
+        }
+        
         self.mainViewModel.isSuccessGetUserInfo.bind { [weak self] isSuccess in
             guard let isSuccess else { return }
             if isSuccess {

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/MyCourse/ViewModels/MyCourseListViewModel.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/MyCourse/ViewModels/MyCourseListViewModel.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-class MyCourseListViewModel {
+class MyCourseListViewModel: Serviceable {
     
     var userName: String = ""
     
@@ -20,6 +20,9 @@ class MyCourseListViewModel {
     var isSuccessGetViewedCourseInfo: ObservablePattern<Bool> = ObservablePattern(nil)
     
     var isSuccessGetMyRegisterCourseInfo: ObservablePattern<Bool> = ObservablePattern(false)
+    
+    var onReissueSuccess: ObservablePattern<Bool> = ObservablePattern(nil)
+
     
     init() {
         let name = UserDefaults.standard.string(forKey: "userName") ?? ""
@@ -39,6 +42,8 @@ class MyCourseListViewModel {
                 }
                 self.viewedCourseData.value = viewedCourseInfo
                 self.isSuccessGetViewedCourseInfo.value = true
+            case .reIssueJWT:
+                self.onReissueSuccess.value = self.patchReissue()
             case .requestErr:
                 print("requestError")
             case .decodedErr:
@@ -63,6 +68,8 @@ class MyCourseListViewModel {
                 self.myRegisterCourseData.value = myRegisterCourseInfo
                 self.isSuccessGetMyRegisterCourseInfo.value = true
                 print("isUpdate>", self.myRegisterCourseData)
+            case .reIssueJWT:
+                self.onReissueSuccess.value = self.patchReissue()
             case .requestErr:
                 print("requestError")
             case .decodedErr:

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/MyCourse/Views/MyRegisterCourseViewController.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/MyCourse/Views/MyRegisterCourseViewController.swift
@@ -80,6 +80,13 @@ extension MyRegisterCourseViewController {
 
 extension MyRegisterCourseViewController {
     func bindViewModel() {
+        self.myRegisterCourseViewModel.onReissueSuccess.bind { [weak self] onSuccess in
+            guard let onSuccess else { return }
+            if onSuccess {
+                self?.navigationController?.pushViewController(SplashViewController(splashViewModel: SplashViewModel()), animated: false)
+            }
+        }
+        
         self.myRegisterCourseViewModel.isSuccessGetMyRegisterCourseInfo.bind { [weak self] isSuccess in
             guard let self = self else { return }
             guard let isSuccess else { return }

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/MyCourse/Views/NavViewedCourseViewController.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/MyCourse/Views/NavViewedCourseViewController.swift
@@ -80,6 +80,13 @@ extension NavViewedCourseViewController {
 
 extension NavViewedCourseViewController {
     func bindViewModel() {
+        self.viewedCourseViewModel.onReissueSuccess.bind { [weak self] onSuccess in
+            guard let onSuccess else { return }
+            if onSuccess {
+                self?.navigationController?.pushViewController(SplashViewController(splashViewModel: SplashViewModel()), animated: false)
+            }
+        }
+        
         self.viewedCourseViewModel.isSuccessGetViewedCourseInfo.bind { [weak self] isSuccess in
             guard let isSuccess else { return }
             if isSuccess {

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/MyPage/ViewModels/MyPageViewModel.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/MyPage/ViewModels/MyPageViewModel.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-final class MyPageViewModel {
+final class MyPageViewModel: Serviceable {
     
     var isAppleLogin: Bool = false
     
@@ -20,6 +20,8 @@ final class MyPageViewModel {
     var onSuccessWithdrawal: ObservablePattern<Bool> = ObservablePattern(nil)
     
     var onSuccessGetUserProfile: ObservablePattern<Bool> = ObservablePattern(nil)
+
+    var onReissueSuccess: ObservablePattern<Bool> = ObservablePattern(nil)
 
 }
 
@@ -38,6 +40,8 @@ extension MyPageViewModel {
                     UserDefaults.standard.removeObject(forKey: key.description)
                 }
                 self.onSuccessLogout.value = true
+            case .reIssueJWT:
+                self.onReissueSuccess.value = self.patchReissue()
             default:
                 print("Failed to fetch post logout")
                 self.onSuccessLogout.value = false
@@ -61,6 +65,8 @@ extension MyPageViewModel {
                     UserDefaults.standard.removeObject(forKey: key.description)
                 }
                 self.onSuccessWithdrawal.value = true
+            case .reIssueJWT:
+                self.onReissueSuccess.value = self.patchReissue()
             default:
                 print("Failed to fetch delete withdrawal")
                 self.onSuccessWithdrawal.value = false
@@ -79,6 +85,8 @@ extension MyPageViewModel {
                                                               imageURL: data.imageURL)
                self.tagData = data.tags
                self.onSuccessGetUserProfile.value = true
+            case .reIssueJWT:
+                self.onReissueSuccess.value = self.patchReissue()
             default:
                 print("Failed to fetch getUserProfile")
                 self.onSuccessGetUserProfile.value = false

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/MyPage/Views/MyPageViewController.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/MyPage/Views/MyPageViewController.swift
@@ -96,6 +96,13 @@ private extension MyPageViewController {
     }
     
     func bindViewModel() {
+        self.myPageViewModel.onReissueSuccess.bind { [weak self] onSuccess in
+            guard let onSuccess else { return }
+            if onSuccess {
+                self?.navigationController?.pushViewController(SplashViewController(splashViewModel: SplashViewModel()), animated: false)
+            }
+        }
+        
         self.myPageViewModel.onSuccessLogout.bind { [weak self] isSuccess in
             guard let isSuccess else { return }
             if isSuccess {

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/PointDetail/ViewModels/PointViewModel.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/PointDetail/ViewModels/PointViewModel.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-final class PointViewModel {
+final class PointViewModel: Serviceable {
     
     var userName: String
     
@@ -26,6 +26,9 @@ final class PointViewModel {
     var isEarnedPointHidden : ObservablePattern<Bool> = ObservablePattern(nil)
    
    var isChange: ObservablePattern<Bool> = ObservablePattern(nil)
+    
+    var onReissueSuccess: ObservablePattern<Bool> = ObservablePattern(nil)
+
     
     init (userName: String, totalPoint: Int) {
         self.userName = userName
@@ -68,6 +71,8 @@ final class PointViewModel {
                 self.updateData(nowEarnedPointHidden: nowEarnedPointHidden)
                 self.isSuccessGetPointInfo.value = true
                self.isChange.value = true
+            case .reIssueJWT:
+                self.onReissueSuccess.value = self.patchReissue()
             case .requestErr:
                  print("requestError")
              case .decodedErr:

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/PointDetail/Views/PointDetailViewController.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/PointDetail/Views/PointDetailViewController.swift
@@ -90,6 +90,13 @@ class PointDetailViewController: BaseNavBarViewController {
 
 extension PointDetailViewController {
     func bindViewModel() {
+        self.pointViewModel.onReissueSuccess.bind { [weak self] onSuccess in
+            guard let onSuccess else { return }
+            if onSuccess {
+                self?.navigationController?.pushViewController(SplashViewController(splashViewModel: SplashViewModel()), animated: false)
+            }
+        }
+        
         // 선택된 내역의 데이터
         self.pointViewModel.nowPointData.bind { [weak self] data in
             print("좀 되라 \(data)")

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/Profile/ViewModels/ProfileViewModel.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/Profile/ViewModels/ProfileViewModel.swift
@@ -7,7 +7,7 @@
 
 import UIKit
 
-final class ProfileViewModel {
+final class ProfileViewModel: Serviceable {
     
     var tagData: [ProfileTagModel] = []
     
@@ -40,6 +40,9 @@ final class ProfileViewModel {
     var onSuccessRegister: ((Bool) -> Void)?
     
     var onSuccessEdit: ((Bool) -> Void)?
+    
+    var onReissueSuccess: ObservablePattern<Bool> = ObservablePattern(nil)
+
  
     init(profileData: ProfileModel) {
         self.profileData = ObservablePattern(profileData)
@@ -133,6 +136,8 @@ extension ProfileViewModel {
                 UserDefaults.standard.setValue(data.refreshToken, forKey: "refreshToken")
                 print("post \(data)")
                 self.onSuccessRegister?(true)
+            case .reIssueJWT:
+                self.onReissueSuccess.value = self.patchReissue()
             default:
                 print("Failed to fetch post signup")
                 self.onSuccessRegister?(false)
@@ -149,6 +154,8 @@ extension ProfileViewModel {
             switch response {
             case .success(_):
                 self.isValidNickname.value = true
+            case .reIssueJWT:
+                self.onReissueSuccess.value = self.patchReissue()
             case .requestErr:
                 self.isValidNickname.value = false
             default:
@@ -167,6 +174,8 @@ extension ProfileViewModel {
             switch response {
             case .success(_):
                 self.onSuccessEdit?(true)
+            case .reIssueJWT:
+                self.onReissueSuccess.value = self.patchReissue()
             default:
                 print("Failed to fetch patch edit profile")
                 self.onSuccessEdit?(false)

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/Profile/Views/ProfileViewController.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/Profile/Views/ProfileViewController.swift
@@ -134,6 +134,13 @@ private extension ProfileViewController {
     }
     
     func bindViewModel() {
+        self.profileViewModel.onReissueSuccess.bind { [weak self] onSuccess in
+            guard let onSuccess else { return }
+            if onSuccess {
+                self?.navigationController?.pushViewController(SplashViewController(splashViewModel: SplashViewModel()), animated: false)
+            }
+        }
+        
         self.profileViewModel.profileImage.bind { [weak self] image in
             guard let initial = self?.initial else { return }
             if self?.editType == EditType.edit && initial {

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/Splash/ViewModels/SplashViewModel.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/Splash/ViewModels/SplashViewModel.swift
@@ -7,15 +7,19 @@
 
 import Foundation
 
-final class SplashViewModel {
+final class SplashViewModel: Serviceable {
     
     var isLoginned: ObservablePattern<Bool> = ObservablePattern(nil)
+
+    var onReissueSuccess: ObservablePattern<Bool> = ObservablePattern(nil)
 
 }
 
 extension SplashViewModel {
     
     func checkIsLoginned() {
+        self.onReissueSuccess.value = self.patchReissue()
+        
         guard let token = UserDefaults.standard.string(forKey: "accessToken")
         else {
             isLoginned.value = false


### PR DESCRIPTION
# 🔥*Pull requests*

## ⛳ **작업한 브랜치**
- feature/#147

## 👷 **작업한 내용**
<!-- 작업한 내용을 적어주세요. -->
- JWT 토큰 재발급

## 🚨 참고 사항
<!-- 참고할 사항이 있다면 적어주세요. -->
### 1️⃣ JWT 토큰 재발급
- 서버 통신의 결과로 토큰이 만료되어 재발급이 필요한 code를 넘겨받을 때, 이에 대한 분기처리를 위해 NetworkResult와 BaseService에 각각 관련 내용을 추가해주었습니다
``` Swift
enum NetworkResult<T> {
    ...
    case reIssueJWT             // 토큰 재발급 필요할 때
}

    func judgeStatus<T: Codable>(statusCode: Int, data: Data) -> NetworkResult<T> {
        switch statusCode {
        ...
        case 401:
            return .reIssueJWT
    }
```

- 모든 서버 통신을 할 때, NetworkResult로 reissue를 받을 때마다 재발급 서버 통신을 해주어야 하는데, 모든 뷰모델에 재발급 서버 통신 메소드를 적어주는 것은 비효율적이라고 판단했습니다. 그래서 Serviceable이라는 프로토콜을 만들었고 해당 프로토콜에 재발급 서버 통신 관련 메소드를 구현했고 모든 뷰모델이 이 프로토콜을 채택받도록 구현했습니다
- 이 메소드는 서버 통신 결과를 Bool 타입으로 반환하는데, 이 값이 true인 경우에만 Splash로 돌아가도록 구현했습니다

``` Swift
// Serviceable 프로토콜

protocol Serviceable: AnyObject {
    func patchReissue() -> Bool
}

extension Serviceable {
    func patchReissue() -> Bool {
        var isSuccess: Bool = false
        let access = UserDefaults.standard.string(forKey: "accessToken") ?? ""
        let token = UserDefaults.standard.string(forKey: "refreshToken") ?? ""

        NetworkService.shared.authService.patchReissue() { response in
            switch response {
            case .success(let data):
                UserDefaults.standard.setValue(data.accessToken, forKey: "accessToken")
                UserDefaults.standard.setValue(data.refreshToken, forKey: "refreshToken")
                UserDefaults.standard.setValue(data.userID, forKey: "userID")
                isSuccess = true
            default:
                print("Failed to fetch patch reissue")
                isSuccess = false
            }
        }
        return isSuccess
    }
}


// 적용 예시
final class LoginViewModel: Serviceable {
    ...    
    var onReissueSuccess: ObservablePattern<Bool> = ObservablePattern(nil)
    
}

extension LoginViewModel {

    func postSignIn() {
         ...
          NetworkService.shared.authService.postSignIn(requestBody: requestBody) { response in
            switch response {
            case .success(let data):
                ...
            case .requestErr:
                ...
            case .reIssueJWT:
                self.onReissueSuccess.value = self.patchReissue()
            default:
                ...
            }
        }
    }
}

// ViewController
self.loginViewModel.onReissueSuccess.bind { [weak self] onSuccess in
    guard let onSuccess else { return }
    if onSuccess {
        self?.navigationController?.pushViewController(SplashViewController(splashViewModel: SplashViewModel()), animated: false)
    }
}

``` 

+커밋에 이슈번호 잘못 적음,,, 레전드 멍청이슈


## 📸 스크린샷
|기능|스크린샷|
|:--:|:--:|
|아이폰15Pro|![Simulator Screen Recording - iPhone 15 Pro - 2024-08-10 at 01 08 09](https://github.com/user-attachments/assets/97a0e337-7401-4b16-b992-856e62c479cd)|


## 📟 관련 이슈
- Resolved: #147 
