### PR TITLE
[FEAT] 코스 상세 변경된 GUI 적용 및 플로우 수정 (#160)

### DIFF
--- a/DATEROAD-iOS/DATEROAD-iOS.xcodeproj/project.pbxproj
+++ b/DATEROAD-iOS/DATEROAD-iOS.xcodeproj/project.pbxproj
@@ -65,6 +65,7 @@
 		0DF905C82C39402A0072EE65 /* Int+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0DF905C72C39402A0072EE65 /* Int+.swift */; };
 		0DF905CC2C3ABAC30072EE65 /* GradientView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0DF905CB2C3ABAC30072EE65 /* GradientView.swift */; };
 		0DF9B3072C69D73800F80B99 /* UIImageView+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0DF9B3062C69D73800F80B99 /* UIImageView+.swift */; };
+		0DF9B3092C6E5F2400F80B99 /* TimelineHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0DF9B3082C6E5F2400F80B99 /* TimelineHeaderView.swift */; };
 		0DFBF92C2C43E42700762956 /* DeleteCourseSettingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0DFBF92B2C43E42700762956 /* DeleteCourseSettingView.swift */; };
 		741AE2E22C3728D80031849F /* ViewedCourseViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 741AE2E12C3728D80031849F /* ViewedCourseViewController.swift */; };
 		742547032C47F0780075DD81 /* GetPointDetailResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 742547022C47F0780075DD81 /* GetPointDetailResponse.swift */; };
@@ -323,6 +324,7 @@
 		0DF905C72C39402A0072EE65 /* Int+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Int+.swift"; sourceTree = "<group>"; };
 		0DF905CB2C3ABAC30072EE65 /* GradientView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GradientView.swift; sourceTree = "<group>"; };
 		0DF9B3062C69D73800F80B99 /* UIImageView+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIImageView+.swift"; sourceTree = "<group>"; };
+		0DF9B3082C6E5F2400F80B99 /* TimelineHeaderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TimelineHeaderView.swift; sourceTree = "<group>"; };
 		0DFBF92B2C43E42700762956 /* DeleteCourseSettingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeleteCourseSettingView.swift; sourceTree = "<group>"; };
 		741AE2E12C3728D80031849F /* ViewedCourseViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewedCourseViewController.swift; sourceTree = "<group>"; };
 		742547022C47F0780075DD81 /* GetPointDetailResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GetPointDetailResponse.swift; sourceTree = "<group>"; };
@@ -623,6 +625,7 @@
 				0D98CBA62C41099400E3618A /* CourseDetailView.swift */,
 				0D9C431A2C41B3F500687CCC /* CourseDetailBottomTabBarView.swift */,
 				0DC9BEFE2C47B70600A817A8 /* StickyHeaderNavBarView.swift */,
+				0DF9B3082C6E5F2400F80B99 /* TimelineHeaderView.swift */,
 			);
 			path = Views;
 			sourceTree = "<group>";
@@ -1885,6 +1888,7 @@
 				0DC9BF092C47F57C00A817A8 /* CourseDetailService.swift in Sources */,
 				CA4EF3DF2C347B4E003B02B6 /* DRButtonType.swift in Sources */,
 				0DA1C7182C3DA98100DF2B92 /* CourseViewController.swift in Sources */,
+				0DF9B3092C6E5F2400F80B99 /* TimelineHeaderView.swift in Sources */,
 				CAA30AED2C37E57400835DE3 /* String+.swift in Sources */,
 				0D98CBA52C41067B00E3618A /* CourseDetailViewController.swift in Sources */,
 				0D0DA3E42C3AF3CF004210EE /* PointCollectionView.swift in Sources */,

--- a/DATEROAD-iOS/DATEROAD-iOS.xcodeproj/xcshareddata/xcschemes/DATEROAD-iOS.xcscheme
+++ b/DATEROAD-iOS/DATEROAD-iOS.xcodeproj/xcshareddata/xcschemes/DATEROAD-iOS.xcscheme
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
    LastUpgradeVersion = "1540"
-   version = "1.8">
+   version = "1.7">
    <BuildAction
       parallelizeBuildables = "YES"
       buildImplicitDependencies = "YES"

--- a/DATEROAD-iOS/DATEROAD-iOS/Global/Literals/StringLiterals.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Global/Literals/StringLiterals.swift
@@ -55,6 +55,7 @@ enum StringLiterals {
         static let viewCoursewithPoint = "포인트로 코스 열람하기"
         static let settingDateCourse = "데이트 코스 설정"
         static let deleteCourse = "글 삭제"
+        static let delclareCourse = "신고하기"
         static let check = "확인"
         static let freeViewTitle = "무료 열람 기회를 사용해 보시겠어요?"
         static let freeViewDescription = "무료 열람 기회는 한번 사용하면 취소할 수 없어요"
@@ -63,7 +64,6 @@ enum StringLiterals {
         static let addCourse = "코스 등록하기"
         static let declareTitle = "데이트 코스를 신고하시겠어요?"
         static let declareDescription = "신고된 게시물은 확인 후 서비스의 운영원칙에\n따라 조치 예정이에요"
-            
         static let deleteTitle = "데이트 코스를 삭제하시겠어요?"
         static let deleteDescription = "삭제된 코스는 복구하실 수 없어요"
         

--- a/DATEROAD-iOS/DATEROAD-iOS/Global/Literals/StringLiterals.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Global/Literals/StringLiterals.swift
@@ -61,6 +61,12 @@ enum StringLiterals {
         static let insufficientPointsTitle = "코스를 열람하기에 포인트가 부족해요"
         static let insufficientPointsDescription = "코스를 등록하고 포인트를 모아보세요"
         static let addCourse = "코스 등록하기"
+        static let declareTitle = "데이트 코스를 신고하시겠어요?"
+        static let declareDescription = "신고된 게시물은 확인 후 서비스의 운영원칙에\n따라 조치 예정이에요"
+            
+        static let deleteTitle = "데이트 코스를 삭제하시겠어요?"
+        static let deleteDescription = "삭제된 코스는 복구하실 수 없어요"
+        
     }
     
     enum Profile {

--- a/DATEROAD-iOS/DATEROAD-iOS/Global/Utils/Enums/AlertType.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Global/Utils/Enums/AlertType.swift
@@ -21,6 +21,7 @@ enum RightButtonType {
     case addCourse
     case checkCourse
     case deleteCourse
+    case declareCourse
     case kakaoShare
     case logout
     case none

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/Banner/Views/BannerDetailView.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/Banner/Views/BannerDetailView.swift
@@ -16,6 +16,8 @@ final class BannerDetailView: BaseView {
     
     lazy var mainCollectionView: UICollectionView = UICollectionView(frame: .zero, collectionViewLayout: self.makeFlowLayout())
     
+    private let gradientView = GradientView()
+    
     let stickyHeaderNavBarView = StickyHeaderNavBarView()
 
     
@@ -40,7 +42,7 @@ final class BannerDetailView: BaseView {
     
     
     override func setHierarchy() {
-        self.addSubviews(mainCollectionView,stickyHeaderNavBarView)
+        self.addSubviews(mainCollectionView, gradientView, stickyHeaderNavBarView)
     }
     
     override func setLayout() {
@@ -48,6 +50,11 @@ final class BannerDetailView: BaseView {
         mainCollectionView.snp.makeConstraints {
             $0.top.horizontalEdges.equalToSuperview()
             $0.bottom.equalToSuperview()
+        }
+        
+        gradientView.snp.makeConstraints {
+            $0.top.horizontalEdges.equalToSuperview()
+            $0.height.equalTo(104)
         }
         
         stickyHeaderNavBarView.snp.makeConstraints {
@@ -100,10 +107,8 @@ extension BannerDetailView {
         let section = NSCollectionLayoutSection(group: group)
         section.orthogonalScrollingBehavior = .groupPaging
         
-        let gradient = makeGradientView()
         let footer = makeBottomPageControllView()
-        
-        section.boundarySupplementaryItems = [gradient, footer]
+        section.boundarySupplementaryItems = [footer]
         
         return section
     }
@@ -137,14 +142,6 @@ extension BannerDetailView {
         let section = NSCollectionLayoutSection(group: group)
 
         return section
-    }
-
-    func makeGradientView() -> NSCollectionLayoutBoundarySupplementaryItem {
-        let gradientSize = NSCollectionLayoutSize(widthDimension: .fractionalWidth(1), heightDimension: .fractionalWidth(0.27))
-        let collectionViewWidth = mainCollectionView.frame.width
-        let gradient = NSCollectionLayoutBoundarySupplementaryItem(layoutSize: gradientSize, elementKind: GradientView.elementKinds, alignment: .top, absoluteOffset: CGPoint(x: 0, y: collectionViewWidth * 0.27))
-        
-        return gradient
     }
 
     func makeBottomPageControllView() -> NSCollectionLayoutBoundarySupplementaryItem {

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/Banner/Views/BannerDetailViewController.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/Banner/Views/BannerDetailViewController.swift
@@ -226,7 +226,7 @@ extension BannerDetailViewController {
 
 extension BannerDetailViewController: StickyHeaderNavBarViewDelegate {
     
-    func didTapDeleteButton() {}
+    func didTapMoreButton() {}
     
     func didTapBackButton() {
         navigationController?.popViewController(animated: true)

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/Banner/Views/BannerDetailViewController.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/Banner/Views/BannerDetailViewController.swift
@@ -119,9 +119,6 @@ private extension BannerDetailViewController {
             
             $0.register(InfoBarView.self, forSupplementaryViewOfKind: InfoBarView.elementKinds, withReuseIdentifier: InfoBarView.identifier)
             
-            
-            $0.register(GradientView.self, forSupplementaryViewOfKind: GradientView.elementKinds, withReuseIdentifier: GradientView.identifier)
-            
             $0.register(BottomPageControllView.self, forSupplementaryViewOfKind: BottomPageControllView.elementKinds, withReuseIdentifier: BottomPageControllView.identifier)
         }
     }
@@ -198,9 +195,6 @@ extension BannerDetailViewController: UICollectionViewDelegate, UICollectionView
             }
             infoView.allHidden()
             return infoView
-        } else if kind == GradientView.elementKinds {
-            guard let gradient = collectionView.dequeueReusableSupplementaryView(ofKind: kind, withReuseIdentifier: GradientView.identifier, for: indexPath) as? GradientView else { return UICollectionReusableView() }
-            return gradient
         } else if kind == BottomPageControllView.elementKinds {
             guard let footer = collectionView.dequeueReusableSupplementaryView(ofKind: kind, withReuseIdentifier: BottomPageControllView.identifier, for: indexPath) as? BottomPageControllView else { return UICollectionReusableView() }
             let likeNum = self.courseDetailViewModel.likeSum.value ?? 0

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/CourseDetail/Cells/MainContentsCell.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/CourseDetail/Cells/MainContentsCell.swift
@@ -24,7 +24,7 @@ final class MainContentsCell: BaseCollectionViewCell {
     override func setLayout() {
         mainTextLabel.snp.makeConstraints {
             $0.top.equalToSuperview()
-            $0.bottom.equalToSuperview().offset(-34)
+            $0.bottom.equalToSuperview().inset(34)
             $0.horizontalEdges.equalToSuperview()
         }
     }

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/CourseDetail/ViewModels/CourseDetailViewModel.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/CourseDetail/ViewModels/CourseDetailViewModel.swift
@@ -75,6 +75,7 @@ class CourseDetailViewModel: Serviceable {
     var isChange: (() -> Void)?
     
     var startAt: String = ""
+    
     var tagArr = [GetCourseDetailTag]()
     
     

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/CourseDetail/ViewModels/CourseDetailViewModel.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/CourseDetail/ViewModels/CourseDetailViewModel.swift
@@ -200,7 +200,6 @@ extension CourseDetailViewModel {
         }
     }
     
-    
     func likeCourse(courseId: Int) {
         LikeCourseService().likeCourse(courseId: courseId) { success in
             if success {
@@ -220,7 +219,6 @@ extension CourseDetailViewModel {
             }
         }
     }
-    
     
     func getBannerDetail(advertismentId: Int) {
         NetworkService.shared.courseDetailService.getBannerDetailInfo(advertismentId: advertismentId){ response in

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/CourseDetail/Views/CourseDetailView.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/CourseDetail/Views/CourseDetailView.swift
@@ -161,7 +161,7 @@ extension CourseDetailView {
         let section = NSCollectionLayoutSection(group: group)
         section.contentInsets = NSDirectionalEdgeInsets(top: 0, leading: 0, bottom: 15, trailing: 0)
         
-        let header = makeHeaderView()
+        let header = makeTimelineHeaderView()
         section.boundarySupplementaryItems = [header]
         
         return section
@@ -211,6 +211,13 @@ extension CourseDetailView {
         let gradient = NSCollectionLayoutBoundarySupplementaryItem(layoutSize: gradientSize, elementKind: GradientView.elementKinds, alignment: .top, absoluteOffset: CGPoint(x: 0, y: collectionViewWidth * 0.27))
         
         return gradient
+    }
+    
+    func makeTimelineHeaderView() -> NSCollectionLayoutBoundarySupplementaryItem {
+        let headerSize = NSCollectionLayoutSize(widthDimension: .fractionalWidth(1), heightDimension: .absolute(60))
+        let header = NSCollectionLayoutBoundarySupplementaryItem(layoutSize: headerSize, elementKind: TimelineHeaderView.elementKinds, alignment: .top)
+        header.contentInsets = NSDirectionalEdgeInsets(top: 0, leading: 16, bottom: 12, trailing: 16)
+        return header
     }
     
     func makeHeaderView() -> NSCollectionLayoutBoundarySupplementaryItem {

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/CourseDetail/Views/CourseDetailView.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/CourseDetail/Views/CourseDetailView.swift
@@ -225,7 +225,7 @@ extension CourseDetailView {
     func makeBottomPageControllView() -> NSCollectionLayoutBoundarySupplementaryItem {
         let footerSize = NSCollectionLayoutSize(widthDimension: .fractionalWidth(1), heightDimension: .estimated(22))
         let footer = NSCollectionLayoutBoundarySupplementaryItem(layoutSize: footerSize, elementKind: BottomPageControllView.elementKinds, alignment: .bottom, absoluteOffset: CGPoint(x: 0, y: -55))
-        footer.contentInsets = NSDirectionalEdgeInsets(top: 0, leading: 16, bottom: 0, trailing: 16)
+        footer.contentInsets = NSDirectionalEdgeInsets(top: 0, leading: 10, bottom: 0, trailing: 10)
         return footer
     }
     
@@ -244,7 +244,6 @@ extension CourseDetailView {
     }
     
     func makeContentMaskView() -> NSCollectionLayoutBoundarySupplementaryItem {
-
         let footerSize = NSCollectionLayoutSize(widthDimension: .fractionalWidth(1), heightDimension: .absolute(360))
         let footer = NSCollectionLayoutBoundarySupplementaryItem(layoutSize: footerSize, elementKind: ContentMaskView.elementKinds, alignment: .bottom, absoluteOffset: CGPoint(x: 0, y: -70))
         footer.contentInsets = NSDirectionalEdgeInsets(top: 0, leading: 0, bottom: 0, trailing: 0)

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/CourseDetail/Views/CourseDetailView.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/CourseDetail/Views/CourseDetailView.swift
@@ -16,6 +16,8 @@ class CourseDetailView: BaseView {
     
     lazy var mainCollectionView: UICollectionView = UICollectionView(frame: .zero, collectionViewLayout: self.makeCompositioinalLayout())
     
+    private let gradientView = GradientView()
+    
     let stickyHeaderNavBarView = StickyHeaderNavBarView()
     
     // MARK: - UI Properties
@@ -38,7 +40,7 @@ class CourseDetailView: BaseView {
     
     
     override func setHierarchy() {
-        self.addSubviews(mainCollectionView,stickyHeaderNavBarView)
+        self.addSubviews(mainCollectionView,gradientView,stickyHeaderNavBarView)
     }
     
     override func setLayout() {
@@ -48,8 +50,12 @@ class CourseDetailView: BaseView {
             $0.bottom.equalToSuperview()
         }
         
+        gradientView.snp.makeConstraints {
+            $0.top.horizontalEdges.equalToSuperview()
+            $0.height.equalTo(104)
+        }
+        
         stickyHeaderNavBarView.snp.makeConstraints {
-            
             $0.top.horizontalEdges.equalToSuperview()
             $0.height.equalTo(104)
         }
@@ -106,10 +112,8 @@ extension CourseDetailView {
         let section = NSCollectionLayoutSection(group: group)
         section.orthogonalScrollingBehavior = .groupPaging
         
-        let gradient = makeGradientView()
         let footer = makeBottomPageControllView()
-        
-        section.boundarySupplementaryItems = [gradient, footer]
+        section.boundarySupplementaryItems = [footer]
         
         return section
     }
@@ -202,15 +206,6 @@ extension CourseDetailView {
         section.boundarySupplementaryItems = [header]
         
         return section
-    }
-
-    
-    func makeGradientView() -> NSCollectionLayoutBoundarySupplementaryItem {
-        let gradientSize = NSCollectionLayoutSize(widthDimension: .fractionalWidth(1), heightDimension: .fractionalWidth(0.27))
-        let collectionViewWidth = mainCollectionView.frame.width
-        let gradient = NSCollectionLayoutBoundarySupplementaryItem(layoutSize: gradientSize, elementKind: GradientView.elementKinds, alignment: .top, absoluteOffset: CGPoint(x: 0, y: collectionViewWidth * 0.2672))
-        
-        return gradient
     }
     
     func makeTimelineHeaderView() -> NSCollectionLayoutBoundarySupplementaryItem {

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/CourseDetail/Views/CourseDetailView.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/CourseDetail/Views/CourseDetailView.swift
@@ -208,7 +208,7 @@ extension CourseDetailView {
     func makeGradientView() -> NSCollectionLayoutBoundarySupplementaryItem {
         let gradientSize = NSCollectionLayoutSize(widthDimension: .fractionalWidth(1), heightDimension: .fractionalWidth(0.27))
         let collectionViewWidth = mainCollectionView.frame.width
-        let gradient = NSCollectionLayoutBoundarySupplementaryItem(layoutSize: gradientSize, elementKind: GradientView.elementKinds, alignment: .top, absoluteOffset: CGPoint(x: 0, y: collectionViewWidth * 0.27))
+        let gradient = NSCollectionLayoutBoundarySupplementaryItem(layoutSize: gradientSize, elementKind: GradientView.elementKinds, alignment: .top, absoluteOffset: CGPoint(x: 0, y: collectionViewWidth * 0.2672))
         
         return gradient
     }

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/CourseDetail/Views/CourseDetailViewController.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/CourseDetail/Views/CourseDetailViewController.swift
@@ -279,37 +279,45 @@ extension CourseDetailViewController: ContentMaskViewDelegate {
         self.present(customAlertVC, animated: false)
     }
     
+    /// 더보기 버튼 눌렀을 때 직접적인 액션 처리 -> 신고 혹은 삭제 버튼 클릭시 액션 처리
+    @objc func didTapBottomSheetLabel(sender: UITapGestureRecognizer) {
+        print("삭제하기 클릭")
+        self.dismiss(animated: true)
+        guard let isCourseMine = courseDetailViewModel.isCourseMine.value else { return }
+        isCourseMine ? showDeleteAlert() : showDecalreAlert()
+    }
+    
     //바텀 시트에서 신고하기 클릭시 팝업창
-    func didTapDeclareLabel(){
-        let customAlertVC = DRCustomAlertViewController(
-            rightActionType: RightButtonType.declareCourse,
-            alertTextType: .hasDecription,
-            alertButtonType: .twoButton,
-            titleText: "데이트 코스를 신고하시겠어요?",
-            descriptionText: "신고된 게시물은 확인 후 서비스의 운영원칙에\n따라 조치 예정이에요",
-            rightButtonText: "신고"
+    func showDecalreAlert(){
+        presentCustomAlert(
+            title: "데이트 코스를 신고하시겠어요?",
+            description: "신고된 게시물은 확인 후 서비스의 운영원칙에\n따라 조치 예정이에요",
+            action: .declareCourse
         )
-        customAlertVC.delegate = self
-        customAlertVC.modalPresentationStyle = .overFullScreen
-        self.present(customAlertVC, animated: false)
     }
     
     //바텀 시트에서 삭제하기 클릭시 팝업창
-    func didTapDeleteLabel(){
-        let customAlertVC = DRCustomAlertViewController(
-            rightActionType: RightButtonType.declareCourse,
-            alertTextType: .hasDecription,
-            alertButtonType: .twoButton,
-            titleText: "데이트 코스를 삭제하시겠어요?",
-            descriptionText: "삭제된 코스는 복구하실 수 없어요",
-            rightButtonText: "삭제"
+    func showDeleteAlert(){
+        presentCustomAlert(
+            title: "데이트 코스를 삭제하시겠어요?",
+            description: "삭제된 코스는 복구하실 수 없어요",
+            action: .deleteCourse
         )
-        customAlertVC.delegate = self
-        customAlertVC.modalPresentationStyle = .overFullScreen
-        self.present(customAlertVC, animated: false)
     }
     
-    
+    func presentCustomAlert(title: String, description: String, action: RightButtonType) {
+        let alertVC = DRCustomAlertViewController(
+            rightActionType: action,
+            alertTextType: .hasDecription,
+            alertButtonType: .twoButton,
+            titleText: title,
+            descriptionText: description,
+            rightButtonText: "확인"
+        )
+        alertVC.delegate = self
+        alertVC.modalPresentationStyle = .overFullScreen
+        present(alertVC, animated: false)
+    }
     
     
     //코스 등록하기로 화면 전환
@@ -334,17 +342,7 @@ extension CourseDetailViewController: ContentMaskViewDelegate {
         courseDetailView.mainCollectionView.reloadData()
     }
     
-    /// 더보기 버튼 눌렀을 때 직접적인 액션 처리 -> 신고 혹은 삭제 버튼 클릭시 액션 처리
-    @objc func didTapBottomSheetLabel(sender: UITapGestureRecognizer) {
-        print("삭제하기 클릭")
-        self.dismiss(animated: true)
-        guard let isCourseMine = courseDetailViewModel.isCourseMine.value else { return }
-        if isCourseMine {
-            didTapDeleteLabel()
-        } else {
-            didTapDeclareLabel()
-        }
-    }
+    
     
 }
 

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/CourseDetail/Views/CourseDetailViewController.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/CourseDetail/Views/CourseDetailViewController.swift
@@ -73,7 +73,9 @@ final class CourseDetailViewController: BaseViewController {
     
     override func setLayout() {
         super.setLayout()
+        
         self.tabBarController?.tabBar.isHidden = true
+        courseInfoTabBarView.isHidden = true
         
         courseDetailView.snp.makeConstraints {
             $0.edges.equalToSuperview()
@@ -82,15 +84,6 @@ final class CourseDetailViewController: BaseViewController {
         courseInfoTabBarView.snp.makeConstraints {
             $0.leading.trailing.bottom.equalToSuperview()
             $0.height.equalTo(108)
-        }
-        
-    }
-    
-    override func setStyle() {
-        super.setStyle()
-        
-        courseInfoTabBarView.do {
-            $0.isHidden = true
         }
         
     }

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/CourseDetail/Views/CourseDetailViewController.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/CourseDetail/Views/CourseDetailViewController.swift
@@ -247,71 +247,49 @@ extension CourseDetailViewController: ContentMaskViewDelegate {
     
     //버튼 분기 처리하기
     func didTapViewButton() {
-        guard let haveFreeCount = self.courseDetailViewModel.haveFreeCount.value else { return }
-        
-        if haveFreeCount {
-            didTapFreeViewButton()
-        } else {
-            didTapReadCourseButton()
-        }
+        courseDetailViewModel.haveFreeCount.value == true ? showFreeViewAlert() : showReadCourseAlert()
     }
     
-    //열람 전 분기 처리 - 무료 사용 기회 다 쓴 경우
-    func didTapReadCourseButton() {
-        let customAlertVC = DRCustomAlertViewController(
-            rightActionType: RightButtonType.checkCourse,
-            alertTextType: .hasDecription,
-            alertButtonType: .twoButton,
-            titleText: StringLiterals.Alert.buyCourse,
-            descriptionText: StringLiterals.Alert.canNotRefund,
-            rightButtonText: StringLiterals.CourseDetail.check
+    // 무료 사용 기회를 다 쓴 경우의 알림
+    func showReadCourseAlert() {
+        presentCustomAlert(
+            title: StringLiterals.Alert.buyCourse,
+            description: StringLiterals.Alert.canNotRefund,
+            action: .checkCourse,
+            buttonText: StringLiterals.CourseDetail.check
         )
-        customAlertVC.delegate = self
-        customAlertVC.modalPresentationStyle = .overFullScreen
-        self.present(customAlertVC, animated: false)
     }
     
-    //열람 전 분기 처리 - 무료 사용 기회 남은 경우
-    func didTapFreeViewButton() {
-        let customAlertVC = DRCustomAlertViewController(
-            rightActionType: RightButtonType.checkCourse,
-            alertTextType: .hasDecription,
-            alertButtonType: .twoButton,
-            titleText: StringLiterals.CourseDetail.freeViewTitle,
-            descriptionText: StringLiterals.CourseDetail.freeViewDescription,
-            rightButtonText: StringLiterals.CourseDetail.check
+    // 무료 사용 기회가 남은 경우의 알림
+    func showFreeViewAlert() {
+        presentCustomAlert(
+            title: StringLiterals.CourseDetail.freeViewTitle,
+            description: StringLiterals.CourseDetail.freeViewDescription,
+            action: .checkCourse,
+            buttonText: StringLiterals.CourseDetail.check
         )
-        customAlertVC.delegate = self
-        customAlertVC.modalPresentationStyle = .overFullScreen
-        self.present(customAlertVC, animated: false)
     }
-    
     
     //포인트가 부족할 때
     func showPointAlert(){
-        let customAlertVC = DRCustomAlertViewController(
-            rightActionType: RightButtonType.addCourse,
-            alertTextType: .hasDecription,
-            alertButtonType: .twoButton,
-            titleText: StringLiterals.CourseDetail.insufficientPointsTitle,
-            descriptionText: StringLiterals.CourseDetail.insufficientPointsDescription,
-            rightButtonText: StringLiterals.CourseDetail.addCourse
+        presentCustomAlert(
+            title: StringLiterals.CourseDetail.insufficientPointsTitle,
+            description: StringLiterals.CourseDetail.insufficientPointsDescription,
+            action: .addCourse,
+            buttonText: StringLiterals.CourseDetail.addCourse
         )
-        customAlertVC.delegate = self
-        customAlertVC.modalPresentationStyle = .overFullScreen
-        self.present(customAlertVC, animated: false)
     }
     
-    /// 더보기 버튼 눌렀을 때 직접적인 액션 처리 -> 신고 혹은 삭제 버튼 클릭시 액션 처리
+    // 신고 혹은 삭제 버튼 클릭 시 처리
     @objc func didTapBottomSheetLabel(sender: UITapGestureRecognizer) {
         print("삭제하기 클릭")
         self.dismiss(animated: true)
-        guard let isCourseMine = courseDetailViewModel.isCourseMine.value else { return }
-        isCourseMine ? showDeleteAlert() : showDecalreAlert()
+        courseDetailViewModel.isCourseMine.value == true ? showDeleteAlert() : showDeclareAlert()
+
     }
     
     //바텀 시트에서 신고하기 클릭시 팝업창
-    func showDecalreAlert(){
+    func showDeclareAlert(){
         presentCustomAlert(
             title: "데이트 코스를 신고하시겠어요?",
             description: "신고된 게시물은 확인 후 서비스의 운영원칙에\n따라 조치 예정이에요",
@@ -328,14 +306,14 @@ extension CourseDetailViewController: ContentMaskViewDelegate {
         )
     }
     
-    func presentCustomAlert(title: String, description: String, action: RightButtonType) {
+    func presentCustomAlert(title: String, description: String, action: RightButtonType, buttonText: String = "확인") {
         let alertVC = DRCustomAlertViewController(
             rightActionType: action,
             alertTextType: .hasDecription,
             alertButtonType: .twoButton,
             titleText: title,
             descriptionText: description,
-            rightButtonText: "확인"
+            rightButtonText: buttonText
         )
         alertVC.delegate = self
         alertVC.modalPresentationStyle = .overFullScreen
@@ -351,7 +329,7 @@ extension CourseDetailViewController: ContentMaskViewDelegate {
 
 }
 
-extension CourseDetailViewController: StickyHeaderNavBarViewDelegate {
+extension CourseDetailViewController: StickyHeaderNavBarViewDelegate, DRBottomSheetDelegate {
     
     func didTapBackButton() {
         navigationController?.popViewController(animated: true)
@@ -364,20 +342,17 @@ extension CourseDetailViewController: StickyHeaderNavBarViewDelegate {
             buttonType: DisabledButton(),
             buttonTitle: StringLiterals.Common.close
         )
-        
+        bottomSheetVC.delegate = self
         deleteCourseSettingView.deleteLabel.text = courseDetailViewModel.isCourseMine.value == true ? "삭제" : "신고하기"
         bottomSheetVC.modalPresentationStyle = .overFullScreen
         present(bottomSheetVC, animated: true)
     }
 
-}
-
-extension CourseDetailViewController: DRBottomSheetDelegate {
-    
     func didTapBottomButton() {
         self.dismiss(animated: true)
     }
 }
+
 
 extension CourseDetailViewController: UIScrollViewDelegate {
     

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/CourseDetail/Views/CourseDetailViewController.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/CourseDetail/Views/CourseDetailViewController.swift
@@ -121,6 +121,8 @@ final class CourseDetailViewController: BaseViewController, DRCustomAlertDelegat
             
             $0.register(InfoHeaderView.self, forSupplementaryViewOfKind: InfoHeaderView.elementKinds, withReuseIdentifier: InfoHeaderView.identifier)
             
+            $0.register(TimelineHeaderView.self, forSupplementaryViewOfKind: TimelineHeaderView.elementKinds, withReuseIdentifier: TimelineHeaderView.identifier)
+            
             $0.register(GradientView.self, forSupplementaryViewOfKind: GradientView.elementKinds, withReuseIdentifier: GradientView.identifier)
             
             $0.register(BottomPageControllView.self, forSupplementaryViewOfKind: BottomPageControllView.elementKinds, withReuseIdentifier: BottomPageControllView.identifier)
@@ -530,8 +532,6 @@ extension CourseDetailViewController: UICollectionViewDelegate, UICollectionView
         } else if kind == InfoHeaderView.elementKinds {
             guard let header = collectionView.dequeueReusableSupplementaryView(ofKind: kind, withReuseIdentifier: InfoHeaderView.identifier, for: indexPath) as? InfoHeaderView else { return UICollectionReusableView() }
             switch courseDetailViewModel.fetchSection(at: indexPath.section) {
-            case .timelineInfo:
-                header.bindTitle(headerTitle: StringLiterals.CourseDetail.timelineInfoLabel)
             case .coastInfo:
                 header.bindTitle(headerTitle: StringLiterals.CourseDetail.coastInfoLabel)
             case .tagInfo:
@@ -539,6 +539,10 @@ extension CourseDetailViewController: UICollectionViewDelegate, UICollectionView
             default:
                 break
             }
+            return header
+        } else if kind == TimelineHeaderView.elementKinds {
+            guard let header = collectionView.dequeueReusableSupplementaryView(ofKind: kind, withReuseIdentifier: TimelineHeaderView.identifier, for: indexPath) as? TimelineHeaderView else { return UICollectionReusableView() }
+            // TODO :  시작 시간 바인딩
             return header
         } else {
             return UICollectionReusableView()

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/CourseDetail/Views/CourseDetailViewController.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/CourseDetail/Views/CourseDetailViewController.swift
@@ -170,13 +170,9 @@ final class CourseDetailViewController: BaseViewController {
     }
     
     func setAddTarget() {
-        let bottomSheetGesture = UITapGestureRecognizer(target: self, action: #selector(didTapBottomSheetLabel(sender:)))
-        deleteCourseSettingView.deleteLabel.addGestureRecognizer(bottomSheetGesture)
-        
-        let tapGesture = UITapGestureRecognizer(target: self, action: #selector(didTapLikeButton))
+        deleteCourseSettingView.deleteLabel.addGestureRecognizer(UITapGestureRecognizer(target: self, action: #selector(didTapBottomSheetLabel(sender:))))
         courseInfoTabBarView.likeButtonView.isUserInteractionEnabled = true
-        courseInfoTabBarView.likeButtonView.addGestureRecognizer(tapGesture)
-        
+        courseInfoTabBarView.likeButtonView.addGestureRecognizer(UITapGestureRecognizer(target: self, action: #selector(didTapLikeButton)))
         courseInfoTabBarView.bringCourseButton.addTarget(self, action: #selector(didTapMySchedule), for: .touchUpInside)
     }
     
@@ -441,126 +437,180 @@ extension CourseDetailViewController: UICollectionViewDelegate, UICollectionView
         return courseDetailViewModel.numberOfItemsInSection(section)
     }
     
-    
     func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
         let sectionType = courseDetailViewModel.fetchSection(at: indexPath.section)
-        let isAccess = self.courseDetailViewModel.isAccess.value ?? false
+        let isAccess = courseDetailViewModel.isAccess.value ?? false
         
         switch sectionType {
         case .imageCarousel:
-            guard let imageCarouselCell = collectionView.dequeueReusableCell(withReuseIdentifier: ImageCarouselCell.cellIdentifier, for: indexPath) as? ImageCarouselCell else {
-                return UICollectionViewCell()
-            }
-            let imageData = courseDetailViewModel.imageData.value ?? []
-            imageCarouselCell.setPageVC(thumbnailModel: imageData)
-            imageCarouselCell.setAccess(isAccess: isAccess)
-            imageCarouselCell.delegate = self
-            return imageCarouselCell
-            
+            return configureImageCarouselCell(collectionView, indexPath: indexPath, isAccess: isAccess)
         case .titleInfo:
-            guard let titleInfoCell = collectionView.dequeueReusableCell(withReuseIdentifier: TitleInfoCell.cellIdentifier, for: indexPath) as? TitleInfoCell else {
-                return UICollectionViewCell()
-            }
-            let titleDate = courseDetailViewModel.titleHeaderData.value  ?? TitleHeaderModel(date: "", title: "", cost: 0, totalTime: 0, city: "")
-            titleInfoCell.setCell(titleHeaderData: titleDate)
-            return titleInfoCell
-            
+            return configureTitleInfoCell(collectionView, indexPath: indexPath)
         case .mainContents:
-            guard let mainContentsCell = collectionView.dequeueReusableCell(withReuseIdentifier: MainContentsCell.cellIdentifier, for: indexPath) as? MainContentsCell else {
-                return UICollectionViewCell()
-            }
-            let mainData = courseDetailViewModel.mainContentsData.value ?? MainContentsModel(description: "")
-            mainContentsCell.setCell(mainContentsData: mainData)
-            mainContentsCell.mainTextLabel.numberOfLines = isAccess ? 0 : 3
-            return mainContentsCell
-            
+            return configureMainContentsCell(collectionView, indexPath: indexPath, isAccess: isAccess)
         case .timelineInfo:
-            guard let timelineInfoCell = collectionView.dequeueReusableCell(withReuseIdentifier: TimelineInfoCell.cellIdentifier, for: indexPath) as? TimelineInfoCell else {
-                return UICollectionViewCell()
-            }
-            let timelineItem = self.courseDetailViewModel.timelineData.value?[indexPath.row] ?? TimelineModel(sequence: 0, title: "", duration: 0)
-            timelineInfoCell.setCell(timelineData: timelineItem)
-            return timelineInfoCell
-            
+            return configureTimelineInfoCell(collectionView, indexPath: indexPath)
         case .coastInfo:
-            guard let coastInfoCell = collectionView.dequeueReusableCell(withReuseIdentifier: CoastInfoCell.cellIdentifier, for: indexPath) as? CoastInfoCell else {
-                return UICollectionViewCell()
-            }
-            let coastData = self.courseDetailViewModel.titleHeaderData.value?.cost ?? 0
-            coastInfoCell.setCell(coastData: coastData)
-            return coastInfoCell
-            
+            return configureCoastInfoCell(collectionView, indexPath: indexPath)
         case .tagInfo:
-            guard let tagInfoCell = collectionView.dequeueReusableCell(withReuseIdentifier: TagInfoCell.cellIdentifier, for: indexPath) as? TagInfoCell else {
-                return UICollectionViewCell()
-            }
-            let tagData = self.courseDetailViewModel.tagData.value?[indexPath.row] ?? TagModel(tag: "")
-            tagInfoCell.setCell(tag: tagData.tag)
-            return tagInfoCell
+            return configureTagInfoCell(collectionView, indexPath: indexPath)
         }
     }
     
+    private func configureImageCarouselCell(_ collectionView: UICollectionView, indexPath: IndexPath, isAccess: Bool) -> UICollectionViewCell {
+        guard let cell = collectionView.dequeueReusableCell(withReuseIdentifier: ImageCarouselCell.cellIdentifier, for: indexPath) as? ImageCarouselCell else {
+            return UICollectionViewCell()
+        }
+        let imageData = courseDetailViewModel.imageData.value ?? []
+        cell.setPageVC(thumbnailModel: imageData)
+        cell.setAccess(isAccess: isAccess)
+        cell.delegate = self
+        return cell
+    }
+    
+    private func configureTitleInfoCell(_ collectionView: UICollectionView, indexPath: IndexPath) -> UICollectionViewCell {
+        guard let cell = collectionView.dequeueReusableCell(withReuseIdentifier: TitleInfoCell.cellIdentifier, for: indexPath) as? TitleInfoCell else {
+            return UICollectionViewCell()
+        }
+        let titleData = courseDetailViewModel.titleHeaderData.value ?? TitleHeaderModel(date: "", title: "", cost: 0, totalTime: 0, city: "")
+        cell.setCell(titleHeaderData: titleData)
+        return cell
+    }
+    
+    private func configureMainContentsCell(_ collectionView: UICollectionView, indexPath: IndexPath, isAccess: Bool) -> UICollectionViewCell {
+        guard let cell = collectionView.dequeueReusableCell(withReuseIdentifier: MainContentsCell.cellIdentifier, for: indexPath) as? MainContentsCell else {
+            return UICollectionViewCell()
+        }
+        let mainData = courseDetailViewModel.mainContentsData.value ?? MainContentsModel(description: "")
+        cell.setCell(mainContentsData: mainData)
+        cell.mainTextLabel.numberOfLines = isAccess ? 0 : 3
+        return cell
+    }
+    
+    private func configureTimelineInfoCell(_ collectionView: UICollectionView, indexPath: IndexPath) -> UICollectionViewCell {
+        guard let cell = collectionView.dequeueReusableCell(withReuseIdentifier: TimelineInfoCell.cellIdentifier, for: indexPath) as? TimelineInfoCell else {
+            return UICollectionViewCell()
+        }
+        let timelineItem = courseDetailViewModel.timelineData.value?[indexPath.row] ?? TimelineModel(sequence: 0, title: "", duration: 0)
+        cell.setCell(timelineData: timelineItem)
+        return cell
+    }
+    
+    private func configureCoastInfoCell(_ collectionView: UICollectionView, indexPath: IndexPath) -> UICollectionViewCell {
+        guard let cell = collectionView.dequeueReusableCell(withReuseIdentifier: CoastInfoCell.cellIdentifier, for: indexPath) as? CoastInfoCell else {
+            return UICollectionViewCell()
+        }
+        let coastData = courseDetailViewModel.titleHeaderData.value?.cost ?? 0
+        cell.setCell(coastData: coastData)
+        return cell
+    }
+    
+    private func configureTagInfoCell(_ collectionView: UICollectionView, indexPath: IndexPath) -> UICollectionViewCell {
+        guard let cell = collectionView.dequeueReusableCell(withReuseIdentifier: TagInfoCell.cellIdentifier, for: indexPath) as? TagInfoCell else {
+            return UICollectionViewCell()
+        }
+        let tagData = courseDetailViewModel.tagData.value?[indexPath.row] ?? TagModel(tag: "")
+        cell.setCell(tag: tagData.tag)
+        return cell
+    }
 
     func collectionView(_ collectionView: UICollectionView, viewForSupplementaryElementOfKind kind: String, at indexPath: IndexPath) -> UICollectionReusableView {
-        
-        let isAccess = self.courseDetailViewModel.isAccess.value ?? false
-        let titleHeaderData = self.courseDetailViewModel.titleHeaderData.value ?? TitleHeaderModel(date: "", title: "", cost: 0, totalTime: 0, city: "")
-        let imageData = self.courseDetailViewModel.imageData.value ?? []
-        
-        if kind == VisitDateView.elementKinds {
-            guard let visitDate = collectionView.dequeueReusableSupplementaryView(ofKind: kind, withReuseIdentifier: VisitDateView.identifier, for: indexPath) as? VisitDateView else {
-                return UICollectionReusableView()
-            }
-            visitDate.bindDate(titleHeaderData: titleHeaderData)
-            return visitDate
-        } else if kind == InfoBarView.elementKinds {
-            guard let footer = collectionView.dequeueReusableSupplementaryView(ofKind: kind, withReuseIdentifier: InfoBarView.identifier, for: indexPath) as? InfoBarView else { return UICollectionReusableView() }
-            footer.bindTitleHeader(titleHeaderData: titleHeaderData)
-            return footer
-        } else if kind == GradientView.elementKinds {
-            guard let gradient = collectionView.dequeueReusableSupplementaryView(ofKind: kind, withReuseIdentifier: GradientView.identifier, for: indexPath) as? GradientView else { return UICollectionReusableView() }
-            return gradient
-        } else if kind == BottomPageControllView.elementKinds {
-            guard let footer = collectionView.dequeueReusableSupplementaryView(ofKind: kind, withReuseIdentifier: BottomPageControllView.identifier, for: indexPath) as? BottomPageControllView else { return UICollectionReusableView() }
-            if !isFirstLike {
-                localLikeNum += courseDetailViewModel.isUserLiked.value == true ? 1 : -1
-            }
-            
-            footer.pageIndexSum = imageData.count
-            footer.bindData(like: localLikeNum)
-            return footer
-        } else if kind == ContentMaskView.elementKinds {
-            if isAccess {
-                return UICollectionReusableView()
-            } else {
-                guard let footer = collectionView.dequeueReusableSupplementaryView(ofKind: kind, withReuseIdentifier: ContentMaskView.identifier, for: indexPath) as? ContentMaskView else { return UICollectionReusableView() }
-                let haveFree = self.courseDetailViewModel.haveFreeCount.value ?? false
-                let count = self.courseDetailViewModel.conditionalData.value?.free ?? 0
-                footer.checkFree(haveFree: haveFree, count: count)
-                footer.delegate = self
-                return footer
-            }
-        } else if kind == InfoHeaderView.elementKinds {
-            guard let header = collectionView.dequeueReusableSupplementaryView(ofKind: kind, withReuseIdentifier: InfoHeaderView.identifier, for: indexPath) as? InfoHeaderView else { return UICollectionReusableView() }
-            switch courseDetailViewModel.fetchSection(at: indexPath.section) {
-            case .coastInfo:
-                header.bindTitle(headerTitle: StringLiterals.CourseDetail.coastInfoLabel)
-            case .tagInfo:
-                header.bindTitle(headerTitle: StringLiterals.CourseDetail.tagInfoLabel)
-            default:
-                break
-            }
-            return header
-        } else if kind == TimelineHeaderView.elementKinds {
-            guard let header = collectionView.dequeueReusableSupplementaryView(ofKind: kind, withReuseIdentifier: TimelineHeaderView.identifier, for: indexPath) as? TimelineHeaderView else { return UICollectionReusableView() }
-            let startAt = self.courseDetailViewModel.startAt
-            header.bindSubTitle(subTitle: startAt)
-            return header
-        } else {
+        let isAccess = courseDetailViewModel.isAccess.value ?? false
+        let titleHeaderData = courseDetailViewModel.titleHeaderData.value ?? TitleHeaderModel(date: "", title: "", cost: 0, totalTime: 0, city: "")
+        let imageData = courseDetailViewModel.imageData.value ?? []
+
+        switch kind {
+        case VisitDateView.elementKinds:
+            return configureVisitDateView(collectionView, indexPath: indexPath, titleHeaderData: titleHeaderData)
+        case InfoBarView.elementKinds:
+            return configureInfoBarView(collectionView, indexPath: indexPath, titleHeaderData: titleHeaderData)
+        case GradientView.elementKinds:
+            return configureGradientView(collectionView, indexPath: indexPath)
+        case BottomPageControllView.elementKinds:
+            return configureBottomPageControlView(collectionView, indexPath: indexPath, imageData: imageData, isAccess: isAccess)
+        case ContentMaskView.elementKinds:
+            return configureContentMaskView(collectionView, indexPath: indexPath, isAccess: isAccess)
+        case InfoHeaderView.elementKinds:
+            return configureInfoHeaderView(collectionView, indexPath: indexPath)
+        case TimelineHeaderView.elementKinds:
+            return configureTimelineHeaderView(collectionView, indexPath: indexPath)
+        default:
             return UICollectionReusableView()
         }
     }
+
+    private func configureVisitDateView(_ collectionView: UICollectionView, indexPath: IndexPath, titleHeaderData: TitleHeaderModel) -> UICollectionReusableView {
+        guard let view = collectionView.dequeueReusableSupplementaryView(ofKind: VisitDateView.elementKinds, withReuseIdentifier: VisitDateView.identifier, for: indexPath) as? VisitDateView else {
+            return UICollectionReusableView()
+        }
+        view.bindDate(titleHeaderData: titleHeaderData)
+        return view
+    }
     
+    private func configureInfoBarView(_ collectionView: UICollectionView, indexPath: IndexPath, titleHeaderData: TitleHeaderModel) -> UICollectionReusableView {
+        guard let view = collectionView.dequeueReusableSupplementaryView(ofKind: InfoBarView.elementKinds, withReuseIdentifier: InfoBarView.identifier, for: indexPath) as? InfoBarView else {
+            return UICollectionReusableView()
+        }
+        view.bindTitleHeader(titleHeaderData: titleHeaderData)
+        return view
+    }
+    
+    private func configureGradientView(_ collectionView: UICollectionView, indexPath: IndexPath) -> UICollectionReusableView {
+        guard let view = collectionView.dequeueReusableSupplementaryView(ofKind: GradientView.elementKinds, withReuseIdentifier: GradientView.identifier, for: indexPath) as? GradientView else {
+            return UICollectionReusableView()
+        }
+        return view
+    }
+    
+    private func configureBottomPageControlView(_ collectionView: UICollectionView, indexPath: IndexPath, imageData: [ThumbnailModel], isAccess: Bool) -> UICollectionReusableView {
+        guard let view = collectionView.dequeueReusableSupplementaryView(ofKind: BottomPageControllView.elementKinds, withReuseIdentifier: BottomPageControllView.identifier, for: indexPath) as? BottomPageControllView else {
+            return UICollectionReusableView()
+        }
+        if !isFirstLike {
+            localLikeNum += courseDetailViewModel.isUserLiked.value == true ? 1 : -1
+        }
+        view.pageIndexSum = imageData.count
+        view.bindData(like: localLikeNum)
+        return view
+    }
+    
+    private func configureContentMaskView(_ collectionView: UICollectionView, indexPath: IndexPath, isAccess: Bool) -> UICollectionReusableView {
+        guard let view = collectionView.dequeueReusableSupplementaryView(ofKind: ContentMaskView.elementKinds, withReuseIdentifier: ContentMaskView.identifier, for: indexPath) as? ContentMaskView else {
+            return UICollectionReusableView()
+        }
+        if !isAccess {
+            let haveFree = courseDetailViewModel.haveFreeCount.value ?? false
+            let count = courseDetailViewModel.conditionalData.value?.free ?? 0
+            view.checkFree(haveFree: haveFree, count: count)
+            view.delegate = self
+        }
+        return view
+    }
+    
+    private func configureInfoHeaderView(_ collectionView: UICollectionView, indexPath: IndexPath) -> UICollectionReusableView {
+        guard let view = collectionView.dequeueReusableSupplementaryView(ofKind: InfoHeaderView.elementKinds, withReuseIdentifier: InfoHeaderView.identifier, for: indexPath) as? InfoHeaderView else {
+            return UICollectionReusableView()
+        }
+        switch courseDetailViewModel.fetchSection(at: indexPath.section) {
+        case .coastInfo:
+            view.bindTitle(headerTitle: StringLiterals.CourseDetail.coastInfoLabel)
+        case .tagInfo:
+            view.bindTitle(headerTitle: StringLiterals.CourseDetail.tagInfoLabel)
+        default:
+            break
+        }
+        return view
+    }
+    
+    private func configureTimelineHeaderView(_ collectionView: UICollectionView, indexPath: IndexPath) -> UICollectionReusableView {
+        guard let view = collectionView.dequeueReusableSupplementaryView(ofKind: TimelineHeaderView.elementKinds, withReuseIdentifier: TimelineHeaderView.identifier, for: indexPath) as? TimelineHeaderView else {
+            return UICollectionReusableView()
+        }
+        let startAt = courseDetailViewModel.startAt
+        view.bindSubTitle(subTitle: startAt)
+        return view
+    }
 }
+
 
 

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/CourseDetail/Views/CourseDetailViewController.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/CourseDetail/Views/CourseDetailViewController.swift
@@ -39,7 +39,6 @@ final class CourseDetailViewController: BaseViewController {
         self.courseDetailViewModel = viewModel
         self.courseId = self.courseDetailViewModel.courseId
         self.courseDetailViewModel.getCourseDetail()
-        
         self.courseDetailView = CourseDetailView(courseDetailSection:self.courseDetailViewModel.sections)
         
         super.init(nibName: nil, bundle: nil)
@@ -330,7 +329,7 @@ extension CourseDetailViewController: StickyHeaderNavBarViewDelegate, DRBottomSh
             buttonTitle: StringLiterals.Common.close
         )
         bottomSheetVC.delegate = self
-        deleteCourseSettingView.deleteLabel.text = courseDetailViewModel.isCourseMine.value == true ? "삭제" : "신고하기"
+        deleteCourseSettingView.deleteLabel.text = courseDetailViewModel.isCourseMine.value == true ? StringLiterals.CourseDetail.deleteCourse : StringLiterals.CourseDetail.delclareCourse
         bottomSheetVC.modalPresentationStyle = .overFullScreen
         present(bottomSheetVC, animated: true)
     }
@@ -402,8 +401,6 @@ private extension CourseDetailViewController {
     }
     
 }
-
-
 
 extension CourseDetailViewController: ImageCarouselDelegate {
     

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/CourseDetail/Views/CourseDetailViewController.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/CourseDetail/Views/CourseDetailViewController.swift
@@ -210,6 +210,11 @@ extension CourseDetailViewController: ContentMaskViewDelegate {
                     didTapBuyButton()
                 }
             }
+        case .declareCourse:
+            let delclareVC = DRWebViewController(urlString: "https://tally.so/r/w4L1a5")
+            self.present(delclareVC, animated: true)
+        case .deleteCourse:
+            deleteCourse()
         default:
             return
         }
@@ -274,36 +279,69 @@ extension CourseDetailViewController: ContentMaskViewDelegate {
         self.present(customAlertVC, animated: false)
     }
     
+    //바텀시트에서 신고하기 클릭시 팝업창
+    func didTapDeclareLabel(){
+        let customAlertVC = DRCustomAlertViewController(
+            rightActionType: RightButtonType.declareCourse,
+            alertTextType: .hasDecription,
+            alertButtonType: .twoButton,
+            titleText: "데이트 코스를 신고하시겠어요?",
+            descriptionText: "신고된 게시물은 확인 후 서비스의 운영원칙에\n따라 조치 예정이에요",
+            rightButtonText: "신고"
+        )
+        customAlertVC.delegate = self
+        customAlertVC.modalPresentationStyle = .overFullScreen
+        self.present(customAlertVC, animated: false)
+    }
+    
+    //바텀시트에서 삭제하기 클릭시 팝업창
+    func didTapDeleteLabel(){
+        let customAlertVC = DRCustomAlertViewController(
+            rightActionType: RightButtonType.declareCourse,
+            alertTextType: .hasDecription,
+            alertButtonType: .twoButton,
+            titleText: "데이트 코스를 삭제하시겠어요?",
+            descriptionText: "삭제된 코스는 복구하실 수 없어요",
+            rightButtonText: "삭제"
+        )
+        customAlertVC.delegate = self
+        customAlertVC.modalPresentationStyle = .overFullScreen
+        self.present(customAlertVC, animated: false)
+    }
+    
+    
     //코스 등록하기로 화면 전환
     func didTapAddCourseButton() {
         let addCourseVC = AddCourseFirstViewController(viewModel: AddCourseViewModel())
         self.navigationController?.pushViewController(addCourseVC, animated: false)
     }
     
-    /// 더보기 버튼 눌렀을 때 직접적인 액션 처리
+    func deleteCourse() {
+        print("삭제")
+        self.dismiss(animated: true)
+        courseDetailViewModel.deleteCourse { [weak self] success in
+            DispatchQueue.main.async {
+                if success {
+                    print("성공적으로 삭제")
+                    self?.navigationController?.popViewController(animated: true)
+                } else {
+                    print("삭제 실패 ㅠ")
+                }
+            }
+        }
+        courseDetailView.mainCollectionView.reloadData()
+    }
+    
+    /// 더보기 버튼 눌렀을 때 직접적인 액션 처리 -> 신고 혹은 삭제 버튼 클릭시 액션 처리
     @objc func didTapBottomSheetLabel(sender: UITapGestureRecognizer) {
-        print("didTapDeleteLabel")
+        print("삭제하기 클릭")
         self.dismiss(animated: true)
         guard let isCourseMine = courseDetailViewModel.isCourseMine.value else { return }
         if isCourseMine {
-            courseDetailViewModel.deleteCourse { [weak self] success in
-                DispatchQueue.main.async {
-                    if success {
-                        print("성공적으로 삭제")
-                        self?.navigationController?.popViewController(animated: true)
-                    } else {
-                        print("삭제 실패 ㅠ")
-                    }
-                }
-            }
-            courseDetailView.mainCollectionView.reloadData()
+            didTapDeleteLabel()
         } else {
-            print("신고하기 웹뷰로 연결")
-            //임시로 아무 링크 ㅎㅎ
-            let delclareVC = DRWebViewController(urlString: "https://blog.naver.com/2cold0utside")
-            self.present(delclareVC, animated: true)
+            didTapDeclareLabel()
         }
-        
     }
     
 }

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/CourseDetail/Views/CourseDetailViewController.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/CourseDetail/Views/CourseDetailViewController.swift
@@ -278,8 +278,8 @@ extension CourseDetailViewController: ContentMaskViewDelegate {
     //바텀 시트에서 신고하기 클릭시 팝업창
     func showDeclareAlert(){
         presentCustomAlert(
-            title: "데이트 코스를 신고하시겠어요?",
-            description: "신고된 게시물은 확인 후 서비스의 운영원칙에\n따라 조치 예정이에요",
+            title: StringLiterals.CourseDetail.declareTitle,
+            description: StringLiterals.CourseDetail.declareDescription,
             action: .declareCourse
         )
     }
@@ -287,8 +287,8 @@ extension CourseDetailViewController: ContentMaskViewDelegate {
     //바텀 시트에서 삭제하기 클릭시 팝업창
     func showDeleteAlert(){
         presentCustomAlert(
-            title: "데이트 코스를 삭제하시겠어요?",
-            description: "삭제된 코스는 복구하실 수 없어요",
+            title: StringLiterals.CourseDetail.deleteTitle,
+            description: StringLiterals.CourseDetail.deleteDescription,
             action: .deleteCourse
         )
     }
@@ -361,9 +361,9 @@ private extension CourseDetailViewController {
     @objc
     func didTapMySchedule() {
         let courseId = courseDetailViewModel.courseId
-        
         let courseDetailViewModel = CourseDetailViewModel(courseId: courseId)
         let addScheduleViewModel = AddScheduleViewModel()
+        
         addScheduleViewModel.viewedDateCourseByMeData = courseDetailViewModel
         addScheduleViewModel.isImporting = true
         
@@ -378,7 +378,6 @@ private extension CourseDetailViewController {
     @objc
     func didTapLikeButton() {
         isFirstLike = false
-        
         guard let isLiked = courseDetailViewModel.isUserLiked.value else { return }
         
         courseDetailViewModel.isUserLiked.value?.toggle()
@@ -387,12 +386,10 @@ private extension CourseDetailViewController {
         likeAction(courseId ?? 0)
         
         self.courseDetailView.mainCollectionView.reloadData()
-        
     }
     
     func updateLikeButtonColor(isLiked: Bool) {
         courseInfoTabBarView.likeButtonImageView.tintColor = isLiked ? UIColor(resource: .deepPurple) : UIColor(resource: .gray200)
-
     }
     
     func setSetctionCount() {

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/CourseDetail/Views/CourseDetailViewController.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/CourseDetail/Views/CourseDetailViewController.swift
@@ -151,7 +151,7 @@ final class CourseDetailViewController: BaseViewController, DRCustomAlertDelegat
             if isSuccess {
                 self?.localLikeNum = self?.courseDetailViewModel.likeSum.value ?? 0
                 self?.setSetctionCount()
-                self?.setTabBar()
+                self?.setTabBarVisibility()
                 self?.courseDetailView.mainCollectionView.reloadData()
             }
         }
@@ -219,7 +219,7 @@ extension CourseDetailViewController: ContentMaskViewDelegate {
             return
         }
         setSetctionCount()
-        setTabBar()
+        setTabBarVisibility()
     }
     
     //버튼 분기 처리하기
@@ -279,7 +279,7 @@ extension CourseDetailViewController: ContentMaskViewDelegate {
         self.present(customAlertVC, animated: false)
     }
     
-    //바텀시트에서 신고하기 클릭시 팝업창
+    //바텀 시트에서 신고하기 클릭시 팝업창
     func didTapDeclareLabel(){
         let customAlertVC = DRCustomAlertViewController(
             rightActionType: RightButtonType.declareCourse,
@@ -294,7 +294,7 @@ extension CourseDetailViewController: ContentMaskViewDelegate {
         self.present(customAlertVC, animated: false)
     }
     
-    //바텀시트에서 삭제하기 클릭시 팝업창
+    //바텀 시트에서 삭제하기 클릭시 팝업창
     func didTapDeleteLabel(){
         let customAlertVC = DRCustomAlertViewController(
             rightActionType: RightButtonType.declareCourse,
@@ -308,6 +308,8 @@ extension CourseDetailViewController: ContentMaskViewDelegate {
         customAlertVC.modalPresentationStyle = .overFullScreen
         self.present(customAlertVC, animated: false)
     }
+    
+    
     
     
     //코스 등록하기로 화면 전환
@@ -433,15 +435,12 @@ private extension CourseDetailViewController {
     }
     
     func setSetctionCount() {
-        guard let isAccess = courseDetailViewModel.isAccess.value else { return }
-        let sectionCount = isAccess ? 6 : 3
-        courseDetailViewModel.setNumberOfSections(sectionCount)
+        courseDetailViewModel.setNumberOfSections(courseDetailViewModel.isAccess.value == true ? 6 : 3)
         courseDetailView.mainCollectionView.reloadData()
     }
     
-    func setTabBar() {
-        guard let isAccess = courseDetailViewModel.isAccess.value else { return }
-        courseInfoTabBarView.isHidden = !isAccess || courseDetailViewModel.isCourseMine.value == true
+    func setTabBarVisibility() {
+        courseInfoTabBarView.isHidden = !(courseDetailViewModel.isAccess.value ?? false) || (courseDetailViewModel.isCourseMine.value == true)
     }
     
 }

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/CourseDetail/Views/CourseDetailViewController.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/CourseDetail/Views/CourseDetailViewController.swift
@@ -115,9 +115,7 @@ final class CourseDetailViewController: BaseViewController {
             $0.register(InfoHeaderView.self, forSupplementaryViewOfKind: InfoHeaderView.elementKinds, withReuseIdentifier: InfoHeaderView.identifier)
             
             $0.register(TimelineHeaderView.self, forSupplementaryViewOfKind: TimelineHeaderView.elementKinds, withReuseIdentifier: TimelineHeaderView.identifier)
-            
-            $0.register(GradientView.self, forSupplementaryViewOfKind: GradientView.elementKinds, withReuseIdentifier: GradientView.identifier)
-            
+                    
             $0.register(BottomPageControllView.self, forSupplementaryViewOfKind: BottomPageControllView.elementKinds, withReuseIdentifier: BottomPageControllView.identifier)
             
             $0.register(ContentMaskView.self, forSupplementaryViewOfKind: ContentMaskView.elementKinds, withReuseIdentifier: ContentMaskView.identifier)
@@ -392,7 +390,7 @@ private extension CourseDetailViewController {
         
     }
     
-    private func updateLikeButtonColor(isLiked: Bool) {
+    func updateLikeButtonColor(isLiked: Bool) {
         courseInfoTabBarView.likeButtonImageView.tintColor = isLiked ? UIColor(resource: .deepPurple) : UIColor(resource: .gray200)
 
     }
@@ -517,8 +515,6 @@ extension CourseDetailViewController: UICollectionViewDelegate, UICollectionView
             return configureVisitDateView(collectionView, indexPath: indexPath, titleHeaderData: titleHeaderData)
         case InfoBarView.elementKinds:
             return configureInfoBarView(collectionView, indexPath: indexPath, titleHeaderData: titleHeaderData)
-        case GradientView.elementKinds:
-            return configureGradientView(collectionView, indexPath: indexPath)
         case BottomPageControllView.elementKinds:
             return configureBottomPageControlView(collectionView, indexPath: indexPath, imageData: imageData, isAccess: isAccess)
         case ContentMaskView.elementKinds:
@@ -545,13 +541,6 @@ extension CourseDetailViewController: UICollectionViewDelegate, UICollectionView
             return UICollectionReusableView()
         }
         view.bindTitleHeader(titleHeaderData: titleHeaderData)
-        return view
-    }
-    
-    private func configureGradientView(_ collectionView: UICollectionView, indexPath: IndexPath) -> UICollectionReusableView {
-        guard let view = collectionView.dequeueReusableSupplementaryView(ofKind: GradientView.elementKinds, withReuseIdentifier: GradientView.identifier, for: indexPath) as? GradientView else {
-            return UICollectionReusableView()
-        }
         return view
     }
     

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/CourseDetail/Views/CourseDetailViewController.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/CourseDetail/Views/CourseDetailViewController.swift
@@ -542,7 +542,8 @@ extension CourseDetailViewController: UICollectionViewDelegate, UICollectionView
             return header
         } else if kind == TimelineHeaderView.elementKinds {
             guard let header = collectionView.dequeueReusableSupplementaryView(ofKind: kind, withReuseIdentifier: TimelineHeaderView.identifier, for: indexPath) as? TimelineHeaderView else { return UICollectionReusableView() }
-            // TODO :  시작 시간 바인딩
+            let startAt = self.courseDetailViewModel.startAt
+            header.bindSubTitle(subTitle: startAt)
             return header
         } else {
             return UICollectionReusableView()

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/CourseDetail/Views/GradientView.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/CourseDetail/Views/GradientView.swift
@@ -18,16 +18,9 @@ class GradientView: UICollectionReusableView {
     
     private let gradient = CAGradientLayer()
     
-    // MARK: - Properties
-    
-    static let elementKinds: String = "gradient"
-    
-    static let identifier: String = "GradientView"
-    
     // MARK: - Life Cycle
     
     override init(frame: CGRect) {
-        
         super.init(frame: frame)
         
         setHierarchy()

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/CourseDetail/Views/InfoBarView.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/CourseDetail/Views/InfoBarView.swift
@@ -69,7 +69,7 @@ class InfoBarView: UICollectionReusableView {
         
         timeIconImageView.snp.makeConstraints {
             $0.top.equalTo(coastIconImageView)
-            $0.leading.equalToSuperview().inset(106)
+            $0.leading.equalTo(coastIconImageView.snp.trailing).offset(102)
             $0.size.equalTo(14)
         }
         
@@ -80,7 +80,7 @@ class InfoBarView: UICollectionReusableView {
         
         locationIconImageView.snp.makeConstraints {
             $0.top.equalTo(coastIconImageView)
-            $0.leading.equalToSuperview().inset(202)
+            $0.leading.equalTo(timeIconImageView.snp.trailing).offset(72)
             $0.width.equalTo(12)
             $0.height.equalTo(14)
         }

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/CourseDetail/Views/InfoHeaderView.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/CourseDetail/Views/InfoHeaderView.swift
@@ -11,7 +11,7 @@ import SnapKit
 import Then
 
 class InfoHeaderView: UICollectionReusableView {
-
+    
     // MARK: - UI Properties
     
     private let titleLabel: UILabel = UILabel()
@@ -21,7 +21,7 @@ class InfoHeaderView: UICollectionReusableView {
     static let elementKinds: String = "infoHeaderView"
     
     static let identifier: String = "InfoHeaderView"
-
+    
     
     // MARK: - Life Cycles
     
@@ -36,14 +36,6 @@ class InfoHeaderView: UICollectionReusableView {
     required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
-    
-    func bindTitle(headerTitle: String) {
-        self.titleLabel.text = headerTitle
-    }
-    
-}
-
-private extension InfoHeaderView {
     
     func setHierarchy() {
         self.addSubview(titleLabel)
@@ -64,6 +56,14 @@ private extension InfoHeaderView {
             $0.font = UIFont.suit(.title_bold_18)
             $0.numberOfLines = 1
         }
+    }
+    
+}
+
+extension InfoHeaderView {
+    
+    func bindTitle(headerTitle: String) {
+        self.titleLabel.text = headerTitle
     }
     
 }

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/CourseDetail/Views/StickyHeaderNavBarView.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/CourseDetail/Views/StickyHeaderNavBarView.swift
@@ -12,7 +12,7 @@ import Then
 
 protocol StickyHeaderNavBarViewDelegate: AnyObject {
     func didTapBackButton()
-    func didTapDeleteButton()
+    func didTapMoreButton()
 }
 
 final class StickyHeaderNavBarView: UIView {
@@ -85,7 +85,7 @@ private extension StickyHeaderNavBarView {
     
     @objc
     func didTapMoreButton() {
-        delegate?.didTapDeleteButton()
+        delegate?.didTapMoreButton()
     }
     
 }

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/CourseDetail/Views/TimelineHeaderView.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/CourseDetail/Views/TimelineHeaderView.swift
@@ -39,12 +39,10 @@ class TimelineHeaderView: UICollectionReusableView {
         fatalError("init(coder:) has not been implemented")
     }
     
-    func bindTitle(headerTitle: String) {
-        self.titleLabel.text = headerTitle
-    }
-    
     func bindSubTitle(subTitle: String?) {
-        self.subLabel.text = subTitle
+        if let startAt = subTitle {
+            self.subLabel.text = "\(startAt) 시작"
+        }
     }
     
 }

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/CourseDetail/Views/TimelineHeaderView.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/CourseDetail/Views/TimelineHeaderView.swift
@@ -1,0 +1,83 @@
+//
+//  TimelineHeaderView.swift
+//  DATEROAD-iOS
+//
+//  Created by 김민서 on 8/16/24.
+//
+
+import UIKit
+
+import SnapKit
+import Then
+
+class TimelineHeaderView: UICollectionReusableView {
+
+    // MARK: - UI Properties
+    
+    private let titleLabel: UILabel = UILabel()
+    
+    private let subLabel: UILabel = UILabel()
+    
+    // MARK: - Properties
+    
+    static let elementKinds: String = "TimelineHeaderView"
+    
+    static let identifier: String = "TimelineHeaderView"
+
+    
+    // MARK: - Life Cycles
+    
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        
+        setHierarchy()
+        setLayout()
+        setStyle()
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    func bindTitle(headerTitle: String) {
+        self.titleLabel.text = headerTitle
+    }
+    
+    func bindSubTitle(subTitle: String?) {
+        self.subLabel.text = subTitle
+    }
+    
+}
+
+private extension TimelineHeaderView {
+    
+    func setHierarchy() {
+        self.addSubviews(titleLabel, subLabel)
+        
+    }
+    
+    func setLayout() {
+        titleLabel.snp.makeConstraints {
+            $0.bottom.equalTo(subLabel.snp.top).offset(-7)
+            $0.leading.equalToSuperview()
+        }
+        
+        subLabel.snp.makeConstraints {
+            $0.bottom.equalToSuperview()
+            $0.leading.equalToSuperview()
+        }
+    }
+    
+    func setStyle() {
+        titleLabel.do {
+            $0.setLabel(text: StringLiterals.CourseDetail.timelineInfoLabel, textColor: UIColor(resource: .drBlack), font: UIFont.suit(.title_bold_18))
+            $0.numberOfLines = 1
+        }
+        
+        subLabel.do {
+            $0.setLabel(text:"12:00 PM 시작",textColor: UIColor(resource: .gray400), font: UIFont.suit(.body_semi_15))
+            $0.numberOfLines = 0
+        }
+    }
+    
+}

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/CourseDetail/Views/TimelineHeaderView.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/CourseDetail/Views/TimelineHeaderView.swift
@@ -11,7 +11,7 @@ import SnapKit
 import Then
 
 class TimelineHeaderView: UICollectionReusableView {
-
+    
     // MARK: - UI Properties
     
     private let titleLabel: UILabel = UILabel()
@@ -23,7 +23,7 @@ class TimelineHeaderView: UICollectionReusableView {
     static let elementKinds: String = "TimelineHeaderView"
     
     static let identifier: String = "TimelineHeaderView"
-
+    
     
     // MARK: - Life Cycles
     
@@ -39,15 +39,6 @@ class TimelineHeaderView: UICollectionReusableView {
         fatalError("init(coder:) has not been implemented")
     }
     
-    func bindSubTitle(subTitle: String?) {
-        if let startAt = subTitle {
-            self.subLabel.text = "\(startAt) 시작"
-        }
-    }
-    
-}
-
-private extension TimelineHeaderView {
     
     func setHierarchy() {
         self.addSubviews(titleLabel, subLabel)
@@ -73,8 +64,25 @@ private extension TimelineHeaderView {
         }
         
         subLabel.do {
-            $0.setLabel(text:"12:00 PM 시작",textColor: UIColor(resource: .gray400), font: UIFont.suit(.body_semi_15))
-            $0.numberOfLines = 0
+            $0.setLabel(
+                text:"12:00 PM 시작",
+                textColor: UIColor(
+                    resource: .gray400
+                ),
+                font: UIFont.suit(
+                    .body_semi_15
+                )
+            )
+        }
+    }
+    
+}
+
+extension TimelineHeaderView {
+    
+    func bindSubTitle(subTitle: String?) {
+        if let startAt = subTitle {
+            self.subLabel.text = "\(startAt) 시작"
         }
     }
     


### PR DESCRIPTION
# 🔥*Pull requests*

## ⛳ **작업한 브랜치**
- feature/#160 

## 👷 **작업한 내용**
<!-- 작업한 내용을 적어주세요. -->
GUI에 시작 시간 확정되어서 반영해주었습니다
그리고 코스 삭제 혹은 신고 클릭 시 팝업창이 나타나는 플로우로 변경되어 이 부분도 반영해주었습니다!

구글폼 확정되어 신고하기 폼 URL 반영시켜두었습니다 (블로그 홍보 ㅃㅃ ㅠㅠ)

분기처리가 많은 뷰여서 제가 쓴 코드도 제가 헷갈리는 사태가 발생하여
전체적으로 메서드로 분리하고 메서드명 통일 시켜주었습니닷!

메인 이미지 부분 위에 덮는 그라디언트 뷰가 1px정도 밀렸는데 이 부분도 수정해주었습니다!
(관리자 글일 떄도 그라디언트 부분만! 수정해두었습니닷! 아마 희슬 언니 뷰..?)

## 🚨 참고 사항
<!-- 참고할 사항이 있다면 적어주세요. -->
compositonal Layout을 쓰다보니,,, VC의 코드가 600줄에 임박하도록 길어졌는데
그러다 보니 가독성이 너무 떨어져서 매서드로 분리해보았습니다만
그러나 ㅠㅠ However.. 가독성은 조금 좋아졌으나 코드가 줄기는 커녕 살짝 늘어나버려서
이 부분을 어떻게 하면 좋을지 잘 모르겠어요 ㅠㅠ


## 📸 스크린샷
|기능|스크린샷|
|:--:|:--:|
|아이폰13 mini|![Simulator Screen Recording - iPhone 13 mini - 2024-08-16 at 12 16 58](https://github.com/user-attachments/assets/d6a9a8f5-7e3f-4446-a8f7-189af02c38c2)|



## 📟 관련 이슈
- Resolved: #160 
