### PR TITLE
[FIX] 데이트 일정 & 지난 데이트 이슈 해결 (#178)

### DIFF
--- a/DATEROAD-iOS/DATEROAD-iOS/Global/UIComponents/TabBarController.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Global/UIComponents/TabBarController.swift
@@ -18,7 +18,7 @@ final class TabBarController: UITabBarController {
     
     let courseVC = CourseViewController(courseViewModel: CourseViewModel())
     
-    let dateVC = UpcomingDateScheduleViewController()
+    let dateVC = UpcomingDateScheduleViewController(upcomingDateScheduleViewModel: DateScheduleViewModel())
     
     let viewedCourseVC = ViewedCourseViewController(viewedCourseViewModel: MyCourseListViewModel())
     

--- a/DATEROAD-iOS/DATEROAD-iOS/Network/DateSchedule/DateScheduleService.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Network/DateSchedule/DateScheduleService.swift
@@ -12,7 +12,7 @@ import Moya
 protocol DateScheduleServiceProtocol {
     func getDateSchdeule(time: String, completion: @escaping (NetworkResult<GetDateScheduleResponse>) -> Void)
     func getDateDetail(dateID: Int, completion: @escaping (NetworkResult<GetDateDetailResponse>) -> Void)
-    func deleteDateSchedule(dateID: Int, completion: @escaping (NetworkResult<DeleteDateScheduleResponse>) -> Void)
+    func deleteDateSchedule(dateID: Int, completion: @escaping (NetworkResult<EmptyResponse>) -> Void)
 }
 
 final class DateScheduleService: BaseService, DateScheduleServiceProtocol {
@@ -42,11 +42,12 @@ final class DateScheduleService: BaseService, DateScheduleServiceProtocol {
         }
     }
     
-    func deleteDateSchedule(dateID: Int, completion: @escaping (NetworkResult<DeleteDateScheduleResponse>) -> Void) {
+    func deleteDateSchedule(dateID: Int, completion: @escaping (NetworkResult<EmptyResponse>) -> Void) {
         dateScheduleProvider.request(.deleteDateSchedule(dateID: dateID)) { result in
             switch result {
             case .success(let response):
-                print(response)
+                let networkResult: NetworkResult<EmptyResponse> = self.judgeStatus(statusCode: response.statusCode, data: response.data)
+                completion(networkResult)
             case .failure(let err):
                 print(err)
             }

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/DateSchedule/View/PastDateDetailViewController.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/DateSchedule/View/PastDateDetailViewController.swift
@@ -67,8 +67,8 @@ final class PastDateDetailViewController: BaseNavBarViewController {
     override func setHierarchy() {
         super.setHierarchy()
         
-        contentView.addSubviews(loadingView, pastDateDetailContentView)
-        
+        self.view.addSubview(loadingView)
+        contentView.addSubviews(pastDateDetailContentView)
     }
     
     override func setLayout() {
@@ -129,17 +129,19 @@ extension PastDateDetailViewController: DRBottomSheetDelegate {
 // MARK: - UI Setting Methods
 
 extension PastDateDetailViewController {
+    
     func bindViewModel() {
-        
-        self.pastDateDetailViewModel?.onDateDetailLoading.bind { [weak self] onLoading in
-            guard let onLoading, let onFailNetwork = self?.pastDateDetailViewModel?.onFailNetwork.value else { return }
+        self.pastDateDetailViewModel.onDateDetailLoading.bind { [weak self] onLoading in
+            guard let onLoading,
+                  let onFailNetwork = self?.pastDateDetailViewModel.onFailNetwork.value
+            else { return }
              if !onFailNetwork {
                  self?.loadingView.isHidden = !onLoading
                  self?.pastDateDetailContentView.isHidden = onLoading
              }
          }
         
-        self.pastDateDetailViewModel?.onReissueSuccess.bind { [weak self] onSuccess in
+        self.pastDateDetailViewModel.onReissueSuccess.bind { [weak self] onSuccess in
             guard let onSuccess else { return }
             if onSuccess {
                 // TODO: - 서버 통신 재시도
@@ -148,15 +150,22 @@ extension PastDateDetailViewController {
             }
         }
         
-        self.pastDateDetailViewModel?.isSuccessGetDateDetailData.bind { [weak self] isSuccess in
-            guard let isSuccess, let data = self?.pastDateDetailViewModel?.dateDetailData.value else { return }
+        self.pastDateDetailViewModel.isSuccessGetDateDetailData.bind { [weak self] isSuccess in
+            guard let isSuccess, 
+                    let data = self?.pastDateDetailViewModel.dateDetailData.value
+            else { return }
             if isSuccess {
                 self?.pastDateDetailContentView.dataBind(data)
                 self?.pastDateDetailContentView.dateTimeLineCollectionView.reloadData()
+                DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
+                    self?.pastDateDetailViewModel.setDateDetailLoading()
+                }
+            }
+        }
             }
         }
         
-        self.pastDateDetailViewModel?.onFailNetwork.bind { [weak self] onFailure in
+        self.pastDateDetailViewModel.onFailNetwork.bind { [weak self] onFailure in
             guard let onFailure else { return }
             if onFailure {
                 self?.loadingView.isHidden = true
@@ -229,11 +238,11 @@ extension PastDateDetailViewController: UICollectionViewDelegateFlowLayout {
 
 extension PastDateDetailViewController: UICollectionViewDataSource {
     func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
-        return pastDateDetailViewModel?.dateDetailData.value?.places.count ?? 0
+        return pastDateDetailViewModel.dateDetailData.value?.places.count ?? 0
     }
     
     func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
-        guard let data = pastDateDetailViewModel?.dateDetailData.value?.places[indexPath.item] else { return UICollectionViewCell() }
+        guard let data = pastDateDetailViewModel.dateDetailData.value?.places[indexPath.item] else { return UICollectionViewCell() }
         guard let cell = collectionView.dequeueReusableCell(withReuseIdentifier: DateTimeLineCollectionViewCell.cellIdentifier, for: indexPath) as? DateTimeLineCollectionViewCell else {
             return UICollectionViewCell() }
         cell.dataBind(data, indexPath.item)
@@ -242,12 +251,3 @@ extension PastDateDetailViewController: UICollectionViewDataSource {
 
 }
 
-//extension PastDateDetailViewController: UICollectionViewDelegate {
-//    func collectionView(_ collectionView: UICollectionView, willDisplay cell: UICollectionViewCell, forItemAt indexPath: IndexPath) {
-//        if indexPath.row == collectionView.numberOfItems(inSection: indexPath.section) - 1 {
-//            DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
-//                self.pastDateDetailViewModel?.setDateDetailLoading()
-//            }
-//        }
-//    }
-//}

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/DateSchedule/View/PastDateDetailViewController.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/DateSchedule/View/PastDateDetailViewController.swift
@@ -87,7 +87,12 @@ final class PastDateDetailViewController: BaseNavBarViewController {
 extension PastDateDetailViewController: DRCustomAlertDelegate {
     @objc
     func tapDeleteLabel() {
-        let customAlertVC = DRCustomAlertViewController(rightActionType: .deleteCourse, alertTextType: .hasDecription, alertButtonType: .twoButton, titleText: StringLiterals.Alert.deletePastDateSchedule, descriptionText: StringLiterals.Alert.noMercy, rightButtonText: "삭제")
+        let customAlertVC = DRCustomAlertViewController(rightActionType: .deleteCourse, 
+                                                        alertTextType: .hasDecription,
+                                                        alertButtonType: .twoButton,
+                                                        titleText: StringLiterals.Alert.deletePastDateSchedule,
+                                                        descriptionText: StringLiterals.Alert.noMercy,
+                                                        rightButtonText: "삭제")
         customAlertVC.delegate = self
         customAlertVC.modalPresentationStyle = .overFullScreen
         self.present(customAlertVC, animated: false)
@@ -95,9 +100,7 @@ extension PastDateDetailViewController: DRCustomAlertDelegate {
 
     func action(rightButtonAction: RightButtonType) {
         if rightButtonAction == .deleteCourse {
-            pastDateDetailViewModel?.deleteDateSchdeuleData(dateID: pastDateDetailViewModel?.dateDetailData.value?.dateID ?? 0)
-            print("헉 헤어졌나??? 서버연결 delete")
-            self.navigationController?.popViewController(animated: true)
+            pastDateDetailViewModel.deleteDateSchdeuleData(dateID: pastDateDetailViewModel.dateDetailData.value?.dateID ?? 0)
         }
     }
 }
@@ -162,6 +165,11 @@ extension PastDateDetailViewController {
                 }
             }
         }
+        
+        self.pastDateDetailViewModel.isSuccessDeleteDateScheduleData.bind { [weak self] isSuccess in
+            guard let isSuccess else { return }
+            if isSuccess {
+                self?.navigationController?.popViewController(animated: true)
             }
         }
         
@@ -178,10 +186,8 @@ extension PastDateDetailViewController {
     @objc
     private func tapShareCourse() {
         print("코스 등록해서 공유하기 여기!!!!!!!!!!!!")
-       guard let data = pastDateDetailViewModel?.dateDetailData.value else {
-               print("No date detail data available")
-               return
-           }
+       guard let data = pastDateDetailViewModel.dateDetailData.value
+        else { return }
            
            let addCourseViewModel = AddCourseViewModel(pastDateDetailData: data)
            let vc = AddCourseFirstViewController(viewModel: addCourseViewModel)

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/DateSchedule/View/PastDateDetailViewController.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/DateSchedule/View/PastDateDetailViewController.swift
@@ -10,7 +10,8 @@ import UIKit
 import SnapKit
 import Then
 
-class PastDateDetailViewController: BaseNavBarViewController {
+final class PastDateDetailViewController: BaseNavBarViewController {
+    
     // MARK: - UI Properties
     
     var pastDateDetailContentView = DateDetailContentView()
@@ -19,27 +20,34 @@ class PastDateDetailViewController: BaseNavBarViewController {
 
     private let errorView: DRErrorViewController = DRErrorViewController()
     
-    // MARK: - Properties
-    var dateID: Int?
     
-    var pastDateDetailViewModel: DateDetailViewModel? = nil
+    // MARK: - Properties
+    
+    var dateID: Int
+    
+    var pastDateDetailViewModel: DateDetailViewModel
     
     private let dateScheduleDeleteView = DateScheduleDeleteView()
     
+    
     // MARK: - LifeCycle
     
-    override func viewWillAppear(_ animated: Bool) {
-        self.tabBarController?.tabBar.isHidden = false
-        bindViewModel()
-        self.pastDateDetailViewModel?.getDateDetailData(dateID: self.dateID ?? 0)
+    init(dateID: Int, pastDateDetailViewModel: DateDetailViewModel) {
+        self.dateID = dateID
+        self.pastDateDetailViewModel = pastDateDetailViewModel
+        
+        super.init(nibName: nil, bundle: nil)
     }
     
-    override func viewDidAppear(_ animated: Bool) {
-        bindViewModel()
-        self.pastDateDetailViewModel?.getDateDetailData(dateID: self.dateID ?? 0)
-        DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
-            self.pastDateDetailViewModel?.setDateDetailLoading()
-        }
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    override func viewWillAppear(_ animated: Bool) {
+        self.navigationController?.tabBarController?.tabBar.isHidden = true
+        self.tabBarController?.tabBar.isHidden = true
+        self.pastDateDetailViewModel.setDateDetailLoading()
+        self.pastDateDetailViewModel.getDateDetailData(dateID: self.dateID)
     }
     
     override func viewDidLoad() {

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/DateSchedule/View/PastDateViewController.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/DateSchedule/View/PastDateViewController.swift
@@ -187,21 +187,9 @@ extension PastDateViewController: UICollectionViewDataSource {
         let location = sender.location(in: pastDateContentView.pastDateCollectionView)
         if let indexPath = pastDateContentView.pastDateCollectionView.indexPathForItem(at: location) {
             guard let data = pastDateScheduleViewModel.pastDateScheduleData.value?[indexPath.item] else { return }
-            let pastDateDetailVC = PastDateDetailViewController()
-            self.navigationController?.pushViewController(pastDateDetailVC, animated: false)
-            pastDateDetailVC.pastDateDetailViewModel = DateDetailViewModel(dateID: data.dateID)
-            pastDateDetailVC.dateID = data.dateID
+            let pastDateDetailVC = PastDateDetailViewController(dateID: data.dateID, pastDateDetailViewModel: DateDetailViewModel())
             pastDateDetailVC.setColor(index: indexPath.item)
-        }
-    }
-}
-  
-extension PastDateViewController: UICollectionViewDelegate {
-    func collectionView(_ collectionView: UICollectionView, willDisplay cell: UICollectionViewCell, forItemAt indexPath: IndexPath) {
-        if indexPath.row == collectionView.numberOfItems(inSection: indexPath.section) - 1 {
-            DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
-                self.pastDateScheduleViewModel.setPastScheduleLoading()
-            }
+            self.navigationController?.pushViewController(pastDateDetailVC, animated: false)
         }
     }
 }

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/DateSchedule/View/PastDateViewController.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/DateSchedule/View/PastDateViewController.swift
@@ -10,7 +10,7 @@ import UIKit
 import SnapKit
 import Then
 
-class PastDateViewController: BaseNavBarViewController {
+final class PastDateViewController: BaseNavBarViewController {
     
     // MARK: - UI Properties
     
@@ -20,14 +20,31 @@ class PastDateViewController: BaseNavBarViewController {
 
     private let errorView: DRErrorViewController = DRErrorViewController()
     
+    
     // MARK: - Properties
     
-    private let pastDateScheduleViewModel = DateScheduleViewModel()
+    var pastDateScheduleViewModel: DateScheduleViewModel
     
-    override func viewDidAppear(_ animated: Bool) {
-        bindViewModel()
-        loadDataAndReload()
+    
+    // MARK: - Life Cycles
+    
+    init(pastDateScheduleViewModel: DateScheduleViewModel) {
+        self.pastDateScheduleViewModel = pastDateScheduleViewModel
+        
+        super.init(nibName: nil, bundle: nil)
     }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    override func viewWillAppear(_ animated: Bool) {
+        self.navigationController?.tabBarController?.tabBar.isHidden = true
+        self.tabBarController?.tabBar.isHidden = true
+        self.pastDateScheduleViewModel.setPastScheduleLoading()
+        self.pastDateScheduleViewModel.getPastDateScheduleData()
+    }
+
     
     // MARK: - LifeCycle
     

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/DateSchedule/View/UpcomingDateDetailViewController.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/DateSchedule/View/UpcomingDateDetailViewController.swift
@@ -10,7 +10,7 @@ import UIKit
 import SnapKit
 import Then
 
-class UpcomingDateDetailViewController: BaseNavBarViewController {
+final class UpcomingDateDetailViewController: BaseNavBarViewController {
 
     // MARK: - UI Properties
     
@@ -20,14 +20,28 @@ class UpcomingDateDetailViewController: BaseNavBarViewController {
 
     private let errorView: DRErrorViewController = DRErrorViewController()
     
-    // MARK: - Properties
-    var dateID: Int?
     
-    var upcomingDateDetailViewModel: DateDetailViewModel? = nil
+    // MARK: - Properties
+    
+    var dateID: Int
+    
+    var upcomingDateDetailViewModel: DateDetailViewModel
     
     private let dateScheduleDeleteView = DateScheduleDeleteView()
     
+    
     // MARK: - LifeCycle
+    
+    init(dateID: Int, upcomingDateDetailViewModel: DateDetailViewModel) {
+        self.dateID = dateID
+        self.upcomingDateDetailViewModel = upcomingDateDetailViewModel
+        
+        super.init(nibName: nil, bundle: nil)
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
     
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -168,11 +182,9 @@ extension UpcomingDateDetailViewController: DRCustomAlertDelegate {
            print("all")
            if rightButtonAction == .deleteCourse {
                print("zz")
-               upcomingDateDetailViewModel?.deleteDateSchdeuleData(dateID: upcomingDateDetailViewModel?.dateDetailData.value?.dateID ?? 0)
-               print("헉 헤어졌나??? 서버연결 delete")
-               self.navigationController?.popViewController(animated: true)
+               upcomingDateDetailViewModel.deleteDateSchdeuleData(dateID: upcomingDateDetailViewModel.dateDetailData.value?.dateID ?? 0)
            } else if rightButtonAction == .kakaoShare {
-               upcomingDateDetailViewModel?.shareToKakao(context: self)
+               upcomingDateDetailViewModel.shareToKakao(context: self)
                print("카카오 공유하기")
            }
        }
@@ -236,11 +248,11 @@ extension UpcomingDateDetailViewController: UICollectionViewDelegateFlowLayout {
 
 extension UpcomingDateDetailViewController: UICollectionViewDataSource {
     func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
-        return upcomingDateDetailViewModel?.dateDetailData.value?.places.count ?? 0
+        return upcomingDateDetailViewModel.dateDetailData.value?.places.count ?? 0
     }
     
     func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
-        guard let data = upcomingDateDetailViewModel?.dateDetailData.value?.places[indexPath.item] else { return UICollectionViewCell() }
+        guard let data = upcomingDateDetailViewModel.dateDetailData.value?.places[indexPath.item] else { return UICollectionViewCell() }
         guard let cell = collectionView.dequeueReusableCell(withReuseIdentifier: DateTimeLineCollectionViewCell.cellIdentifier, for: indexPath) as? DateTimeLineCollectionViewCell else {
             return UICollectionViewCell() }
         cell.dataBind(data, indexPath.item)
@@ -248,13 +260,3 @@ extension UpcomingDateDetailViewController: UICollectionViewDataSource {
     }
 
 }
-
-//extension UpcomingDateDetailViewController: UICollectionViewDelegate {
-//    func collectionView(_ collectionView: UICollectionView, willDisplay cell: UICollectionViewCell, forItemAt indexPath: IndexPath) {
-//        if indexPath.row == collectionView.numberOfItems(inSection: indexPath.section) - 1 {
-//            DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
-//                self.upcomingDateDetailViewModel?.setDateDetailLoading()
-//            }
-//        }
-//    }
-//}

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/DateSchedule/View/UpcomingDateDetailViewController.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/DateSchedule/View/UpcomingDateDetailViewController.swift
@@ -131,6 +131,11 @@ extension UpcomingDateDetailViewController {
                 }
             }
         }
+        
+        self.upcomingDateDetailViewModel.isSuccessDeleteDateScheduleData.bind { [weak self] isSuccess in
+            guard let isSuccess else { return }
+            if isSuccess {
+                self?.navigationController?.popViewController(animated: true)
             }
         }
     }

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/DateSchedule/View/UpcomingDateScheduleViewController.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/DateSchedule/View/UpcomingDateScheduleViewController.swift
@@ -270,12 +270,11 @@ extension UpcomingDateScheduleViewController: UICollectionViewDataSource {
         let location = sender.location(in: upcomingDateScheduleView.cardCollectionView)
         if let indexPath = upcomingDateScheduleView.cardCollectionView.indexPathForItem(at: location) {
             let data = upcomingDateScheduleViewModel.upcomingDateScheduleData.value?[indexPath.item] ?? DateCardModel(dateID: 0, title: "", date: "", city: "", tags: [], dDay: 0)
-            let upcomingDateDetailVC = UpcomingDateDetailViewController()
+            let upcomingDateDetailVC = UpcomingDateDetailViewController(dateID: data.dateID, upcomingDateDetailViewModel: DateDetailViewModel()
+            )
+            upcomingDateDetailVC.setColor(index: indexPath.item)
             self.navigationController?.pushViewController(upcomingDateDetailVC, animated: false)
 //            upcomingDateDetailVC.upcomingDateScheduleView = upcomingDateScheduleView
-            upcomingDateDetailVC.upcomingDateDetailViewModel = DateDetailViewModel(dateID: data.dateID)
-            upcomingDateDetailVC.dateID = data.dateID
-            upcomingDateDetailVC.setColor(index: indexPath.item)
         }
     }
     

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/DateSchedule/View/UpcomingDateScheduleViewController.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/DateSchedule/View/UpcomingDateScheduleViewController.swift
@@ -10,7 +10,7 @@ import UIKit
 import SnapKit
 import Then
 
-class UpcomingDateScheduleViewController: BaseViewController {
+final class UpcomingDateScheduleViewController: BaseViewController {
     
     // MARK: - UI Properties
     
@@ -20,27 +20,32 @@ class UpcomingDateScheduleViewController: BaseViewController {
 
     private let errorView: DRErrorViewController = DRErrorViewController()
     
+    
     // MARK: - Properties
     
-    private let upcomingDateScheduleViewModel = DateScheduleViewModel()
+    private var upcomingDateScheduleViewModel: DateScheduleViewModel
+    
     
     // MARK: - LifeCycle
     
-    override func viewWillAppear(_ animated: Bool) {
-        super.viewWillAppear(animated)
-        bindViewModel()
-        self.upcomingDateScheduleViewModel.getUpcomingDateScheduleData()
+    init(upcomingDateScheduleViewModel: DateScheduleViewModel) {
+        self.upcomingDateScheduleViewModel = upcomingDateScheduleViewModel
+        
+        super.init(nibName: nil, bundle: nil)
     }
     
-    override func viewDidAppear(_ animated: Bool) {
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    override func viewWillAppear(_ animated: Bool) {
+        self.upcomingDateScheduleViewModel.setUpcomingScheduleLoading()
         self.upcomingDateScheduleViewModel.getUpcomingDateScheduleData()
-        DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
-            self.upcomingDateScheduleViewModel.setUpcomingScheduleLoading()
-        }
     }
     
     override func viewDidLoad() {
         super.viewDidLoad()
+        
         registerCell()
         setDelegate()
         setUIMethods()

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/DateSchedule/View/UpcomingDateScheduleViewController.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/DateSchedule/View/UpcomingDateScheduleViewController.swift
@@ -90,7 +90,7 @@ private extension UpcomingDateScheduleViewController {
     
     @objc
     func pushToPastDateVC() {
-        let pastDateVC = PastDateViewController()
+        let pastDateVC = PastDateViewController(pastDateScheduleViewModel: DateScheduleViewModel())
         self.navigationController?.pushViewController(pastDateVC, animated: false)
     }
     

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/DateSchedule/View/UpcomingDateScheduleViewController.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/DateSchedule/View/UpcomingDateScheduleViewController.swift
@@ -65,7 +65,6 @@ class UpcomingDateScheduleViewController: BaseViewController {
     
     func drawDateCardView() {
         print("draw date card view")
-        upcomingDateScheduleView.cardCollectionView.reloadData()
         setUIMethods()
         setEmptyView()
     }
@@ -94,7 +93,7 @@ private extension UpcomingDateScheduleViewController {
         upcomingDateScheduleView.cardPageControl.do {
             $0.numberOfPages = upcomingDateScheduleViewModel.upcomingDateScheduleData.value?.count ?? 0
         }
-        print(upcomingDateScheduleViewModel.upcomingDateScheduleData.value?.count)
+        print("pagecontrol \(upcomingDateScheduleViewModel.upcomingDateScheduleData.value?.count)")
     }
     
     func setAddTarget() {
@@ -112,25 +111,28 @@ private extension UpcomingDateScheduleViewController {
             upcomingDateScheduleView.emptyView.isHidden = false
         }
     }
-    
-    private func loadDataAndReload() {
-        self.upcomingDateScheduleViewModel.getPastDateScheduleData()
-        self.upcomingDateScheduleViewModel.isSuccessGetPastDateScheduleData.bind { [weak self] isSuccess in
-            guard let self = self else { return }
-            if isSuccess == true {
-                DispatchQueue.main.async {
-                    self.drawDateCardView()
-                }
-            }
-        }
-    }
+//    
+//    private func loadDataAndReload() {
+//        self.upcomingDateScheduleViewModel.getPastDateScheduleData()
+//        self.upcomingDateScheduleViewModel.isSuccessGetPastDateScheduleData.bind { [weak self] isSuccess in
+//            guard let self = self else { return }
+//            if isSuccess == true {
+//                DispatchQueue.main.async {
+//                    self.drawDateCardView()
+//                }
+//            }
+//        }
+//    }
     
     func bindViewModel() {
         self.upcomingDateScheduleViewModel.onUpcomingScheduleLoading.bind { [weak self] onLoading in
-             guard let onLoading, let onFailNetwork = self?.upcomingDateScheduleViewModel.onUpcomingScheduleFailNetwork.value else { return }
+             guard let onLoading, 
+                    let onFailNetwork = self?.upcomingDateScheduleViewModel.onUpcomingScheduleFailNetwork.value
+            else { return }
              if !onFailNetwork {
                  self?.loadingView.isHidden = !onLoading
                  self?.upcomingDateScheduleView.isHidden = onLoading
+                 self?.tabBarController?.tabBar.isHidden = onLoading
              }
          }
         
@@ -145,11 +147,13 @@ private extension UpcomingDateScheduleViewController {
         
         self.upcomingDateScheduleViewModel.isSuccessGetUpcomingDateScheduleData.bind { [weak self] isSuccess in
             guard let isSuccess else { return }
-            if isSuccess == true {
+            if isSuccess {
                 print("success 인디케이터")
+                self?.upcomingDateScheduleView.cardCollectionView.reloadData()
                 self?.drawDateCardView()
-            } else {
-                print("fail 인디케이터")
+                DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
+                    self?.upcomingDateScheduleViewModel.setUpcomingScheduleLoading()
+                }
             }
         }
         
@@ -253,6 +257,11 @@ extension UpcomingDateScheduleViewController: UICollectionViewDataSource {
         cell.dataBind(data, indexPath.item)
         cell.setColor(index: indexPath.item)
         cell.addGestureRecognizer(UITapGestureRecognizer(target: self, action: #selector(pushToUpcomingDateDetailVC(_:))))
+//        if indexPath.row == collectionView.numberOfItems(inSection: indexPath.section) - 1 {
+//            DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
+//                self.upcomingDateScheduleViewModel.setUpcomingScheduleLoading()
+//            }
+//        }
         return cell
     }
     

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/DateSchedule/View/UpcomingDateScheduleViewController.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/DateSchedule/View/UpcomingDateScheduleViewController.swift
@@ -116,18 +116,6 @@ private extension UpcomingDateScheduleViewController {
             upcomingDateScheduleView.emptyView.isHidden = false
         }
     }
-//    
-//    private func loadDataAndReload() {
-//        self.upcomingDateScheduleViewModel.getPastDateScheduleData()
-//        self.upcomingDateScheduleViewModel.isSuccessGetPastDateScheduleData.bind { [weak self] isSuccess in
-//            guard let self = self else { return }
-//            if isSuccess == true {
-//                DispatchQueue.main.async {
-//                    self.drawDateCardView()
-//                }
-//            }
-//        }
-//    }
     
     func bindViewModel() {
         self.upcomingDateScheduleViewModel.onUpcomingScheduleLoading.bind { [weak self] onLoading in
@@ -262,11 +250,6 @@ extension UpcomingDateScheduleViewController: UICollectionViewDataSource {
         cell.dataBind(data, indexPath.item)
         cell.setColor(index: indexPath.item)
         cell.addGestureRecognizer(UITapGestureRecognizer(target: self, action: #selector(pushToUpcomingDateDetailVC(_:))))
-//        if indexPath.row == collectionView.numberOfItems(inSection: indexPath.section) - 1 {
-//            DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
-//                self.upcomingDateScheduleViewModel.setUpcomingScheduleLoading()
-//            }
-//        }
         return cell
     }
     

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/DateSchedule/ViewModel/DateDetailViewModel.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/DateSchedule/ViewModel/DateDetailViewModel.swift
@@ -14,12 +14,8 @@ import KakaoSDKAuth
 import KakaoSDKUser
 
 class DateDetailViewModel: Serviceable {
-
+    
     var onReissueSuccess: ObservablePattern<Bool> = ObservablePattern(nil)
-
-    init(dateID: Int) {
-        getDateDetailData(dateID: dateID)
-    }
     
     var emptyDateDetailData = DateDetailModel(dateID: 0, title: "", startAt: "", city: "", tags: [], date: "", places: [], dDay: 0)
     
@@ -34,15 +30,35 @@ class DateDetailViewModel: Serviceable {
     var isSuccessDeleteDateScheduleData: ObservablePattern<Bool> = ObservablePattern(nil)
     
     var onDateDetailLoading: ObservablePattern<Bool> = ObservablePattern(true)
-
+    
     var onFailNetwork: ObservablePattern<Bool> = ObservablePattern(false)
+    
+    var kakaoShareInfo: [String: String] = [:]
+    
+    var kakaoPlacesInfo : [KakaoPlaceModel] = []
+    
+    var maxPlaces : Int {
+        return min(dateDetailData.value?.places.count ?? 0, 5)
+    }
+    
+    var isMoreThanFiveSchedule : Bool {
+        return (dateDetailData.value?.places.count ?? 0 >= 5)
+    }
+    
+//    init(dateID: Int) {
+//        getDateDetailData(dateID: dateID)
+//    }
+    
+}
+
+extension DateDetailViewModel {
     
     func getDateDetailData(dateID: Int) {
         self.isSuccessGetDateDetailData.value = false
         self.onFailNetwork.value = false
         self.setDateDetailLoading()
         
-        dateScheduleService.getDateDetail(dateID: dateID) { response in
+        NetworkService.shared.dateScheduleService.getDateDetail(dateID: dateID) { response in
             switch response {
             case .success(let data):
                 let tagsInfo: [TagsModel] = data.tags.map { tag in
@@ -69,10 +85,9 @@ class DateDetailViewModel: Serviceable {
      }
     
     func deleteDateSchdeuleData(dateID: Int) {
-        dateScheduleService.deleteDateSchedule(dateID: dateID) { response in
+        NetworkService.shared.dateScheduleService.deleteDateSchedule(dateID: dateID) { response in
             switch response {
             case .success(let data):
-                print(data)
                 self.isSuccessDeleteDateScheduleData.value = true
                 print("success", self.isSuccessDeleteDateScheduleData.value)
             case .reIssueJWT:
@@ -81,19 +96,6 @@ class DateDetailViewModel: Serviceable {
                 self.isSuccessDeleteDateScheduleData.value = false
             }
         }
-    }
-
-    
-    var kakaoShareInfo: [String: String] = [:]
-    
-    var kakaoPlacesInfo : [KakaoPlaceModel] = []
-    
-    var maxPlaces : Int {
-        return min(dateDetailData.value?.places.count ?? 0, 5)
-    }
-    
-    var isMoreThanFiveSchedule : Bool {
-        return (dateDetailData.value?.places.count ?? 0 >= 5)
     }
     
     func setTempArgs() {

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/DateSchedule/ViewModel/DateDetailViewModel.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/DateSchedule/ViewModel/DateDetailViewModel.swift
@@ -51,7 +51,6 @@ extension DateDetailViewModel {
     func getDateDetailData(dateID: Int) {
         self.isSuccessGetDateDetailData.value = false
         self.onFailNetwork.value = false
-        self.setDateDetailLoading()
         
         NetworkService.shared.dateScheduleService.getDateDetail(dateID: dateID) { response in
             switch response {
@@ -76,7 +75,7 @@ extension DateDetailViewModel {
     
     func setDateDetailLoading() {
          guard let isSuccessGetDateDetailData = self.isSuccessGetDateDetailData.value else { return }
-         self.onDateDetailLoading.value = isSuccessGetDateDetailData ? false : true
+         self.onDateDetailLoading.value = !isSuccessGetDateDetailData
      }
     
     func deleteDateSchdeuleData(dateID: Int) {

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/DateSchedule/ViewModel/DateDetailViewModel.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/DateSchedule/ViewModel/DateDetailViewModel.swift
@@ -43,12 +43,7 @@ class DateDetailViewModel: Serviceable {
     
     var isMoreThanFiveSchedule : Bool {
         return (dateDetailData.value?.places.count ?? 0 >= 5)
-    }
-    
-//    init(dateID: Int) {
-//        getDateDetailData(dateID: dateID)
-//    }
-    
+    }    
 }
 
 extension DateDetailViewModel {

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/DateSchedule/ViewModel/DateScheduleViewModel.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/DateSchedule/ViewModel/DateScheduleViewModel.swift
@@ -10,9 +10,7 @@ import Foundation
 class DateScheduleViewModel: Serviceable {
     
     var onReissueSuccess: ObservablePattern<Bool> = ObservablePattern(nil)
-    
-    let dateScheduleService = DateScheduleService()
-    
+        
     var upcomingDateScheduleData: ObservablePattern<[DateCardModel]> = ObservablePattern(nil)
     
     var pastDateScheduleData: ObservablePattern<[DateCardModel]> = ObservablePattern([])
@@ -41,7 +39,7 @@ class DateScheduleViewModel: Serviceable {
         self.onPastScheduleFailNetwork.value = false
         self.setPastScheduleLoading()
         
-        dateScheduleService.getDateSchdeule(time: "PAST") { response in
+        NetworkService.shared.dateScheduleService.getDateSchdeule(time: "PAST") { response in
             switch response {
             case .success(let data):
                 let dateScheduleInfo = data.dates.map { date in
@@ -71,9 +69,8 @@ class DateScheduleViewModel: Serviceable {
     func getUpcomingDateScheduleData() {
         self.isSuccessGetUpcomingDateScheduleData.value = false
         self.onUpcomingScheduleFailNetwork.value = false
-        self.setUpcomingScheduleLoading()
         
-        dateScheduleService.getDateSchdeule(time: "FUTURE") { response in
+        NetworkService.shared.dateScheduleService.getDateSchdeule(time: "FUTURE") { response in
             switch response {
             case .success(let data):
                 let dateScheduleInfo = data.dates.map { date in
@@ -97,8 +94,9 @@ class DateScheduleViewModel: Serviceable {
     }
     
     func setUpcomingScheduleLoading() {
-         guard let isSuccessGetUpcomingDateScheduleData = self.isSuccessGetUpcomingDateScheduleData.value else { return }
-         self.onUpcomingScheduleLoading.value = isSuccessGetUpcomingDateScheduleData ? false : true
+        guard let isSuccessGetUpcomingDateScheduleData = self.isSuccessGetUpcomingDateScheduleData.value
+        else { return }
+        self.onUpcomingScheduleLoading.value = isSuccessGetUpcomingDateScheduleData ? false : true
      }
 
 

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/DateSchedule/ViewModel/DateScheduleViewModel.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/DateSchedule/ViewModel/DateScheduleViewModel.swift
@@ -37,7 +37,6 @@ class DateScheduleViewModel: Serviceable {
     func getPastDateScheduleData() {
         self.isSuccessGetPastDateScheduleData.value = false
         self.onPastScheduleFailNetwork.value = false
-        self.setPastScheduleLoading()
         
         NetworkService.shared.dateScheduleService.getDateSchdeule(time: "PAST") { response in
             switch response {
@@ -62,8 +61,9 @@ class DateScheduleViewModel: Serviceable {
     }
     
     func setPastScheduleLoading() {
-         guard let isSuccessGetPastDateScheduleData = self.isSuccessGetPastDateScheduleData.value else { return }
-         self.onPastScheduleLoading.value = isSuccessGetPastDateScheduleData ? false : true
+        guard let isSuccessGetPastDateScheduleData = self.isSuccessGetPastDateScheduleData.value
+        else { return }
+        self.onPastScheduleLoading.value = !isSuccessGetPastDateScheduleData
      }
     
     func getUpcomingDateScheduleData() {

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/Main/Views/DateTicketView.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/Main/Views/DateTicketView.swift
@@ -67,8 +67,9 @@ final class DateTicketView: BaseView {
         }
         
         moveButton.snp.makeConstraints {
-            $0.trailing.equalToSuperview().inset(27)
+            $0.trailing.equalToSuperview().inset(12)
             $0.centerY.equalToSuperview()
+            $0.size.equalTo(44)
         }
     }
 

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/Main/Views/EmptyTicketView.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/Main/Views/EmptyTicketView.swift
@@ -45,8 +45,9 @@ final class EmptyTicketView: BaseView {
         }
         
         moveButton.snp.makeConstraints {
-            $0.trailing.equalToSuperview().inset(27)
+            $0.trailing.equalToSuperview().inset(12)
             $0.centerY.equalToSuperview()
+            $0.size.equalTo(44)
         }
     }
 

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/Main/Views/MainViewController.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/Main/Views/MainViewController.swift
@@ -237,8 +237,7 @@ extension MainViewController {
     @objc
     func pushToDateDetailVC(_ sender: UIButton) {
         let dateID = sender.tag
-        let upcomingDateDetailVC = UpcomingDateDetailViewController()
-        upcomingDateDetailVC.upcomingDateDetailViewModel = DateDetailViewModel(dateID: dateID)
+        let upcomingDateDetailVC = UpcomingDateDetailViewController(dateID: dateID, upcomingDateDetailViewModel: DateDetailViewModel())
         upcomingDateDetailVC.setColor(index: dateID)
         self.navigationController?.pushViewController(upcomingDateDetailVC, animated: true)
     }


### PR DESCRIPTION
# 🔥*Pull requests*

## ⛳ **작업한 브랜치**
- fix/#178

## 👷 **작업한 내용**
<!-- 작업한 내용을 적어주세요. -->
- [x] 데이트 일정 로딩뷰 이슈 해결
- [x] 데이트 일정 상세 로딩뷰 이슈 해결 
- [x] 지난 데이트 로딩뷰 이슈 해결
- [x] 지난 데이트 상세 로딩뷰 이슈 해결
- [x] 데이트 일정 서버 통신 시점 이슈 해결
- [x] 데이트 일정 상세 등록/삭제 후 반영 이슈 해결
- [x] 지나간 데이트 일정 서버 통신 시점 이슈 해결
- [x] 지나간 데이트 일정 등록/삭제 후 반영 이슈 해결

## 🚨 참고 사항
<!-- 참고할 사항이 있다면 적어주세요. -->
### 1️⃣ 서버 통신 시점
기존에 수민이 코드에서 viewWillAppear, viewDidLoad, viewDidAppear에서 서버 통신을 중복 호출 하고 있었는데요, 중복 호출을 모두 없애고 viewWillAppear에서 한번만 호출하도록 수정했습니다.

### 2️⃣ 로딩뷰 이슈 해결
뷰가 나타나기 전 로딩뷰를 띄운 후 서버 통신을 하고
만약 성공적으로 데이터를 불러오게 되면 reload를 하고, 0.1초간 지연 후에 로딩뷰를 업데이트 하는 방식으로 로딩뷰를 구현했습니다
``` Swift
// viewWillAppear
self.upcomingDateDetailViewModel.setDateDetailLoading()
self.upcomingDateDetailViewModel.getDateDetailData(dateID: self.dateID)


// bindViewModel
self.upcomingDateDetailViewModel.isSuccessGetDateDetailData.bind { [weak self] isSuccess in
    guard let isSuccess, 
            let data = self?.upcomingDateDetailViewModel.dateDetailData.value
    else { return }
    if isSuccess {
        self?.upcomingDateDetailContentView.dataBind(data)
        self?.upcomingDateDetailContentView.dateTimeLineCollectionView.reloadData()
        DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
            self?.upcomingDateDetailViewModel.setDateDetailLoading()
        }
    }
}
```

### 3️⃣ 삭제 로직 수정
기존에는 삭제 서버 통신 후 바로 pop 하는 로직으로 되어 있었는데 이렇게 되면 서버 통신 성공 여부와 관계 없이 무조건 pop하게 되므로 로직을 수정했습니다.
서버 통신을 성공했다면 옵저버 프로퍼티를 통해 성공한 경우만 pop 하도록 수정했습니다
``` Swift
//ViewModel
func deleteDateSchdeuleData(dateID: Int) {
    NetworkService.shared.dateScheduleService.deleteDateSchedule(dateID: dateID) { response in
        switch response {
        case .success(let data):
            **self.isSuccessDeleteDateScheduleData.value = true**
        case .reIssueJWT:
            self.onReissueSuccess.value = self.patchReissue()
        default:
            self.isSuccessDeleteDateScheduleData.value = false
        }
    }
}

// bindViewModel
self.upcomingDateDetailViewModel.isSuccessDeleteDateScheduleData.bind { [weak self] isSuccess in
    guard let isSuccess else { return }
    if isSuccess {
        self?.navigationController?.popViewController(animated: true)
    }
}
```

## 📸 스크린샷
|기능|스크린샷|기능|스크린샷|
|:--:|:--:|:--:|:--:|
|로딩뷰|![Simulator Screen Recording - iPhone 15 Pro - 2024-08-27 at 23 09 14](https://github.com/user-attachments/assets/a6eb0bd0-0576-418d-b83c-d8fc85e6f90e)|등록/삭제|![Simulator Screen Recording - iPhone 15 Pro - 2024-08-27 at 23 10 21](https://github.com/user-attachments/assets/238d4f3a-2f89-42c7-88f1-39a3bde2d366)|


## 📟 관련 이슈
- Resolved: #178 
