### PR TITLE
[FIX] iOS 2차 QA 적용 (#231)

### DIFF
--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/AddCourse/Views/AddCourseSecond/AddCourseSecondViewController.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/AddCourse/Views/AddCourseSecond/AddCourseSecondViewController.swift
@@ -111,7 +111,13 @@ private extension AddCourseSecondViewController {
    func pastDateBindViewModel() {
       if viewModel.pastDatePlaces.count > 0  {
          for i in viewModel.pastDatePlaces {
-            viewModel.tapAddBtn(datePlace: i.name, timeRequire: i.duration)
+            if let doubleValue = Double(String(i.duration)) {
+               let text = doubleValue.truncatingRemainder(dividingBy: 1) == 0 ?
+               String(Int(doubleValue)) : String(doubleValue)
+               viewModel.tapAddBtn(datePlace: i.name, timeRequire: "\(text) 시간")
+            } else {
+               viewModel.tapAddBtn(datePlace: i.name, timeRequire: "\(String(i.duration)) 시간")
+            }
          }
       }
    }

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/AddCourse/Views/AddCourseThird/AddCourseThirdViewController.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/AddCourse/Views/AddCourseThird/AddCourseThirdViewController.swift
@@ -175,9 +175,10 @@ private extension AddCourseThirdViewController {
          self?.viewModel.isDoneBtnValid()
       }
       viewModel.priceText.bind { [weak self] date in
-         self?.addCourseThirdView.addThirdView.updatePriceText(price: date ?? 0)
-         let flag = (date ?? 0 > 0) ? true : false
-         self?.viewModel.price = date ?? 0
+         guard let date = date else {return}
+         self?.addCourseThirdView.addThirdView.updatePriceText(price: date)
+         let flag = (date >= 0) ? true : false
+         self?.viewModel.price = date
          self?.viewModel.priceFlag = flag
          self?.viewModel.isDoneBtnValid()
       }

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/AddCourse/Views/AddCourseThird/AddCourseThirdViewController.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/AddCourse/Views/AddCourseThird/AddCourseThirdViewController.swift
@@ -175,9 +175,9 @@ private extension AddCourseThirdViewController {
          self?.viewModel.isDoneBtnValid()
       }
       viewModel.priceText.bind { [weak self] date in
-         guard let date = date else {return}
+         guard let date else {return}
          self?.addCourseThirdView.addThirdView.updatePriceText(price: date)
-         let flag = (date >= 0) ? true : false
+         let flag = (date >= 0)
          self?.viewModel.price = date
          self?.viewModel.priceFlag = flag
          self?.viewModel.isDoneBtnValid()

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/AddCourse/Views/AddCourseThird/AddThirdView.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/AddCourse/Views/AddCourseThird/AddThirdView.swift
@@ -160,9 +160,7 @@ extension AddThirdView {
    }
    
    func updatePriceText(price: Int) {
-      if price != 0 {
-         priceTextField.text = String(price.formattedWithSeparator)
-      }
+      priceTextField.text = String(price.formattedWithSeparator)
    }
    
    func updateContentTextView(_ textView: UITextView, withText text: String, placeholder: String) {

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/AddSchedule/Views/AddScheduleSecond/AddScheduleSecondViewController.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/AddSchedule/Views/AddScheduleSecond/AddScheduleSecondViewController.swift
@@ -111,7 +111,13 @@ private extension AddScheduleSecondViewController {
    func pastDateBindViewModel() {
       if viewModel.pastDatePlaces.count > 0  {
          for i in viewModel.pastDatePlaces {
-            viewModel.tapAddBtn(datePlace: i.title, timeRequire: String(i.duration))
+            if let doubleValue = Double(String(i.duration)) {
+               let text = doubleValue.truncatingRemainder(dividingBy: 1) == 0 ?
+               String(Int(doubleValue)) : String(doubleValue)
+               viewModel.tapAddBtn(datePlace: i.title, timeRequire: "\(text) 시간")
+            } else {
+               viewModel.tapAddBtn(datePlace: i.title, timeRequire: "\(String(i.duration)) 시간")
+            }
          }
       }
    }


### PR DESCRIPTION
# 🔥*Pull requests*

## ⛳ **작업한 브랜치**
- fix/#231

## 👷 **작업한 내용**
<!-- 작업한 내용을 적어주세요. -->
- [x] `코스 or 일정 등록` 당시 불러온 데이터가 있을 경우 각 두 번째 뷰에 `시간` 키워드 누락된 것 수정 // 1️⃣
- [x] `코스 등록하기 3` 총 비용 `0원` 허용 // 2️⃣

## 🚨 참고 사항
<!-- 참고할 사항이 있다면 적어주세요. -->

## 📸 스크린샷
|기종|1️⃣ 스크린샷|기종|2️⃣ 스크린샷|
|:--:|:--:|:--:|:--:|
|아이폰15Pro|<img src = "https://github.com/user-attachments/assets/c3742d14-9ba4-4a33-95e4-6c4b2de1cde3" width ="250">|아이폰15Pro|<img src = "https://github.com/user-attachments/assets/fc0666a3-a2f0-48b0-b462-f5a4ed98d091" width ="250">|


## 📟 관련 이슈
- Resolved: #231 
