### PR TITLE
[FIX] 2차 QA 이전 버그 수정 (#221)

### DIFF
--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/AddCourse/Views/AddCourseThird/AddCourseThirdViewController.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/AddCourse/Views/AddCourseThird/AddCourseThirdViewController.swift
@@ -312,9 +312,9 @@ extension AddCourseThirdViewController: UITextFieldDelegate {
          }
          self.view.layoutIfNeeded() // 레이아웃 즉시 갱신
       }
-      
-      // textField 값이 변경된 경우 처리
-      viewModel.priceText.value = Int(textField.text ?? "0")
+      // textField 값이 변경된 경우 ',' 제거한 값으로 처리
+      let money = textField.text?.filter { $0.isNumber }
+      viewModel.priceText.value = Int(money ?? "0")
    }
    
 }

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/AddCourse/Views/AddCourseThird/AddCourseThirdViewController.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/AddCourse/Views/AddCourseThird/AddCourseThirdViewController.swift
@@ -141,8 +141,8 @@ private extension AddCourseThirdViewController {
             errorVC.onDismiss = {
                print("🚀onDismiss 출동🚀")
                // 코스 등록 3 로딩뷰, 에러뷰 false 설정
-               self?.viewModel.onLoading.value = false
                self?.viewModel.onFailNetwork.value = false
+               self?.viewModel.onLoading.value = false
             }
             
             self?.navigationController?.pushViewController(errorVC, animated: false)

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/AddCourse/Views/AddCourseThird/AddThirdView.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/AddCourse/Views/AddCourseThird/AddThirdView.swift
@@ -160,8 +160,7 @@ extension AddThirdView {
    }
    
    func updatePriceText(price: Int) {
-      if price == 0 {
-      } else {
+      if price != 0 {
          priceTextField.text = String(price.formattedWithSeparator)
       }
    }

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/AddSchedule/Views/AddScheduleFirst/AddScheduleFirstViewController.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/AddSchedule/Views/AddScheduleFirst/AddScheduleFirstViewController.swift
@@ -111,8 +111,8 @@ private extension AddScheduleFirstViewController {
             errorVC.onDismiss = {
                print("🚀onDismiss 출동🚀")
                // 일정 등록 1 로딩뷰, 에러뷰 false 설정
-               self?.viewModel.onLoading.value = false
                self?.viewModel.onFailNetwork.value = false
+               self?.viewModel.onLoading.value = false
             }
             
             self?.navigationController?.pushViewController(errorVC, animated: false)

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/AddSchedule/Views/AddScheduleSecond/AddScheduleSecondViewController.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/AddSchedule/Views/AddScheduleSecond/AddScheduleSecondViewController.swift
@@ -135,8 +135,8 @@ private extension AddScheduleSecondViewController {
             errorVC.onDismiss = {
                print("🚀onDismiss 출동🚀")
                // 일정 등록 2 로딩뷰, 에러뷰 false 설정
-               self?.viewModel.onLoading.value = false
                self?.viewModel.onFailNetwork.value = false
+               self?.viewModel.onLoading.value = false
             }
             
             self?.navigationController?.pushViewController(errorVC, animated: false)


### PR DESCRIPTION
# 🔥*Pull requests*

## ⛳ **작업한 브랜치**
- fix/#221

## 👷 **작업한 내용**
<!-- 작업한 내용을 적어주세요. -->
- [x] '코스 등록하기 3' 에러뷰 `뒤로가기` 이후 무한 로딩 // 1️⃣
- [x] '코스 등록하기 3' 금액 수정 시 `완료 버튼` 비활성화 // 2️⃣

### 문제 1️⃣ 해결 방법
- 문제
   ```swift
    #📌_1
    errorVC.onDismiss = {
       print("🚀onDismiss 출동🚀")
       // 코스 등록 3 로딩뷰, 에러뷰 false 설정
       self?.viewModel.onLoading.value = false
       self?.viewModel.onFailNetwork.value = false
    }
    
    ...
    
    #📌_2
    self.viewModel.onLoading.bind { [weak self] onLoading in
        guard let onLoading, let onFailNetwork = self?.viewModel.onFailNetwork.value else { return }
       
       if !onFailNetwork {
           onLoading ? self?.showLoadingView() : self?.hideLoadingView()
          self?.addCourseThirdView.isHidden = onLoading
          self?.tabBarController?.tabBar.isHidden = onLoading
       }
    }
    ```
  - error View를 닫을 때에 실행되는 `📌_1` 의 `onDismiss 클로저` 속 코드가 기존에는 이와 같이 onLoading.value의 값이 먼저 바뀌는 순서라서, 아래 `📌_2` 의 코드가 실행 될 때 `onFailNetwork`의 값이 `true` 값으로 계산되어 `self?.hideLoadingView()` 가 실행되지 않고 있었습니다.

- 해결
  ```swift
    #📌_3
    errorVC.onDismiss = {
       print("🚀onDismiss 출동🚀")
       // 코스 등록 3 로딩뷰, 에러뷰 false 설정
       self?.viewModel.onFailNetwork.value = false
       self?.viewModel.onLoading.value = false
    }
    ``` 
  - 위와 같이 `self?.viewModel.onFailNetwork.value = false` 의 코드를 위로 옮겨주어 기존 `📌_2` 코드가 실행 될 때 `onFailNetwork`의 값이 `false` 값으로 잘 적용되어 무한 로딩뷰의 상황을 해결할 수 있었습니다.

### 문제 2️⃣ 해결 방법
- 문제
  - `코스 등록하기 3` 뷰 내의 총 금액 TextField의 값을 수정할 경우 입력된 값이 0으로 계산되었습니다.

- 해결
  - ```swift
    func textFieldDidEndEditing(_ textField: UITextField) {
      UIView.animate(withDuration: 0.3) {
         // 원래의 제약 조건으로 되돌림
         self.addCourseThirdView.addThirdDoneBtn.snp.remakeConstraints { make in
            make.height.equalTo(54)
            make.horizontalEdges.equalToSuperview().inset(16)
            make.bottom.equalTo(self.view.safeAreaLayoutGuide).offset(-4) // 안전 영역 하단에 위치
         }
         self.view.layoutIfNeeded() // 레이아웃 즉시 갱신
      }
      
      // #📌_1 textField 값이 변경된 경우 ',' 제거한 값으로 처리
      let money = textField.text?.filter { $0.isNumber }
      viewModel.priceText.value = Int(money ?? "0")
    }
    ```
  - 첫 입력 이후 `,(쉼표)`가 계산되어 입력돼있을 `textField.text`의 값에 변화가 있을 경우 `,(쉼표)`를 제거한 값만을 사용하도록  `📌_1`과 같이고차함수 filter를 사용하였습니다.

## 🚨 참고 사항
<!-- 참고할 사항이 있다면 적어주세요. -->

## 📸 스크린샷
|기능|스크린샷|
|:--:|:--:|
|아이폰15Pro|<img src = "https://github.com/user-attachments/assets/11141e96-ff4f-447c-9d3b-41dfc842abc7" width ="250">|


## 📟 관련 이슈
- Resolved: #221 
