### PR TITLE
[FIX] 데이트일정 삭제 후 pageControl 보이는 오류 해결 (#225)

### DIFF
--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/DateSchedule/View/UpcomingDateScheduleViewController.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/DateSchedule/View/UpcomingDateScheduleViewController.swift
@@ -71,6 +71,7 @@ final class UpcomingDateScheduleViewController: BaseViewController {
         let isEmpty = upcomingDateScheduleViewModel.upcomingDateScheduleData.value?.count == 0
         upcomingDateScheduleView.emptyView.isHidden = !isEmpty
         upcomingDateScheduleView.cardCollectionView.isHidden = isEmpty
+        upcomingDateScheduleView.cardPageControl.isHidden = isEmpty
         if !isEmpty {
             upcomingDateScheduleView.cardPageControl.numberOfPages = upcomingDateScheduleViewModel.upcomingDateScheduleData.value?.count ?? 0
             self.upcomingDateScheduleView.cardCollectionView.reloadData()


### PR DESCRIPTION
# 🔥*Pull requests*

## ⛳ **작업한 브랜치**
- #225 

## 👷 **작업한 내용**
하나 남은 데이트일정 삭제 후 pageControl 보이는 오류 해결하였습니다. (스크린샷에 보이는 오류입니다 !!)

## 🚨 참고 사항
테플에서 발견했습니다.. 너무 늦게 발견해서 죄송합니다 ㅜㅜ

## 📸 스크린샷
![Simulator Screenshot - iPhone 16 Pro - 2024-09-23 at 17 05 11](https://github.com/user-attachments/assets/a870c552-7831-4b2e-95db-d653b08f7e33)
![Simulator Screenshot - iPhone 16 Pro - 2024-09-23 at 17 08 19](https://github.com/user-attachments/assets/8b432a21-dff3-429e-9c7a-a9524b683910)


## 📟 관련 이슈
- Resolved: #225
