### PR TITLE
[REFACTOR] 프로필 등록 & 수정 리팩토링 (#197)

### DIFF
--- a/DATEROAD-iOS/DATEROAD-iOS.xcodeproj/project.pbxproj
+++ b/DATEROAD-iOS/DATEROAD-iOS.xcodeproj/project.pbxproj
@@ -266,6 +266,7 @@
 		CAC80FF72C3FCAE500658EA6 /* BannerIndexFooterView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CAC80FF62C3FCAE500658EA6 /* BannerIndexFooterView.swift */; };
 		CAE8760A2C6F232900D64B34 /* DRLoadingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CAE876092C6F232900D64B34 /* DRLoadingView.swift */; };
 		CAE8760C2C6F68A000D64B34 /* DRErrorViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = CAE8760B2C6F68A000D64B34 /* DRErrorViewController.swift */; };
+		CAE890A32C86C94C00834A9E /* EditProfileViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = CAE890A22C86C94C00834A9E /* EditProfileViewController.swift */; };
 		CAE8C1992C45920E00F153B3 /* GetMainUserProfileResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = CAE8C1982C45920E00F153B3 /* GetMainUserProfileResponse.swift */; };
 /* End PBXBuildFile section */
 
@@ -520,6 +521,7 @@
 		CAC80FF62C3FCAE500658EA6 /* BannerIndexFooterView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BannerIndexFooterView.swift; sourceTree = "<group>"; };
 		CAE876092C6F232900D64B34 /* DRLoadingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DRLoadingView.swift; sourceTree = "<group>"; };
 		CAE8760B2C6F68A000D64B34 /* DRErrorViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DRErrorViewController.swift; sourceTree = "<group>"; };
+		CAE890A22C86C94C00834A9E /* EditProfileViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditProfileViewController.swift; sourceTree = "<group>"; };
 		CAE8C1932C4581B500F153B3 /* MainTargetType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainTargetType.swift; sourceTree = "<group>"; };
 		CAE8C1952C4590B400F153B3 /* MainService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainService.swift; sourceTree = "<group>"; };
 		CAE8C1982C45920E00F153B3 /* GetMainUserProfileResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GetMainUserProfileResponse.swift; sourceTree = "<group>"; };
@@ -1457,6 +1459,7 @@
 				CAA30ADD2C3718C500835DE3 /* ProfileViewController.swift */,
 				CAA30ADF2C3733DF00835DE3 /* ProfileView.swift */,
 				CAC80FD12C3D7E5100658EA6 /* ProfileImageSettingView.swift */,
+				CAE890A22C86C94C00834A9E /* EditProfileViewController.swift */,
 			);
 			path = Views;
 			sourceTree = "<group>";
@@ -1871,6 +1874,7 @@
 				745547712C3D12CD00B526F3 /* PastDateDetailViewController.swift in Sources */,
 				CA4EF3E22C3537F3003B02B6 /* OnboardingModel.swift in Sources */,
 				CA4EF3D52C34763B003B02B6 /* OnboardingViewController.swift in Sources */,
+				CAE890A32C86C94C00834A9E /* EditProfileViewController.swift in Sources */,
 				CABDCE732C47FA5C00631FB3 /* AuthService.swift in Sources */,
 				9E590B4C2C3D276600039690 /* AddSecondView.swift in Sources */,
 				CAA30ADE2C3718C500835DE3 /* ProfileViewController.swift in Sources */,

--- a/DATEROAD-iOS/DATEROAD-iOS/Global/Literals/StringLiterals.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Global/Literals/StringLiterals.swift
@@ -72,6 +72,7 @@ enum StringLiterals {
     enum Profile {
         static let myProfile = "내 프로필"
         static let nickname = "닉네임"
+        static let nicknameInfo = "(한글, 영문, 숫자만 가능)"
         static let nicknamePlaceholder = "닉네임을 입력하세요."
         static let doubleCheck = "중복확인"
         static let disabledNickname = "이미 사용 중인 닉네임이에요"

--- a/DATEROAD-iOS/DATEROAD-iOS/Network/User/DTO/PatchEditProfileRequest.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Network/User/DTO/PatchEditProfileRequest.swift
@@ -11,4 +11,5 @@ struct PatchEditProfileRequest {
     let name: String
     let tags: [String]
     let image: UIImage?
+    let isDefaultImage: Bool
 }

--- a/DATEROAD-iOS/DATEROAD-iOS/Network/User/UserTargetType.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Network/User/UserTargetType.swift
@@ -55,6 +55,15 @@ extension UserTargetType: BaseTargetType {
                 multipartData.append(MultipartFormData(provider: .data(tagData), name: "tags"))
             }
             
+            let boolString = requestBody.isDefaultImage ? "true" : "false"
+
+            // 문자열을 Data로 변환
+            let boolData = boolString.data(using: .utf8)!
+
+            // MultipartFormData 생성
+            let boolPart = MultipartFormData(provider: .data(boolData), name: "isDefaultImage")
+            multipartData.append(boolPart)
+            
             return .uploadMultipart(multipartData)
         }
     }

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/MyPage/Views/MyPageViewController.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/MyPage/Views/MyPageViewController.swift
@@ -179,8 +179,7 @@ private extension MyPageViewController {
             let tags = userInfoData.tagList
             
             let profile = ProfileModel(profileImage: self.myPageView.userInfoView.profileImageView.image, nickname: nickname, tags: tags)
-            let profileVC = ProfileViewController(profileViewModel: ProfileViewModel(profileData: profile),
-                                                  editType: EditType.edit)
+            let profileVC = EditProfileViewController(profileViewModel: ProfileViewModel(profileData: profile))
             
             self.navigationController?.pushViewController(profileVC, animated: false)
         }

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/Onboarding/Views/OnboardingViewController.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/Onboarding/Views/OnboardingViewController.swift
@@ -77,8 +77,7 @@ private extension OnboardingViewController {
         
         self.onboardingViewModel.goToNextVC = { [weak self] isLastIndex in
             if isLastIndex {
-                let createProfileVC = ProfileViewController(profileViewModel: ProfileViewModel(profileData: ProfileModel(profileImage: nil, nickname: "", tags: [])),
-                                                            editType: EditType.add)
+                let createProfileVC = ProfileViewController(profileViewModel: ProfileViewModel(profileData: ProfileModel(profileImage: nil, nickname: "", tags: [])))
                 self?.navigationController?.pushViewController(createProfileVC, animated: true)
             } else {
                 let currentOffset = self?.onboardingView.onboardingCollectionView.contentOffset ?? CGPoint.zero

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/Profile/ViewModels/ProfileViewModel.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/Profile/ViewModels/ProfileViewModel.swift
@@ -107,7 +107,7 @@ extension ProfileViewModel {
               let isValidTag = isValidTag.value,
               let is5CntVaild = is5orLess.value else { return }
 
-        self.isValidRegistration.value = (isValidNickname && isValidTag && is5CntVaild) ? true : false
+        self.isValidRegistration.value = (isValidNickname && isValidTag && is5CntVaild)
         
         print("isValidNickname \(isValidNickname)  isValidTag \(isValidTag)  is5CntValid \(is5CntVaild)")
     }

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/Profile/ViewModels/ProfileViewModel.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/Profile/ViewModels/ProfileViewModel.swift
@@ -53,6 +53,8 @@ final class ProfileViewModel: Serviceable {
     
 }
 
+// 프로필 등록 & 수정 공통 메소드
+
 extension ProfileViewModel {
     
     func fetchTagData() {
@@ -110,10 +112,6 @@ extension ProfileViewModel {
         print("isValidNickname \(isValidNickname)  isValidTag \(isValidTag)  is5CntValid \(is5CntVaild)")
     }
     
-    func compareExistingNickname() {
-        isExistedNickname.value = existingNickname.value == nickname.value ? true : false
-    }
-    
     func postSignUp(image: UIImage?) {
         let socialType = UserDefaults.standard.bool(forKey: "SocialType")
         
@@ -164,6 +162,12 @@ extension ProfileViewModel {
         }
     }
     
+}
+
+// 프로필 수정 관련 메소드
+
+extension ProfileViewModel {
+    
     func patchEditProfile() {
         guard let name = self.nickname.value else { return }
         let requestBody = PatchEditProfileRequest(name: name, tags: self.selectedTagData, image: self.profileImage.value)
@@ -180,4 +184,9 @@ extension ProfileViewModel {
             }
         }
     }
+    
+    func compareExistingNickname() {
+        isExistedNickname.value = existingNickname.value == nickname.value ? true : false
+    }
+    
 }

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/Profile/ViewModels/ProfileViewModel.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/Profile/ViewModels/ProfileViewModel.swift
@@ -15,6 +15,8 @@ final class ProfileViewModel: Serviceable {
     
     var profileData: ObservablePattern<ProfileModel>
     
+    var isDefaultImage: Bool = true
+    
     var profileImage: ObservablePattern<UIImage>
     
     var existingNickname: ObservablePattern<String>
@@ -170,7 +172,10 @@ extension ProfileViewModel {
     
     func patchEditProfile() {
         guard let name = self.nickname.value else { return }
-        let requestBody = PatchEditProfileRequest(name: name, tags: self.selectedTagData, image: self.profileImage.value)
+        let requestBody = PatchEditProfileRequest(name: name, 
+                                                  tags: self.selectedTagData,
+                                                  image: self.profileImage.value,
+                                                  isDefaultImage: self.isDefaultImage)
         
         NetworkService.shared.userService.patchEditProfile(requestBody: requestBody) { response in
             switch response {

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/Profile/ViewModels/ProfileViewModel.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/Profile/ViewModels/ProfileViewModel.swift
@@ -15,10 +15,10 @@ final class ProfileViewModel: Serviceable {
     
     var profileData: ObservablePattern<ProfileModel>
     
-    var isDefaultImage: Bool = true
+    var isDefaultImage: Bool = false
     
     var profileImage: ObservablePattern<UIImage>
-    
+
     var existingNickname: ObservablePattern<String>
     
     var isExistedNickname: ObservablePattern<Bool> = ObservablePattern(nil)
@@ -172,7 +172,8 @@ extension ProfileViewModel {
     
     func patchEditProfile() {
         guard let name = self.nickname.value else { return }
-        let requestBody = PatchEditProfileRequest(name: name, 
+        checkDefaultImage()
+        let requestBody = PatchEditProfileRequest(name: name,
                                                   tags: self.selectedTagData,
                                                   image: self.profileImage.value,
                                                   isDefaultImage: self.isDefaultImage)
@@ -191,7 +192,13 @@ extension ProfileViewModel {
     }
     
     func compareExistingNickname() {
-        isExistedNickname.value = existingNickname.value == nickname.value ? true : false
+        isExistedNickname.value = existingNickname.value == nickname.value
     }
-    
+
+    func checkDefaultImage() {
+        if self.profileImage.value == UIImage(resource: .emptyProfileImg) {
+            self.profileImage.value = nil
+            self.isDefaultImage = false
+        }
+    }
 }

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/Profile/Views/EditProfileViewController.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/Profile/Views/EditProfileViewController.swift
@@ -233,16 +233,6 @@ private extension EditProfileViewController {
             self?.profileView.updateDoubleCheckButton(isValid: !isExisted)
         }
         
-        self.profileViewModel.onSuccessRegister = { [weak self] isSuccess in
-            if isSuccess {
-                let mainVC = TabBarController()
-                self?.navigationController?.pushViewController(mainVC, animated: false)
-            } else {
-                let loginVC = LoginViewController()
-                self?.navigationController?.pushViewController(loginVC, animated: false)
-            }
-        }
-        
         self.profileViewModel.onSuccessEdit = { [weak self] isSuccess in
             if isSuccess {
                 self?.navigationController?.popViewController(animated: false)

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/Profile/Views/EditProfileViewController.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/Profile/Views/EditProfileViewController.swift
@@ -226,6 +226,7 @@ private extension EditProfileViewController {
                 self?.navigationController?.popViewController(animated: false)
             } else {
                 // TODO: - 토스트 메세지 추가
+                self?.profileView.registerButton.isEnabled = true
                 print("fail to edit profile")
             }
         }
@@ -295,6 +296,7 @@ private extension EditProfileViewController {
     
     @objc
     func registerProfile() {
+        self.profileView.registerButton.isEnabled = false
         self.profileViewModel.patchEditProfile()
     }
     

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/Profile/Views/ProfileView.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/Profile/Views/ProfileView.swift
@@ -17,6 +17,8 @@ final class ProfileView: BaseView {
     
     private let nicknameLabel: UILabel = UILabel()
     
+    private let nicknameInfoLabel: UILabel = UILabel()
+    
     let nicknameTextfield: UITextField = UITextField()
     
     private let rightViewBox: UIView = UIView()
@@ -59,6 +61,7 @@ final class ProfileView: BaseView {
         self.addSubviews(profileImageView,
                          editImageButton,
                          nicknameLabel,
+                         nicknameInfoLabel,
                          nicknameTextfield,
                          nicknameErrMessageLabel,
                          countLabel,
@@ -83,7 +86,12 @@ final class ProfileView: BaseView {
         
         nicknameLabel.snp.makeConstraints {
             $0.top.equalTo(profileImageView.snp.bottom).offset(43)
-            $0.horizontalEdges.equalToSuperview()
+            $0.leading.equalToSuperview()
+        }
+        
+        nicknameInfoLabel.snp.makeConstraints {
+            $0.centerY.equalTo(nicknameLabel)
+            $0.leading.equalTo(nicknameLabel.snp.trailing).offset(5)
         }
         
         nicknameTextfield.snp.makeConstraints {
@@ -140,12 +148,15 @@ final class ProfileView: BaseView {
             $0.isUserInteractionEnabled = true
         }
         
-        nicknameLabel.do {
-            $0.setLabel(text: StringLiterals.Profile.nickname,
-                        alignment: .left,
-                        textColor: UIColor(resource: .drBlack),
-                        font: UIFont.suit(.body_bold_15))
-        }
+        nicknameLabel.setLabel(text: StringLiterals.Profile.nickname,
+                               alignment: .left,
+                               textColor: UIColor(resource: .drBlack),
+                               font: UIFont.suit(.body_bold_15))
+        
+        nicknameInfoLabel.setLabel(text: StringLiterals.Profile.nicknameInfo,
+                               alignment: .left,
+                               textColor: UIColor(resource: .gray300),
+                               font: UIFont.suit(.body_med_13))
         
         nicknameTextfield.do {
             rightViewBox.addSubview(doubleCheckButton)

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/Profile/Views/ProfileView.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/Profile/Views/ProfileView.swift
@@ -253,7 +253,8 @@ extension ProfileView {
     }
     
     func updateDoubleCheckButton(isValid: Bool) {
-       isValid ? doubleCheckButton.setButtonStatus(buttonType: enabledButtonType)
+       isValid 
+        ? doubleCheckButton.setButtonStatus(buttonType: enabledButtonType)
         : doubleCheckButton.setButtonStatus(buttonType: disabledButtonType)
         doubleCheckButton.titleLabel?.font = UIFont.suit(.body_med_13)
         doubleCheckButton.layer.cornerRadius = 10

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/Profile/Views/ProfileViewController.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/Profile/Views/ProfileViewController.swift
@@ -227,8 +227,6 @@ private extension ProfileViewController {
             }
         }
         self.profileViewModel.checkValidRegistration()
-
-//        self.profileViewModel.checkValidNickname()
     }
     
     @objc
@@ -252,6 +250,7 @@ private extension ProfileViewController {
     
     @objc
     func registerProfile() {
+        self.profileView.registerButton.isEnabled = false
         self.profileViewModel.postSignUp(image: self.profileView.profileImageView.image)
     }
     

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/Profile/Views/ProfileViewController.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/Profile/Views/ProfileViewController.swift
@@ -41,6 +41,7 @@ final class ProfileViewController: BaseNavBarViewController {
         super.viewDidLoad()
         
         setTitleLabelStyle(title: StringLiterals.Profile.myProfile, alignment: .center)
+        self.profileView.registerButton.setTitle(StringLiterals.Profile.registerProfile, for: .normal)
         registerCell()
         setDelegate()
         setAddGesture()


### PR DESCRIPTION
# 🔥*Pull requests*

## ⛳ **작업한 브랜치**
- refactor/#197

## 👷 **작업한 내용**
<!-- 작업한 내용을 적어주세요. -->
- [x] 프로필 등록/수정 뷰컨 분리
- [x] 닉네임 추가된 문구 반영
- [x] 프로필 등록 로직 리팩
- [x] 프로필 수정 추가된 필드 적용
- [x] 프로필 수정 로직 리팩
- [x] 프로필 등록 버튼 막기

## 🚨 참고 사항
<!-- 참고할 사항이 있다면 적어주세요. -->
### 1️⃣ 프로필 등록 / 수정 분리
기존에는 하나의 뷰컨에서 등록과 수정을 분기처리해주었는데요, 필드값이 추가되고 로직 또한 변경되는 부분이 생겨서 아예 분리해버렸습니다.

### 2️⃣ 버튼 블락 처리
등록 버튼을 누른 후 메인 화면에 진입하기 전까지 계속 버튼을 누르게 되면 여러 번 회원 가입이 되는 이슈가 있어서 한 번 누르면 버튼을 막아두었습니다. 
**‼️ 여러분들도 이런 부분들을 고려해서 중복 호출 되지 않도록 버튼 막아주세요!**

## 📸 스크린샷
없습니다

## 📟 관련 이슈
- Resolved: #197 
