### PR TITLE
[FIX] Auth 관련 QA 적용 (#201)

### DIFF
--- a/DATEROAD-iOS/DATEROAD-iOS/Global/Literals/StringLiterals.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Global/Literals/StringLiterals.swift
@@ -207,6 +207,10 @@ enum StringLiterals {
         static let deleteDateSchedule = "데이트 일정을 삭제하시겠어요?"
         static let deletePastDateSchedule = "지난 데이트를 삭제하시겠어요?"
         static let noMercy = "삭제된 일정은 복구하실 수 없어요"
+        static let failToLogout = "로그아웃 실패"
+        static let failToWithdrawal = "회원탈퇴 실패"
+        static let failToLogin = "로그인 실패"
+        static let confirm = "확인"
     }
     
     enum Course {

--- a/DATEROAD-iOS/DATEROAD-iOS/Global/Protocols/Serviceable.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Global/Protocols/Serviceable.swift
@@ -8,29 +8,26 @@
 import Foundation
 
 protocol Serviceable: AnyObject {
-    func patchReissue() -> Bool
+    func patchReissue(completion: @escaping (Bool) -> Void)
 }
 
 extension Serviceable {
-    func patchReissue() -> Bool {
-        var isSuccess: Bool = false
-
+    func patchReissue(completion: @escaping (Bool) -> Void) {
         NetworkService.shared.authService.patchReissue() { response in
             switch response {
             case .success(let data):
                 UserDefaults.standard.setValue(data.accessToken, forKey: StringLiterals.Network.accessToken)
                 UserDefaults.standard.setValue(data.refreshToken, forKey: StringLiterals.Network.refreshToken)
                 UserDefaults.standard.setValue(data.userID, forKey: StringLiterals.Network.userID)
-                isSuccess = true
+                completion(true)
 
             default:
                 print("Failed to fetch patch reissue")
                 for key in UserDefaults.standard.dictionaryRepresentation().keys {
                     UserDefaults.standard.removeObject(forKey: key.description)
                 }
-                isSuccess = false
+                completion(false)
             }
         }
-        return isSuccess
     }
 }

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/AddCourse/ViewModels/AddCourseViewModel.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/AddCourse/ViewModels/AddCourseViewModel.swift
@@ -342,7 +342,9 @@ extension AddCourseViewModel {
          case .serverErr:
             self.onFailNetwork.value = true
          case .reIssueJWT:
-            self.onReissueSuccess.value = self.patchReissue()
+             self.patchReissue { isSuccess in
+                 self.onReissueSuccess.value = isSuccess
+             }
          default:
             print("Failed to fetch user profile")
             return

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/AddSchedule/ViewModels/AddScheduleViewModel.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/AddSchedule/ViewModels/AddScheduleViewModel.swift
@@ -321,7 +321,9 @@ extension AddScheduleViewModel {
             case .serverErr:
                self.onFailNetwork.value = true
             case .reIssueJWT:
-               self.onReissueSuccess.value = self.patchReissue()
+                self.patchReissue { isSuccess in
+                    self.onReissueSuccess.value = isSuccess
+                }
             default:
                print("Failed to fetch user profile")
                return

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/Course/ViewModels/CourseViewModel.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/Course/ViewModels/CourseViewModel.swift
@@ -105,7 +105,9 @@ extension CourseViewModel {
                 self.isSuccessGetData.value = true
 
             case .reIssueJWT:
-                self.onReissueSuccess.value = self.patchReissue()
+                self.patchReissue { isSuccess in
+                    self.onReissueSuccess.value = isSuccess
+                }
             case .serverErr:
                 self.onFailNetwork.value = true
             default:

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/Course/Views/CourseViewController.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/Course/Views/CourseViewController.swift
@@ -44,7 +44,6 @@ final class CourseViewController: BaseViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         
-        getCourse()
         registerCell()
         setDelegate()
         bindViewModel()

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/CourseDetail/ViewModels/CourseDetailViewModel.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/CourseDetail/ViewModels/CourseDetailViewModel.swift
@@ -170,8 +170,9 @@ extension CourseDetailViewModel {
                 self.isSuccessGetData.value = true
                 
             case .reIssueJWT:
-                self.onReissueSuccess.value = self.patchReissue()
-                
+                self.patchReissue { isSuccess in
+                    self.onReissueSuccess.value = isSuccess
+                }
             default:
                 self.isSuccessGetData.value = false
                 print("Failed to fetch course data")
@@ -187,7 +188,9 @@ extension CourseDetailViewModel {
                 self.isAccess.value = true
                 print("🥽Successfully used points:", response)
             case .reIssueJWT:
-                self.onReissueSuccess.value = self.patchReissue()
+                self.patchReissue { isSuccess in
+                    self.onReissueSuccess.value = isSuccess
+                }
             default:
                 self.isSuccessGetData.value = false
                 print("Failed to post course data")
@@ -242,7 +245,9 @@ extension CourseDetailViewModel {
                 
                 self.isSuccessGetBannerData.value = true
             case .reIssueJWT:
-                self.onReissueSuccess.value = self.patchReissue()
+                self.patchReissue { isSuccess in
+                    self.onReissueSuccess.value = isSuccess
+                }
             case .serverErr:
                 self.onFailNetwork.value = true
             default:

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/DateSchedule/ViewModel/DateDetailViewModel.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/DateSchedule/ViewModel/DateDetailViewModel.swift
@@ -66,7 +66,9 @@ extension DateDetailViewModel {
             case .serverErr:
                 self.onFailNetwork.value = true
             case .reIssueJWT:
-                self.onReissueSuccess.value = self.patchReissue()
+                self.patchReissue { isSuccess in
+                    self.onReissueSuccess.value = isSuccess
+                }
             default:
                 self.isSuccessGetDateDetailData.value = false
             }
@@ -85,7 +87,9 @@ extension DateDetailViewModel {
                 self.isSuccessDeleteDateScheduleData.value = true
                 print("success", self.isSuccessDeleteDateScheduleData.value)
             case .reIssueJWT:
-                self.onReissueSuccess.value = self.patchReissue()
+                self.patchReissue { isSuccess in
+                    self.onReissueSuccess.value = isSuccess
+                }
             default:
                 self.isSuccessDeleteDateScheduleData.value = false
             }

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/DateSchedule/ViewModel/DateScheduleViewModel.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/DateSchedule/ViewModel/DateScheduleViewModel.swift
@@ -53,7 +53,9 @@ class DateScheduleViewModel: Serviceable {
             case .serverErr:
                 self.onPastScheduleFailNetwork.value = true
             case .reIssueJWT:
-                self.onReissueSuccess.value = self.patchReissue()
+                self.patchReissue { isSuccess in
+                    self.onReissueSuccess.value = isSuccess
+                }
             default:
                 self.isSuccessGetPastDateScheduleData.value = false
             }
@@ -85,7 +87,9 @@ class DateScheduleViewModel: Serviceable {
             case .serverErr:
                 self.onUpcomingScheduleFailNetwork.value = true
             case .reIssueJWT:
-                self.onReissueSuccess.value = self.patchReissue()
+                self.patchReissue { isSuccess in
+                    self.onReissueSuccess.value = isSuccess
+                }
             default:
                 self.isSuccessGetUpcomingDateScheduleData.value = false
                 print("false?")

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/Login/ViewModels/LoginViewModel.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/Login/ViewModels/LoginViewModel.swift
@@ -129,7 +129,9 @@ extension LoginViewModel {
             case .requestErr:
                 self.isSignIn.value = false
             case .reIssueJWT:
-                self.onReissueSuccess.value = self.patchReissue()
+                self.patchReissue { isSuccess in
+                    self.onReissueSuccess.value = isSuccess
+                }
             default:
                 print("Failed to fetch post signin")
                 self.onLoginSuccess.value = false

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/Login/ViewModels/LoginViewModel.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/Login/ViewModels/LoginViewModel.swift
@@ -78,16 +78,16 @@ extension LoginViewModel {
     func loginWithApple(userInfo: ASAuthorizationAppleIDCredential) {
         guard let userIdentifier = userInfo.identityToken,
               let code = userInfo.authorizationCode,
-              let token = String(data: userIdentifier, encoding: .utf8)
+              let token = String(data: userIdentifier, encoding: .utf8),
+              let authCode = String(data: code, encoding: .utf8)
         else { return }
         
+        UserDefaults.standard.setValue(authCode, forKey: "authCode")
         self.isKaKaoLogin.value = false
         self.socialType.value = .APPLE
 
         self.setToken(token: token)
         self.setUserInfo(userInfo: userInfo)
-        let authCode = String(data: code, encoding: .utf8)
-        UserDefaults.standard.setValue(authCode, forKey: "authCode")
 
         print("identifier token: \(String(describing: token))")
         print("authorization code: \(String(describing: authCode))")
@@ -120,11 +120,11 @@ extension LoginViewModel {
         NetworkService.shared.authService.postSignIn(requestBody: requestBody) { response in
             switch response {
             case .success(let data):
-                self.onLoginSuccess.value = true
                 UserDefaults.standard.setValue(data.userID, forKey: "userID")
                 UserDefaults.standard.setValue(data.accessToken, forKey: "accessToken")
                 UserDefaults.standard.setValue(data.refreshToken, forKey: "refreshToken")
                 print("login \(data)")
+                self.onLoginSuccess.value = true
                 self.isSignIn.value = true
             case .requestErr:
                 self.isSignIn.value = false

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/Main/ViewModels/MainViewModel.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/Main/ViewModels/MainViewModel.swift
@@ -67,7 +67,9 @@ extension MainViewModel {
                 UserDefaults.standard.setValue(data.point, forKey: "userPoint")
                 self.isSuccessGetUserInfo.value = true
             case .reIssueJWT:
-                self.onReissueSuccess.value = self.patchReissue()
+                self.patchReissue { isSuccess in
+                    self.onReissueSuccess.value = isSuccess
+                }
             case .serverErr:
                 self.onFailNetwork.value = true
             default:
@@ -108,7 +110,9 @@ extension MainViewModel {
                     self.isSuccessGetNewDate.value = true
                 }
             case .reIssueJWT:
-                self.onReissueSuccess.value = self.patchReissue()
+                self.patchReissue { isSuccess in
+                    self.onReissueSuccess.value = isSuccess
+                }
             case .serverErr:
                 self.onFailNetwork.value = true
             default:
@@ -135,7 +139,9 @@ extension MainViewModel {
             case .requestErr:
                 self.isSuccessGetUpcomingDate.value = true
             case .reIssueJWT:
-                self.onReissueSuccess.value = self.patchReissue()
+                self.patchReissue { isSuccess in
+                    self.onReissueSuccess.value = isSuccess
+                }
             case .serverErr:
                 self.onFailNetwork.value = false
             default:
@@ -163,7 +169,9 @@ extension MainViewModel {
                 self.bannerData.value?.append(first)
                 self.isSuccessGetBanner.value = true
             case .reIssueJWT:
-                self.onReissueSuccess.value = self.patchReissue()
+                self.patchReissue { isSuccess in
+                    self.onReissueSuccess.value = isSuccess
+                }
             case .serverErr:
                 self.onFailNetwork.value = true
             default:

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/MyCourse/ViewModels/MyCourseListViewModel.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/MyCourse/ViewModels/MyCourseListViewModel.swift
@@ -60,7 +60,9 @@ class MyCourseListViewModel: Serviceable {
                 self.viewedCourseData.value = viewedCourseInfo
                 self.isSuccessGetViewedCourseInfo.value = true
             case .reIssueJWT:
-                self.onReissueSuccess.value = self.patchReissue()
+                self.patchReissue { isSuccess in
+                    self.onReissueSuccess.value = isSuccess
+                }
             case .serverErr:
                 self.onViewedCourseFailNetwork.value = true
             default:
@@ -90,7 +92,9 @@ class MyCourseListViewModel: Serviceable {
                 self.viewedCourseData.value = viewedCourseInfo
                 self.isSuccessGetNavViewedCourseInfo.value = true
             case .reIssueJWT:
-                self.onReissueSuccess.value = self.patchReissue()
+                self.patchReissue { isSuccess in
+                    self.onReissueSuccess.value = isSuccess
+                }
             case .serverErr:
                 self.onNavViewedCourseFailNetwork.value = true
             default:
@@ -121,7 +125,9 @@ class MyCourseListViewModel: Serviceable {
                 self.isSuccessGetMyRegisterCourseInfo.value = true
                 print("isUpdate>", self.myRegisterCourseData)
             case .reIssueJWT:
-                self.onReissueSuccess.value = self.patchReissue()
+                self.patchReissue { isSuccess in
+                    self.onReissueSuccess.value = isSuccess
+                }
             case .serverErr:
                 self.onMyRegisterCourseFailNetwork.value = true
             default:

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/MyPage/ViewModels/MyPageViewModel.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/MyPage/ViewModels/MyPageViewModel.swift
@@ -33,7 +33,7 @@ extension MyPageViewModel {
     
     func checkSocialLogin() {
         let socialType = UserDefaults.standard.bool(forKey: "SocialType")
-        isAppleLogin = socialType ? false : true
+        isAppleLogin = !socialType
     }
 
     func deleteLogout() {
@@ -45,7 +45,9 @@ extension MyPageViewModel {
                 }
                 self.onSuccessLogout.value = true
             case .reIssueJWT:
-                self.onReissueSuccess.value = self.patchReissue()
+                self.patchReissue { isSuccess in
+                    self.onReissueSuccess.value = isSuccess
+                }
             default:
                 print("Failed to fetch post logout")
                 self.onSuccessLogout.value = false
@@ -70,7 +72,10 @@ extension MyPageViewModel {
                 }
                 self.onSuccessWithdrawal.value = true
             case .reIssueJWT:
-                self.onReissueSuccess.value = self.patchReissue()
+                // 토큰 재발급 서버 통신 후 값을 설정
+                self.patchReissue { isSuccess in
+                    self.onReissueSuccess.value = isSuccess
+                }
             default:
                 print("Failed to fetch delete withdrawal")
                 self.onSuccessWithdrawal.value = false
@@ -93,7 +98,9 @@ extension MyPageViewModel {
                self.tagData = data.tags
                self.onSuccessGetUserProfile.value = true
             case .reIssueJWT:
-                self.onReissueSuccess.value = self.patchReissue()
+                self.patchReissue { isSuccess in
+                    self.onReissueSuccess.value = isSuccess
+                }
             case .serverErr:
                 self.onFailNetwork.value = true
             default:

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/MyPage/Views/MyPageViewController.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/MyPage/Views/MyPageViewController.swift
@@ -128,7 +128,7 @@ private extension MyPageViewController {
         self.myPageViewModel.onReissueSuccess.bind { [weak self] onSuccess in
             guard let onSuccess else { return }
             if onSuccess {
-                // TODO: - 서버 통신 재시도
+                self?.myPageViewModel.getUserProfile()
             } else {
                 self?.navigationController?.pushViewController(SplashViewController(splashViewModel: SplashViewModel()), animated: false)
             }

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/MyPage/Views/MyPageViewController.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/MyPage/Views/MyPageViewController.swift
@@ -140,7 +140,7 @@ private extension MyPageViewController {
             if isSuccess {
                 self?.navigationController?.popToRootViewController(animated: false)
             } else {
-                self?.presentAlertVC(title: "로그아웃 실패")
+                self?.presentAlertVC(title: StringLiterals.Alert.failToLogout)
             }
         }
         
@@ -149,7 +149,7 @@ private extension MyPageViewController {
             if isSuccess {
                 self?.navigationController?.popToRootViewController(animated: false)
             } else {
-                self?.presentAlertVC(title: "회원탈퇴 실패")
+                self?.presentAlertVC(title: StringLiterals.Alert.failToWithdrawal)
             }
         }
         
@@ -166,7 +166,7 @@ private extension MyPageViewController {
             if isSuccess {
                 self?.myPageViewModel.deleteWithdrawal()
             } else {
-                self?.presentAlertVC(title: "회원탈퇴 실패")
+                self?.presentAlertVC(title: StringLiterals.Alert.failToWithdrawal)
             }
         }
     }
@@ -183,7 +183,7 @@ private extension MyPageViewController {
     
     func presentAlertVC(title: String) {
         let alert = UIAlertController(title: title, message: nil, preferredStyle: .alert)
-        alert.addAction(.init(title: "확인", style: .cancel))
+        alert.addAction(.init(title: StringLiterals.Alert.confirm, style: .cancel))
         self.present(alert, animated: true)
     }
     
@@ -377,7 +377,7 @@ extension MyPageViewController: ASAuthorizationControllerDelegate {
     }
     
     func authorizationController(controller: ASAuthorizationController, didCompleteWithError error: any Error) {
-        self.presentAlertVC(title: "로그인 실패")
+        self.presentAlertVC(title: StringLiterals.Alert.failToLogin)
     }
     
 }

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/MyPage/Views/MyPageViewController.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/MyPage/Views/MyPageViewController.swift
@@ -28,6 +28,7 @@ final class MyPageViewController: BaseNavBarViewController {
     
     private var selectedAlertFlag: Int = 0
     
+    
     // MARK: - Life Cycle
     
     init(myPageViewModel: MyPageViewModel) {
@@ -138,6 +139,8 @@ private extension MyPageViewController {
             guard let isSuccess else { return }
             if isSuccess {
                 self?.navigationController?.popToRootViewController(animated: false)
+            } else {
+                self?.presentAlertVC(title: "로그아웃 실패")
             }
         }
         
@@ -145,6 +148,8 @@ private extension MyPageViewController {
             guard let isSuccess else { return }
             if isSuccess {
                 self?.navigationController?.popToRootViewController(animated: false)
+            } else {
+                self?.presentAlertVC(title: "회원탈퇴 실패")
             }
         }
         
@@ -153,6 +158,15 @@ private extension MyPageViewController {
             if isSuccess {
                 self?.myPageView.userInfoView.bindData(userInfo: data)
                 self?.myPageView.userInfoView.tagCollectionView.reloadData()
+            }
+        }
+        
+        self.loginViewModel.onLoginSuccess.bind { [weak self] isSuccess in
+            guard let isSuccess else { return }
+            if isSuccess {
+                self?.myPageViewModel.deleteWithdrawal()
+            } else {
+                self?.presentAlertVC(title: "회원탈퇴 실패")
             }
         }
     }
@@ -166,6 +180,29 @@ private extension MyPageViewController {
         
         self.myPageView.withdrawalButton.addTarget(self, action: #selector(withDrawalButtonTapped), for: .touchUpInside)
     }
+    
+    func presentAlertVC(title: String) {
+        let alert = UIAlertController(title: title, message: nil, preferredStyle: .alert)
+        alert.addAction(.init(title: "확인", style: .cancel))
+        self.present(alert, animated: true)
+    }
+    
+    func appleLogin() {
+        let appleProvider = ASAuthorizationAppleIDProvider()
+        let request = appleProvider.createRequest()
+        request.requestedScopes = [.fullName, .email]
+        
+        let controller = ASAuthorizationController(authorizationRequests: [request])
+        controller.delegate = self
+        controller.performRequests()
+    }
+    
+}
+
+
+// MARK: @objc methods
+
+extension MyPageViewController {
     
     @objc
     func pushToPointDetailVC() {
@@ -185,13 +222,9 @@ private extension MyPageViewController {
         }
     }
     
-}
-
-extension MyPageViewController: DRCustomAlertDelegate {
-    
     @objc
-    private func logOutSectionTapped() {
-        let customAlertVC = DRCustomAlertViewController(rightActionType: RightButtonType.logout, 
+    func logOutSectionTapped() {
+        let customAlertVC = DRCustomAlertViewController(rightActionType: RightButtonType.logout,
                                                         alertTextType: .noDescription,
                                                         alertButtonType: .twoButton,
                                                         titleText: StringLiterals.Alert.wouldYouLogOut,
@@ -204,12 +237,12 @@ extension MyPageViewController: DRCustomAlertDelegate {
     }
     
     @objc
-    private func withDrawalButtonTapped() {
-        let customAlertVC = DRCustomAlertViewController(rightActionType: RightButtonType.none, 
+    func withDrawalButtonTapped() {
+        let customAlertVC = DRCustomAlertViewController(rightActionType: RightButtonType.none,
                                                         alertTextType: .noDescription,
                                                         alertButtonType: .twoButton,
                                                         titleText: StringLiterals.Alert.realWithdrawal,
-                                                        descriptionText: StringLiterals.Alert.lastWarning, 
+                                                        descriptionText: StringLiterals.Alert.lastWarning,
                                                         leftButtonText: StringLiterals.MyPage.alertWithdrawal,
                                                         rightButtonText: StringLiterals.Common.cancel)
         customAlertVC.delegate = self
@@ -217,6 +250,12 @@ extension MyPageViewController: DRCustomAlertDelegate {
         selectedAlertFlag = 1
         self.present(customAlertVC, animated: false)
     }
+}
+
+
+// MARK: DRCustomAlertDelegate
+
+extension MyPageViewController: DRCustomAlertDelegate {
     
     func action(rightButtonAction: RightButtonType) {
         if selectedAlertFlag == 0 {
@@ -228,20 +267,12 @@ extension MyPageViewController: DRCustomAlertDelegate {
         if selectedAlertFlag == 1 {
             if self.myPageViewModel.isAppleLogin {
                 appleLogin()
+            } else {
+                myPageViewModel.deleteWithdrawal()
             }
-            myPageViewModel.deleteWithdrawal()
         }
     }
-    
-    func appleLogin() {
-        let appleProvider = ASAuthorizationAppleIDProvider()
-        let request = appleProvider.createRequest()
-        request.requestedScopes = [.fullName, .email]
-        
-        let controller = ASAuthorizationController(authorizationRequests: [request])
-        controller.delegate = self
-        controller.performRequests()
-    }
+
 }
 
 // MARK: - UICollectionView Delegates
@@ -346,9 +377,7 @@ extension MyPageViewController: ASAuthorizationControllerDelegate {
     }
     
     func authorizationController(controller: ASAuthorizationController, didCompleteWithError error: any Error) {
-        let alert = UIAlertController(title: "로그인 실패", message: nil, preferredStyle: .alert)
-        alert.addAction(.init(title: "확인", style: .cancel))
-        present(alert, animated: true)
+        self.presentAlertVC(title: "로그인 실패")
     }
     
 }

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/PointDetail/ViewModels/PointViewModel.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/PointDetail/ViewModels/PointViewModel.swift
@@ -68,7 +68,9 @@ final class PointViewModel: Serviceable {
                 self.usedPointData.value = pointUsedInfo
                 self.isSuccessGetPointInfo.value = true
             case .reIssueJWT:
-                self.onReissueSuccess.value = self.patchReissue()
+                self.patchReissue { isSuccess in
+                    self.onReissueSuccess.value = isSuccess
+                }
             case .serverErr:
                 self.onFailNetwork.value = true
             default:

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/Profile/ViewModels/ProfileViewModel.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/Profile/ViewModels/ProfileViewModel.swift
@@ -135,7 +135,9 @@ extension ProfileViewModel {
                 print("post \(data)")
                 self.onSuccessRegister?(true)
             case .reIssueJWT:
-                self.onReissueSuccess.value = self.patchReissue()
+                self.patchReissue { isSuccess in
+                    self.onReissueSuccess.value = isSuccess
+                }
             default:
                 print("Failed to fetch post signup")
                 self.onSuccessRegister?(false)
@@ -153,7 +155,9 @@ extension ProfileViewModel {
             case .success(_):
                 self.isValidNickname.value = true
             case .reIssueJWT:
-                self.onReissueSuccess.value = self.patchReissue()
+                self.patchReissue { isSuccess in
+                    self.onReissueSuccess.value = isSuccess
+                }
             case .requestErr:
                 self.isValidNickname.value = false
             default:
@@ -183,7 +187,9 @@ extension ProfileViewModel {
             case .success(_):
                 self.onSuccessEdit?(true)
             case .reIssueJWT:
-                self.onReissueSuccess.value = self.patchReissue()
+                self.patchReissue { isSuccess in
+                    self.onReissueSuccess.value = isSuccess
+                }
             default:
                 print("Failed to fetch patch edit profile")
                 self.onSuccessEdit?(false)


### PR DESCRIPTION
# 🔥*Pull requests*

## ⛳ **작업한 브랜치**
- fix/#201 

## 👷 **작업한 내용**
<!-- 작업한 내용을 적어주세요. -->
- [x] 애플 탈퇴 로직 수정
- [x] 토큰 재발급 비동기 처리

## 🚨 참고 사항
<!-- 참고할 사항이 있다면 적어주세요. -->
### 1️⃣ 토큰 재발급 비동기 처리
기존 : 토큰 재발급 비동기 처리를 하지 않아 토큰 재발급 서버 통신의 결과를 받는 시점이나 그에 대한 이벤트를 발생시키는 게 매번 달랐습니다
변경 후 : 토큰 재발급 서버 통신 메소드에서 클로저를 매개변수로 받아 토큰 재발급 통신이 완료되면 성공 여부를 기존 서버 통신 메소드들에 전달해줄 수 있게 되었고, 토큰 재발급 통신 결과를 받는 시점과 이벤트 발생 시점을 동일하게 가져갈 수 있게 되었습니다

## 📸 스크린샷
없습니다


## 📟 관련 이슈
- Resolved: #201 
