### PR TITLE
[FIX] iOS 2차 QA 적용 (#228)

### DIFF
--- a/DATEROAD-iOS/DATEROAD-iOS.xcodeproj/project.pbxproj
+++ b/DATEROAD-iOS/DATEROAD-iOS.xcodeproj/project.pbxproj
@@ -186,6 +186,7 @@
 		CA5B979E2C91889C00F90A4C /* AmplitudeManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA5B979D2C91889C00F90A4C /* AmplitudeManager.swift */; };
 		CA5B97A02C9C7B4300F90A4C /* Header.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA5B979F2C9C7B4200F90A4C /* Header.swift */; };
 		CA5B97A22CA2FCD700F90A4C /* NetworkType.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA5B97A12CA2FCD700F90A4C /* NetworkType.swift */; };
+		CA5B97A42CA5562000F90A4C /* CourseDetailSection.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA5B97A32CA5562000F90A4C /* CourseDetailSection.swift */; };
 		CA73F16E2C6080180089856C /* EditType.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA73F16D2C6080180089856C /* EditType.swift */; };
 		CA73F1702C61E1C30089856C /* PatchEditProfileRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA73F16F2C61E1C30089856C /* PatchEditProfileRequest.swift */; };
 		CA78FE442C383D53001B1403 /* SUIT-Medium.otf in Resources */ = {isa = PBXBuildFile; fileRef = 74A70BF62C329A6400855E61 /* SUIT-Medium.otf */; };
@@ -453,6 +454,7 @@
 		CA5B979D2C91889C00F90A4C /* AmplitudeManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AmplitudeManager.swift; sourceTree = "<group>"; };
 		CA5B979F2C9C7B4200F90A4C /* Header.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Header.swift; sourceTree = "<group>"; };
 		CA5B97A12CA2FCD700F90A4C /* NetworkType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkType.swift; sourceTree = "<group>"; };
+		CA5B97A32CA5562000F90A4C /* CourseDetailSection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CourseDetailSection.swift; sourceTree = "<group>"; };
 		CA73F16D2C6080180089856C /* EditType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditType.swift; sourceTree = "<group>"; };
 		CA73F16F2C61E1C30089856C /* PatchEditProfileRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PatchEditProfileRequest.swift; sourceTree = "<group>"; };
 		CA78FE462C38667A001B1403 /* DRErrorLabel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DRErrorLabel.swift; sourceTree = "<group>"; };
@@ -1359,6 +1361,7 @@
 				CA73F16D2C6080180089856C /* EditType.swift */,
 				CA5B979F2C9C7B4200F90A4C /* Header.swift */,
 				CA5B97A12CA2FCD700F90A4C /* NetworkType.swift */,
+				CA5B97A32CA5562000F90A4C /* CourseDetailSection.swift */,
 			);
 			path = Enums;
 			sourceTree = "<group>";
@@ -2108,6 +2111,7 @@
 				CA80C0CF2C445D38002CAA9B /* MoyaLoggingPluggin.swift in Sources */,
 				9E754CF32C4841BE00E2CA91 /* AddScheduleService.swift in Sources */,
 				CAC80FB92C3BCE4E00658EA6 /* MyPageSection.swift in Sources */,
+				CA5B97A42CA5562000F90A4C /* CourseDetailSection.swift in Sources */,
 				CABDCEB92C4A6C8800631FB3 /* AdTagType.swift in Sources */,
 				CAC80FDE2C3E7F0100658EA6 /* MainViewModel.swift in Sources */,
 				CA78FE472C38667A001B1403 /* DRErrorLabel.swift in Sources */,

--- a/DATEROAD-iOS/DATEROAD-iOS.xcodeproj/project.pbxproj
+++ b/DATEROAD-iOS/DATEROAD-iOS.xcodeproj/project.pbxproj
@@ -185,6 +185,7 @@
 		CA5B979B2C91848F00F90A4C /* AmplitudeSwift in Frameworks */ = {isa = PBXBuildFile; productRef = CA5B979A2C91848F00F90A4C /* AmplitudeSwift */; };
 		CA5B979E2C91889C00F90A4C /* AmplitudeManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA5B979D2C91889C00F90A4C /* AmplitudeManager.swift */; };
 		CA5B97A02C9C7B4300F90A4C /* Header.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA5B979F2C9C7B4200F90A4C /* Header.swift */; };
+		CA5B97A22CA2FCD700F90A4C /* NetworkType.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA5B97A12CA2FCD700F90A4C /* NetworkType.swift */; };
 		CA73F16E2C6080180089856C /* EditType.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA73F16D2C6080180089856C /* EditType.swift */; };
 		CA73F1702C61E1C30089856C /* PatchEditProfileRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA73F16F2C61E1C30089856C /* PatchEditProfileRequest.swift */; };
 		CA78FE442C383D53001B1403 /* SUIT-Medium.otf in Resources */ = {isa = PBXBuildFile; fileRef = 74A70BF62C329A6400855E61 /* SUIT-Medium.otf */; };
@@ -451,6 +452,7 @@
 		CA4EF3E42C3538AA003B02B6 /* OnboardingViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingViewModel.swift; sourceTree = "<group>"; };
 		CA5B979D2C91889C00F90A4C /* AmplitudeManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AmplitudeManager.swift; sourceTree = "<group>"; };
 		CA5B979F2C9C7B4200F90A4C /* Header.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Header.swift; sourceTree = "<group>"; };
+		CA5B97A12CA2FCD700F90A4C /* NetworkType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkType.swift; sourceTree = "<group>"; };
 		CA73F16D2C6080180089856C /* EditType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditType.swift; sourceTree = "<group>"; };
 		CA73F16F2C61E1C30089856C /* PatchEditProfileRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PatchEditProfileRequest.swift; sourceTree = "<group>"; };
 		CA78FE462C38667A001B1403 /* DRErrorLabel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DRErrorLabel.swift; sourceTree = "<group>"; };
@@ -1356,6 +1358,7 @@
 				CABDCEB82C4A6C8800631FB3 /* AdTagType.swift */,
 				CA73F16D2C6080180089856C /* EditType.swift */,
 				CA5B979F2C9C7B4200F90A4C /* Header.swift */,
+				CA5B97A12CA2FCD700F90A4C /* NetworkType.swift */,
 			);
 			path = Enums;
 			sourceTree = "<group>";
@@ -2125,6 +2128,7 @@
 				9E754CF92C48471100E2CA91 /* PostAddScheduleResponse.swift in Sources */,
 				9EBD5C732C7C850400EDE081 /* UINavigationController+.swift in Sources */,
 				CAC80FCA2C3C95A100658EA6 /* UICollectionViewFlowLayout+.swift in Sources */,
+				CA5B97A22CA2FCD700F90A4C /* NetworkType.swift in Sources */,
 				CABDCEBD2C4A70AF00631FB3 /* BannerInfoHeaderView.swift in Sources */,
 				0D98CBA12C40A2F100E3618A /* ContentMaskView.swift in Sources */,
 				9E443A4E2C3819DB00C1F92C /* AddFirstView.swift in Sources */,

--- a/DATEROAD-iOS/DATEROAD-iOS.xcodeproj/project.pbxproj
+++ b/DATEROAD-iOS/DATEROAD-iOS.xcodeproj/project.pbxproj
@@ -252,7 +252,6 @@
 		CAC80FC52C3C759B00658EA6 /* PointSystemModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = CAC80FC42C3C759B00658EA6 /* PointSystemModel.swift */; };
 		CAC80FC82C3C75F200658EA6 /* PointSystemViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = CAC80FC72C3C75F200658EA6 /* PointSystemViewModel.swift */; };
 		CAC80FCA2C3C95A100658EA6 /* UICollectionViewFlowLayout+.swift in Sources */ = {isa = PBXBuildFile; fileRef = CAC80FC92C3C95A000658EA6 /* UICollectionViewFlowLayout+.swift */; };
-		CAC80FCC2C3D2EA600658EA6 /* DRButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = CAC80FCB2C3D2EA600658EA6 /* DRButton.swift */; };
 		CAC80FCE2C3D2FD800658EA6 /* BottomControlView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CAC80FCD2C3D2FD800658EA6 /* BottomControlView.swift */; };
 		CAC80FD02C3D723200658EA6 /* DRBottomSheetViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = CAC80FCF2C3D723200658EA6 /* DRBottomSheetViewController.swift */; };
 		CAC80FD22C3D7E5100658EA6 /* ProfileImageSettingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CAC80FD12C3D7E5100658EA6 /* ProfileImageSettingView.swift */; };
@@ -515,7 +514,6 @@
 		CAC80FC42C3C759B00658EA6 /* PointSystemModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PointSystemModel.swift; sourceTree = "<group>"; };
 		CAC80FC72C3C75F200658EA6 /* PointSystemViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PointSystemViewModel.swift; sourceTree = "<group>"; };
 		CAC80FC92C3C95A000658EA6 /* UICollectionViewFlowLayout+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UICollectionViewFlowLayout+.swift"; sourceTree = "<group>"; };
-		CAC80FCB2C3D2EA600658EA6 /* DRButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DRButton.swift; sourceTree = "<group>"; };
 		CAC80FCD2C3D2FD800658EA6 /* BottomControlView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BottomControlView.swift; sourceTree = "<group>"; };
 		CAC80FCF2C3D723200658EA6 /* DRBottomSheetViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DRBottomSheetViewController.swift; sourceTree = "<group>"; };
 		CAC80FD12C3D7E5100658EA6 /* ProfileImageSettingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfileImageSettingView.swift; sourceTree = "<group>"; };
@@ -1506,7 +1504,6 @@
 				CA78FE462C38667A001B1403 /* DRErrorLabel.swift */,
 				0D07420B2C3B0339004B3F59 /* TabBarController.swift */,
 				CAC80FF02C3EFF6600658EA6 /* DRPaddingLabel.swift */,
-				CAC80FCB2C3D2EA600658EA6 /* DRButton.swift */,
 				CAC80FCF2C3D723200658EA6 /* DRBottomSheetViewController.swift */,
 				74C88EEF2C4047E400A4C638 /* CustomEmptyView.swift */,
 				9E0789192C4547C200B9F9B8 /* CustomImagePicker.swift */,
@@ -1950,7 +1947,6 @@
 				CAA30AED2C37E57400835DE3 /* String+.swift in Sources */,
 				0D98CBA52C41067B00E3618A /* CourseDetailViewController.swift in Sources */,
 				0D0DA3E42C3AF3CF004210EE /* PointCollectionView.swift in Sources */,
-				CAC80FCC2C3D2EA600658EA6 /* DRButton.swift in Sources */,
 				CAC80FA22C3B10EA00658EA6 /* MyPageViewController.swift in Sources */,
 				CA73F1702C61E1C30089856C /* PatchEditProfileRequest.swift in Sources */,
 				CA4EF3C02C3285BA003B02B6 /* SocialType.swift in Sources */,

--- a/DATEROAD-iOS/DATEROAD-iOS/Global/Literals/StringLiterals.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Global/Literals/StringLiterals.swift
@@ -226,6 +226,7 @@ enum StringLiterals {
         static let failToDeleteCourse = "코스 삭제 실패"
         static let failToAddLike = "좋아요 등록 실패"
         static let failToDeleteLike = "좋아요 해제 실패"
+        static let delete = "삭제"
     }
     
     enum Course {
@@ -293,6 +294,7 @@ enum StringLiterals {
     
     enum Elementkinds {
         static let bannerInfoHeaderView = "BannerInfoHeaderView"
+        static let contentMaskView = "ContentMaskView"
     }
     
     enum Amplitude {

--- a/DATEROAD-iOS/DATEROAD-iOS/Global/Literals/StringLiterals.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Global/Literals/StringLiterals.swift
@@ -71,7 +71,8 @@ enum StringLiterals {
         static let deleteTitle = "데이트 코스를 삭제하시겠어요?"
         static let deleteDescription = "삭제된 코스는 복구하실 수 없어요"
         static let viewCourse = "코스 열람하기"
-        
+        static let pointUsed = "POINT_USED"
+        static let usedFreeView = "무료 열람 기회 사용"
     }
     
     enum Profile {
@@ -222,6 +223,9 @@ enum StringLiterals {
         static let failToLogin = "로그인 실패"
         static let confirm = "확인"
         static let failToEditProfile = "프로필 변경 실패"
+        static let failToDeleteCourse = "코스 삭제 실패"
+        static let failToAddLike = "좋아요 등록 실패"
+        static let failToDeleteLike = "좋아요 해제 실패"
     }
     
     enum Course {
@@ -280,6 +284,7 @@ enum StringLiterals {
     enum WebView {
         static let inquiryLink = "https://dateroad.notion.site/1055d2f7bfe94b3fa6c03709448def21?pvs=4"
         static let privacyPolicyLink = "https://dateroad.notion.site/04da4aa279ca4b599193784091a52859?pvs=4"
+        static let declareLink = "https://tally.so/r/w4L1a5"
     }
     
     enum Identifier {

--- a/DATEROAD-iOS/DATEROAD-iOS/Global/Protocols/MainSectionLayout.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Global/Protocols/MainSectionLayout.swift
@@ -89,6 +89,8 @@ struct HotDateLayout: MainSectionLayout {
     
     var supplemetaryItemSize: NSCollectionLayoutSize = NSCollectionLayoutSize(widthDimension: .fractionalWidth(1), heightDimension: .estimated(119))
     
+    var scrollDirection: UICollectionLayoutSectionOrthogonalScrollingBehavior = .continuous
+    
 }
 
 struct BannerDateLayout: MainSectionLayout {
@@ -102,6 +104,7 @@ struct BannerDateLayout: MainSectionLayout {
     var supplemetaryItemSize: NSCollectionLayoutSize = NSCollectionLayoutSize(widthDimension: .fractionalWidth(1), heightDimension: .estimated(20))
  
     var absoluteOffset: CGPoint = CGPoint(x: -16, y: -55)
+    
 }
 
 struct NewDateLayout: MainSectionLayout {

--- a/DATEROAD-iOS/DATEROAD-iOS/Global/Service/DRCompositionalLayoutFactory.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Global/Service/DRCompositionalLayoutFactory.swift
@@ -7,7 +7,7 @@
 
 import UIKit
 
-class DRCompositionalLayoutFactory {
+final class DRCompositionalLayoutFactory {
     
     func createLayout(
         widthDimension: NSCollectionLayoutDimension,

--- a/DATEROAD-iOS/DATEROAD-iOS/Global/UIComponents/CustomAlert/DRCustomAlertView.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Global/UIComponents/CustomAlert/DRCustomAlertView.swift
@@ -7,7 +7,7 @@
 
 import UIKit
 
-class DRCustomAlertView: BaseView {
+final class DRCustomAlertView: BaseView {
     
     // MARK: - UI Properties
     

--- a/DATEROAD-iOS/DATEROAD-iOS/Global/UIComponents/CustomAlert/DRCustomAlertViewController.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Global/UIComponents/CustomAlert/DRCustomAlertViewController.swift
@@ -19,7 +19,7 @@ extension DRCustomAlertDelegate {
     func exit() {}
 }
 
-class DRCustomAlertViewController: BaseViewController {
+final class DRCustomAlertViewController: BaseViewController {
     
     // MARK: - UI Properties
     

--- a/DATEROAD-iOS/DATEROAD-iOS/Global/UIComponents/CustomImagePicker.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Global/UIComponents/CustomImagePicker.swift
@@ -13,7 +13,7 @@ protocol ImagePickerDelegate: AnyObject {
    func didPickImages(_ images: [UIImage])
 }
 
-class CustomImagePicker: NSObject, PHPickerViewControllerDelegate {
+final class CustomImagePicker: NSObject, PHPickerViewControllerDelegate {
    
    // MARK: - Properties
    

--- a/DATEROAD-iOS/DATEROAD-iOS/Global/UIComponents/DRErrorLabel.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Global/UIComponents/DRErrorLabel.swift
@@ -7,7 +7,7 @@
 
 import UIKit
 
-class DRErrorLabel: UILabel {
+final class DRErrorLabel: UILabel {
     
     // MARK: - Properties
         

--- a/DATEROAD-iOS/DATEROAD-iOS/Global/UIComponents/DRPaddingLabel.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Global/UIComponents/DRPaddingLabel.swift
@@ -7,7 +7,8 @@
 
 import UIKit
 
-class DRPaddingLabel: UILabel {
+final class DRPaddingLabel: UILabel {
+    
     var padding = UIEdgeInsets.zero
 
     override func drawText(in rect: CGRect) {

--- a/DATEROAD-iOS/DATEROAD-iOS/Global/UIComponents/DRPriceButton.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Global/UIComponents/DRPriceButton.swift
@@ -7,7 +7,7 @@
 
 import UIKit
 
-class DRPriceButton: UIButton {
+final class DRPriceButton: UIButton {
     
     // MARK: - Properties
         

--- a/DATEROAD-iOS/DATEROAD-iOS/Global/UIComponents/DRTagButton.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Global/UIComponents/DRTagButton.swift
@@ -7,7 +7,7 @@
 
 import UIKit
 
-class DRTagButton: UIButton {
+final class DRTagButton: UIButton {
     
     // MARK: - Properties
         

--- a/DATEROAD-iOS/DATEROAD-iOS/Global/Utils/Enums/CourseDetailSection.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Global/Utils/Enums/CourseDetailSection.swift
@@ -1,0 +1,21 @@
+//
+//  CourseDetailSection.swift
+//  DATEROAD-iOS
+//
+//  Created by 윤희슬 on 9/26/24.
+//
+
+import Foundation
+
+enum CourseDetailSection {
+    case imageCarousel
+    case titleInfo
+    case mainContents
+    case timelineInfo
+    case coastInfo
+    case tagInfo
+    
+    static var dataSource: [CourseDetailSection] {
+        return [.imageCarousel, .titleInfo, .mainContents, .timelineInfo, .coastInfo, .tagInfo]
+    }
+}

--- a/DATEROAD-iOS/DATEROAD-iOS/Global/Utils/Enums/MainSection.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Global/Utils/Enums/MainSection.swift
@@ -13,19 +13,6 @@ enum MainSection {
     case banner
     case newDateCourse
     
-//    var title: String {
-//        switch self {
-//        case .upcomingDate:
-//            return StringLiterals.MyPage.myCourse
-//        case .hotDateCourse:
-//            return StringLiterals.MyPage.pointSystem
-//        case .banner:
-//            return StringLiterals.MyPage.inquiry
-//        case .newDateCourse:
-//            return StringLiterals.MyPage.logout
-//        }
-//    }
-    
     static let dataSource: [MainSection] = [
         MainSection.upcomingDate,
         MainSection.hotDateCourse,

--- a/DATEROAD-iOS/DATEROAD-iOS/Global/Utils/Enums/NetworkType.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Global/Utils/Enums/NetworkType.swift
@@ -1,0 +1,13 @@
+//
+//  NetworkType.swift
+//  DATEROAD-iOS
+//
+//  Created by 윤희슬 on 9/24/24.
+//
+
+import Foundation
+
+enum NetworkType: String {
+    case getDateDetail
+    case deleteDateSchedule
+}

--- a/DATEROAD-iOS/DATEROAD-iOS/Network/Base/NetworkService.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Network/Base/NetworkService.swift
@@ -33,4 +33,7 @@ final class NetworkService {
     
     let courseDetailService: CourseDetailService = CourseDetailService()
     
+    let likedCourseService: LikeCourseService = LikeCourseService()
+    
+    
 }

--- a/DATEROAD-iOS/DATEROAD-iOS/Network/Base/NetworkService.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Network/Base/NetworkService.swift
@@ -35,5 +35,6 @@ final class NetworkService {
     
     let likedCourseService: LikeCourseService = LikeCourseService()
     
+    let usePointService: UsePointService = UsePointService()
     
 }

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/AddCourse/Views/AddCourseFirst/AddCourseFirstViewController.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/AddCourse/Views/AddCourseFirst/AddCourseFirstViewController.swift
@@ -102,15 +102,6 @@ private extension AddCourseFirstViewController {
    }
    
    func bindViewModel() {
-      self.viewModel.onReissueSuccess.bind { [weak self] onSuccess in
-         guard let onSuccess else { return }
-         if onSuccess {
-            // TODO: - 서버 통신 재시도
-         } else {
-            self?.navigationController?.pushViewController(SplashViewController(splashViewModel: SplashViewModel()), animated: false)
-         }
-      }
-      
       viewModel.ispastDateVaild.bind { date in
          self.viewModel.fetchPastDate()
          self.addCourseFirstView.addFirstView.tendencyTagCollectionView.reloadData()

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/AddCourse/Views/AddCourseSecond/AddCourseSecondViewController.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/AddCourse/Views/AddCourseSecond/AddCourseSecondViewController.swift
@@ -117,15 +117,6 @@ private extension AddCourseSecondViewController {
    }
    
    func bindViewModel() {
-      self.viewModel.onReissueSuccess.bind { [weak self] onSuccess in
-         guard let onSuccess else { return }
-         if onSuccess {
-            // TODO: - 서버 통신 재시도
-         } else {
-            self?.navigationController?.pushViewController(SplashViewController(splashViewModel: SplashViewModel()), animated: false)
-         }
-      }
-      
       viewModel.isDataSourceNotEmpty()
       
       viewModel.editBtnEnableState.bind { [weak self] date in

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/AddCourse/Views/AddCourseThird/AddCourseThirdViewController.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/AddCourse/Views/AddCourseThird/AddCourseThirdViewController.swift
@@ -162,7 +162,7 @@ private extension AddCourseThirdViewController {
       self.viewModel.onReissueSuccess.bind { [weak self] onSuccess in
          guard let onSuccess else { return }
          if onSuccess {
-            // TODO: - 서버 통신 재시도
+             self?.viewModel.postAddCourse()
          } else {
             self?.navigationController?.pushViewController(SplashViewController(splashViewModel: SplashViewModel()), animated: false)
          }

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/AddSchedule/Views/AddScheduleFirst/AddScheduleFirstViewController.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/AddSchedule/Views/AddScheduleFirst/AddScheduleFirstViewController.swift
@@ -130,15 +130,6 @@ private extension AddScheduleFirstViewController {
          }
       }
       
-      self.viewModel.onReissueSuccess.bind { [weak self] onSuccess in
-         guard let onSuccess else { return }
-         if onSuccess {
-            // TODO: - 서버 통신 재시도
-         } else {
-            self?.navigationController?.pushViewController(SplashViewController(splashViewModel: SplashViewModel()), animated: false)
-         }
-      }
-      
       viewModel.ispastDateVaild.bind { [weak self] isValid in
          guard let self = self else { return }
          self.viewModel.fetchPastDate()

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/AddSchedule/Views/AddScheduleSecond/AddScheduleSecondViewController.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/AddSchedule/Views/AddScheduleSecond/AddScheduleSecondViewController.swift
@@ -156,7 +156,7 @@ private extension AddScheduleSecondViewController {
       self.viewModel.onReissueSuccess.bind { [weak self] onSuccess in
          guard let onSuccess else { return }
          if onSuccess {
-            // TODO: - 서버 통신 재시도
+             self?.viewModel.postAddScheduel()
          } else {
             self?.navigationController?.pushViewController(SplashViewController(splashViewModel: SplashViewModel()), animated: false)
          }

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/Banner/Views/BannerDetailViewController.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/Banner/Views/BannerDetailViewController.swift
@@ -56,7 +56,6 @@ final class BannerDetailViewController: BaseViewController {
     override func viewIsAppearing(_ animated: Bool) {
         super.viewIsAppearing(animated)
         
-        self.courseDetailViewModel.setBannerDetailLoading()
         self.courseDetailViewModel.getBannerDetail(advertismentId: advertismentId)
     }
     
@@ -83,11 +82,14 @@ final class BannerDetailViewController: BaseViewController {
     }
     
     func bindViewModel() {
+        self.courseDetailViewModel.isSuccessGetBannerData.bind { [weak self] onSuccess in
+            guard let onSuccess  else { return }
+            self?.courseDetailViewModel.onLoading.value = !onSuccess
+        }
+        
         self.courseDetailViewModel.onReissueSuccess.bind { [weak self] onSuccess in
-            guard let onSuccess, let advertisementId = self?.courseDetailViewModel.advertisementId 
-            else { return }
+            guard let onSuccess, let advertisementId = self?.courseDetailViewModel.advertisementId else { return }
             if onSuccess {
-                self?.courseDetailViewModel.setBannerDetailLoading()
                 self?.courseDetailViewModel.getBannerDetail(advertismentId: advertisementId)
             } else {
                 self?.navigationController?.pushViewController(SplashViewController(splashViewModel: SplashViewModel()), animated: false)
@@ -197,7 +199,6 @@ extension BannerDetailViewController: UICollectionViewDataSource {
         
     }
     
-    // TODO: - switch 문으로 변경
     func collectionView(_ collectionView: UICollectionView, viewForSupplementaryElementOfKind kind: String, at indexPath: IndexPath) -> UICollectionReusableView {
         
         let imageData = self.courseDetailViewModel.imageData.value ?? []

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/Banner/Views/BannerDetailViewController.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/Banner/Views/BannerDetailViewController.swift
@@ -114,7 +114,7 @@ final class BannerDetailViewController: BaseViewController {
                     self?.setNavBar()
                     self?.bannerDetailView.mainCollectionView.reloadData()
                     self?.bannerDetailView.isHidden = false
-                    DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) {
+                    DispatchQueue.main.asyncAfter(deadline: .now() + 0.2) {
                         self?.hideLoadingView()
                     }
                 }

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/Banner/Views/BannerDetailViewController.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/Banner/Views/BannerDetailViewController.swift
@@ -97,11 +97,15 @@ final class BannerDetailViewController: BaseViewController {
         }
         
         self.courseDetailViewModel.onFailNetwork.bind { [weak self] onFailure in
-            guard let onFailure else { return }
-            if onFailure {
-                let errorVC = DRErrorViewController()
-                self?.navigationController?.pushViewController(errorVC, animated: false)
-            }
+           guard let onFailure else { return }
+           if onFailure {
+              let errorVC = DRErrorViewController()
+              errorVC.onDismiss = {
+                 self?.courseDetailViewModel.onFailNetwork.value = false
+                 self?.courseDetailViewModel.onLoading.value = false
+              }
+              self?.navigationController?.pushViewController(errorVC, animated: false)
+           }
         }
         
         self.courseDetailViewModel.onLoading.bind { [weak self] onLoading in

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/Base/BaseNavBarViewController.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/Base/BaseNavBarViewController.swift
@@ -56,7 +56,7 @@ class BaseNavBarViewController: UIViewController {
       navigationBarView.snp.makeConstraints {
          $0.top.equalTo(topInsetView.snp.bottom)
          $0.horizontalEdges.equalToSuperview()
-         $0.height.equalTo(55) //임시 네비바 높이
+         $0.height.equalTo(55)
       }
       
       contentView.snp.makeConstraints {
@@ -66,12 +66,12 @@ class BaseNavBarViewController: UIViewController {
       
       leftButton.snp.makeConstraints {
          $0.centerY.equalToSuperview()
-         $0.leading.equalToSuperview() //탭바 확정 후 다시 수정 - 메인화면 로고 패딩과 다른 백버튼 패딩이 다름
+         $0.leading.equalToSuperview()
       }
       
       rightButton.snp.makeConstraints {
          $0.centerY.equalToSuperview()
-         $0.trailing.equalToSuperview()//탭바 확정 후 다시 수정 - 메인화면 로고 패딩과 다른 백버튼 패딩이 다름 22
+         $0.trailing.equalToSuperview()
       }
       
       titleLabel.snp.makeConstraints {

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/Commons/LocationFilter/Views/LocationFilterView.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/Commons/LocationFilter/Views/LocationFilterView.swift
@@ -15,7 +15,7 @@ protocol LocationFilterViewDelegate: AnyObject {
     func didTapApplyButton()
 }
 
-class LocationFilterView: BaseView {
+final class LocationFilterView: BaseView {
     
     // MARK: - UI Properties
     

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/Commons/LocationFilter/Views/LocationFilterViewController.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/Commons/LocationFilter/Views/LocationFilterViewController.swift
@@ -15,7 +15,7 @@ protocol LocationFilterDelegate: AnyObject {
    func getCourse()
 }
 
-class LocationFilterViewController: BaseViewController {
+final class LocationFilterViewController: BaseViewController {
    
    // MARK: - UI Properties
    

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/Course/ViewModels/CourseViewModel.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/Course/ViewModels/CourseViewModel.swift
@@ -109,13 +109,10 @@ extension CourseViewModel {
                 self.patchReissue { isSuccess in
                     self.onReissueSuccess.value = isSuccess
                 }
-            case .serverErr:
-                self.onFailNetwork.value = true
             default:
-                self.isSuccessGetData.value = false
+                self.onFailNetwork.value = true
                 print("Failed to fetch course data")
             }
-            self.setLoading()
         }
     }
     

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/Course/Views/CourseFilterView.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/Course/Views/CourseFilterView.swift
@@ -15,7 +15,7 @@ protocol CourseFilterViewDelegate: AnyObject {
     func didTapResetButton()
 }
 
-class CourseFilterView: BaseView {
+final class CourseFilterView: BaseView {
     
     // MARK: - UI Properties
     

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/Course/Views/CourseNavigationBarView.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/Course/Views/CourseNavigationBarView.swift
@@ -14,7 +14,7 @@ protocol CourseNavigationBarViewDelegate: AnyObject {
     func didTapAddCourseButton()
 }
 
-class CourseNavigationBarView: BaseView {
+final class CourseNavigationBarView: BaseView {
     
     // MARK: - UI Properties
     

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/Course/Views/CourseView.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/Course/Views/CourseView.swift
@@ -10,7 +10,7 @@ import UIKit
 import SnapKit
 import Then
 
-class CourseView: BaseView {
+final class CourseView: BaseView {
     
     // MARK: - UI Properties
    

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/Course/Views/CourseViewController.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/Course/Views/CourseViewController.swift
@@ -85,11 +85,15 @@ final class CourseViewController: BaseViewController {
     func bindViewModel() {
         
         self.courseViewModel.onFailNetwork.bind { [weak self] onFailure in
-            guard let onFailure else { return }
-            if onFailure {
-                let errorVC = DRErrorViewController()
-                self?.navigationController?.pushViewController(errorVC, animated: false)
-            }
+           guard let onFailure else { return }
+           if onFailure {
+              let errorVC = DRErrorViewController()
+              errorVC.onDismiss = {
+                 self?.courseViewModel.onFailNetwork.value = false
+                 self?.courseViewModel.onLoading.value = false
+              }
+              self?.navigationController?.pushViewController(errorVC, animated: false)
+           }
         }
         
         self.courseViewModel.onLoading.bind { [weak self] onLoading in
@@ -121,8 +125,7 @@ final class CourseViewController: BaseViewController {
             }
         }
         
-        courseViewModel.isSuccessGetData.bind { [weak self] isSuccess in
-            guard let isSuccess else { return }
+        self.courseViewModel.isSuccessGetData.bind { [weak self] _ in
             self?.courseViewModel.setLoading()
         }
         

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/Course/Views/CourseViewController.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/Course/Views/CourseViewController.swift
@@ -115,7 +115,7 @@ final class CourseViewController: BaseViewController {
         self.courseViewModel.onReissueSuccess.bind { [weak self] onSuccess in
             guard let onSuccess else { return }
             if onSuccess {
-                // TODO: - 서버 통신 재시도
+                self?.getCourse()
             } else {
                 self?.navigationController?.pushViewController(SplashViewController(splashViewModel: SplashViewModel()), animated: false)
             }

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/Course/Views/CourseViewController.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/Course/Views/CourseViewController.swift
@@ -49,7 +49,6 @@ final class CourseViewController: BaseViewController {
     
     override func viewWillAppear(_ animated: Bool) {
         self.tabBarController?.tabBar.isHidden = false
-        self.courseViewModel.setLoading()
         getCourse()
         courseViewModel.fetchPriceData()
     }
@@ -103,7 +102,7 @@ final class CourseViewController: BaseViewController {
                         self?.tabBarController?.tabBar.isHidden = true
                     } else {
                         self?.courseView.courseListView.courseListCollectionView.reloadData()
-                        DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
+                        DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) {
                             self?.courseView.isHidden = false
                             self?.tabBarController?.tabBar.isHidden = false
                             self?.hideLoadingView()
@@ -124,9 +123,7 @@ final class CourseViewController: BaseViewController {
         
         courseViewModel.isSuccessGetData.bind { [weak self] isSuccess in
             guard let isSuccess else { return }
-            if isSuccess {
-                self?.courseViewModel.setLoading()
-            }
+            self?.courseViewModel.setLoading()
         }
         
         self.courseViewModel.selectedPriceIndex.bind { [weak self] index in

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/Course/Views/CourseViewController.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/Course/Views/CourseViewController.swift
@@ -102,7 +102,7 @@ final class CourseViewController: BaseViewController {
                         self?.tabBarController?.tabBar.isHidden = true
                     } else {
                         self?.courseView.courseListView.courseListCollectionView.reloadData()
-                        DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) {
+                        DispatchQueue.main.asyncAfter(deadline: .now() + 0.2) {
                             self?.courseView.isHidden = false
                             self?.tabBarController?.tabBar.isHidden = false
                             self?.hideLoadingView()

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/CourseDetail/Cells/ImageCarouselCell.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/CourseDetail/Cells/ImageCarouselCell.swift
@@ -27,9 +27,7 @@ final class ImageCarouselCell: BaseCollectionViewCell {
     var thumbnailModel: ThumbnailModel?
     
     let pageViewController = UIPageViewController(transitionStyle: .scroll, navigationOrientation: .horizontal)
-    
-    static let identifier: String = "ImageCarouselCell"
-    
+        
     weak var delegate: ImageCarouselDelegate?
     
     override init(frame: CGRect) {

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/CourseDetail/Cells/TagInfoCell.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/CourseDetail/Cells/TagInfoCell.swift
@@ -45,6 +45,7 @@ final class TagInfoCell: BaseCollectionViewCell {
 }
 
 extension TagInfoCell {
+    
     func setCell(tag: String) {
         guard let tendencyTag = TendencyTag.getTag(byEnglish: tag) else { return }
         tagButton.do {

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/CourseDetail/Cells/TimelineInfoCell.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/CourseDetail/Cells/TimelineInfoCell.swift
@@ -7,7 +7,7 @@
 
 import UIKit
 
-class TimelineInfoCell: BaseCollectionViewCell {
+final class TimelineInfoCell: BaseCollectionViewCell {
 
     // MARK: - UI Properties
     

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/CourseDetail/Cells/TitleInfoCell.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/CourseDetail/Cells/TitleInfoCell.swift
@@ -18,6 +18,7 @@ final class TitleInfoCell: BaseCollectionViewCell {
     private let titleLabel = UILabel()
     
     
+    // MARK: - Life Cycles
     
     override func setHierarchy() {
         

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/CourseDetail/Models/CourseDetailModel.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/CourseDetail/Models/CourseDetailModel.swift
@@ -21,10 +21,6 @@ struct ConditionalModel {
         self.totalPoint = totalPoint
         self.isUserLiked = isUserLiked
     }
-    
-    static var conditionalDummyData: ConditionalModel {
-        return ConditionalModel(courseId: 0, isCourseMine: true, isAccess: true, free: 0, totalPoint: 0, isUserLiked: true)
-    }
 }
 
 
@@ -40,25 +36,11 @@ struct TitleHeaderModel {
     var cost: Int
     var totalTime: Double
     var city: String
-    
-    static var titleHeaderDummyData: TitleHeaderModel {
-        return TitleHeaderModel(date: "2024.7.14", title: "만원으로 데이트 하기 챌린지", cost: 10000, totalTime: 10.5, city: "건대/성수/왕십리")
-    }
 }
 
 
 struct MainContentsModel {
     var description: String
-    
-    static var descriptionDummyData: MainContentsModel {
-        return MainContentsModel(description: """
-5년차 장기연애 커플이 보장하는 성수동 당일치기 데이트 코스를 소개해 드릴게요. 저희 커플은 12시에 만나서 브런치 집을 갔어요. 여기에서는 프렌치 토스트를 꼭 시키세요. 강추합니다.
-                                 
-1시간 정도 밥을 먹고 바로 성수미술관에 가서 그림을 그렸는데요. 물감이 튈 수 있어서 흰색 옷은 피하는 것을 추천드려요. 2시간 정도 소요가 되는데 저희는 예약을 해둬서 웨이팅 없이 바로 입장했고, 네이버 예약을 이용했습니다. 평일 기준 20,000원이니 꼭 예약해서 가세요!
-
-미술관에서 나와서는 어니언 카페에 가서 팡도르를 먹었습니다. 일찍 안 가면 없다고 하니 꼭 일찍 가세요!
-""")
-    }
 }
 
 struct TimelineModel {
@@ -71,11 +53,6 @@ struct TimelineModel {
         self.title = title
         self.duration = duration
     }
-    
-    static let timelineContents: [TimelineModel] = [
-        TimelineModel(sequence: 1, title: "플롭 안국점", duration: 0.5),
-        TimelineModel(sequence: 1, title: "플롭 안국점", duration: 0.5)
-    ]
 }
 
 
@@ -83,16 +60,10 @@ struct TimelineModel {
 
 struct CoastModel {
     let totalCoast: Int
-    
-    static var coastDummyData: CoastModel {
-        return CoastModel(totalCoast: 10000)
-    }
 }
 
 
 struct TagModel {
     let tag: String
-    
-    static var tagDummyData: [TagModel] = []
 }
 

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/CourseDetail/Models/CourseDetailModel.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/CourseDetail/Models/CourseDetailModel.swift
@@ -43,6 +43,7 @@ struct MainContentsModel {
     var description: String
 }
 
+
 struct TimelineModel {
     let sequence: Int
     let title: String
@@ -54,8 +55,6 @@ struct TimelineModel {
         self.duration = duration
     }
 }
-
-
 
 
 struct CoastModel {

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/CourseDetail/ViewModels/CourseDetailViewModel.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/CourseDetail/ViewModels/CourseDetailViewModel.swift
@@ -173,7 +173,7 @@ extension CourseDetailViewModel {
     
     
     func postUsePoint(courseId: Int, request: PostUsePointRequest) {
-        UsePointService().postUsePoint(courseId: self.courseId, request: request)  { result in
+        NetworkService.shared.usePointService.postUsePoint(courseId: self.courseId, request: request)  { result in
             switch result {
             case .success(let response):
                 self.isAccess.value = true

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/CourseDetail/ViewModels/CourseDetailViewModel.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/CourseDetail/ViewModels/CourseDetailViewModel.swift
@@ -7,20 +7,8 @@
 
 import UIKit
 
-enum CourseDetailSection {
-    case imageCarousel
-    case titleInfo
-    case mainContents
-    case timelineInfo
-    case coastInfo
-    case tagInfo
-    
-    static var dataSource: [CourseDetailSection] {
-        return [.imageCarousel, .titleInfo, .mainContents, .timelineInfo, .coastInfo, .tagInfo]
-    }
-}
 
-class CourseDetailViewModel: Serviceable {
+final class CourseDetailViewModel: Serviceable {
     
     var courseId: Int
     
@@ -204,29 +192,19 @@ extension CourseDetailViewModel {
     
     func deleteCourse(completion: @escaping (Bool) -> Void) {
         NetworkService.shared.courseDetailService.deleteCourse(courseId: courseId) { (success: Bool) in
-            if success {
-                completion(success)
-            }
+            completion(success)
         }
     }
     
-    func likeCourse(courseId: Int) {
-        LikeCourseService().likeCourse(courseId: courseId) { success in
-            if success {
-                
-            } else {
-                print("ffsdasdfsadfsadfsdfdsafs")
-            }
+    func likeCourse(courseId: Int, completion: @escaping (Bool) -> Void) {
+        NetworkService.shared.likedCourseService.likeCourse(courseId: courseId) { success in
+            completion(success)
         }
     }
     
-    func deleteLikeCourse(courseId: Int) {
-        LikeCourseService().deleteLikeCourse(courseId: courseId) { success in
-            if success {
-                
-            } else {
-                print("dfsadfasdsfasdfadsfdsasf")
-            }
+    func deleteLikeCourse(courseId: Int, completion: @escaping (Bool) -> Void) {
+        NetworkService.shared.likedCourseService.deleteLikeCourse(courseId: courseId) { success in
+            completion(success)
         }
     }
     

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/CourseDetail/ViewModels/CourseDetailViewModel.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/CourseDetail/ViewModels/CourseDetailViewModel.swift
@@ -121,7 +121,10 @@ class CourseDetailViewModel: Serviceable {
 extension CourseDetailViewModel {
     
     func getCourseDetail() {
+        self.isSuccessGetData.value = false
         setLoading()
+        self.onFailNetwork.value = false
+
         NetworkService.shared.courseDetailService.getCourseDetailInfo(courseId: courseId){ response in
             switch response {
             case .success(let data):
@@ -173,7 +176,7 @@ extension CourseDetailViewModel {
                     self.onReissueSuccess.value = isSuccess
                 }
             default:
-                self.isSuccessGetData.value = false
+                self.onFailNetwork.value = true
                 print("Failed to fetch course data")
             }
         }

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/CourseDetail/ViewModels/CourseDetailViewModel.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/CourseDetail/ViewModels/CourseDetailViewModel.swift
@@ -231,6 +231,7 @@ extension CourseDetailViewModel {
     
     func getBannerDetail(advertismentId: Int) {
         self.isSuccessGetBannerData.value = false
+        self.setBannerDetailLoading()
         self.onFailNetwork.value = false
         
         NetworkService.shared.courseDetailService.getBannerDetailInfo(advertismentId: advertismentId){ response in
@@ -245,13 +246,10 @@ extension CourseDetailViewModel {
                 self.patchReissue { isSuccess in
                     self.onReissueSuccess.value = isSuccess
                 }
-            case .serverErr:
-                self.onFailNetwork.value = true
             default:
-                self.isSuccessGetBannerData.value = false
+                self.onFailNetwork.value = true
                 print("Failed to fetch banner detail data")
             }
-            self.setBannerDetailLoading()
         }
     }
     
@@ -261,16 +259,8 @@ extension CourseDetailViewModel {
     }
     
     func setLoading() {
-        guard let isSuccessGetData = self.isSuccessGetData.value else {
-            return
-        }
-        
-        if isSuccessGetData {
-            self.onLoading.value = false
-        } else {
-            self.onLoading.value = true
-        }
+        guard let isSuccessGetData = self.isSuccessGetData.value else { return }
+        self.onLoading.value = !isSuccessGetData
     }
-
     
 }

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/CourseDetail/Views/BottomPageControllView.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/CourseDetail/Views/BottomPageControllView.swift
@@ -11,7 +11,7 @@ import SnapKit
 import Then
 
 
-class BottomPageControllView: UICollectionReusableView {
+final class BottomPageControllView: UICollectionReusableView {
     
     // MARK: - UI Properties
     

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/CourseDetail/Views/ContentMaskView.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/CourseDetail/Views/ContentMaskView.swift
@@ -15,7 +15,7 @@ protocol ContentMaskViewDelegate: AnyObject {
     func didTapViewButton()
 }
 
-class ContentMaskView: UICollectionReusableView {
+final class ContentMaskView: UICollectionReusableView {
     
     // MARK: - UI Properties
     
@@ -35,9 +35,9 @@ class ContentMaskView: UICollectionReusableView {
     
     weak var delegate: ContentMaskViewDelegate?
     
-    static let elementKinds: String = "ContentMaskView"
+    static let elementKinds: String = StringLiterals.Elementkinds.contentMaskView
     
-    static let identifier: String = "ContentMaskView"
+    static let identifier: String = StringLiterals.Elementkinds.contentMaskView
     
     // MARK: - Life Cycle
     

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/CourseDetail/Views/CourseDetailBottomTabBarView.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/CourseDetail/Views/CourseDetailBottomTabBarView.swift
@@ -8,8 +8,7 @@ import SnapKit
 import Then
 
 
-
-class CourseDetailBottomTabBarView: BaseView {
+final class CourseDetailBottomTabBarView: BaseView {
     
     // MARK: - UI Properties
     

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/CourseDetail/Views/CourseDetailView.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/CourseDetail/Views/CourseDetailView.swift
@@ -10,7 +10,7 @@ import UIKit
 import SnapKit
 import Then
 
-class CourseDetailView: BaseView {
+final class CourseDetailView: BaseView {
     
     // MARK: - UI Properties
     

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/CourseDetail/Views/CourseDetailViewController.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/CourseDetail/Views/CourseDetailViewController.swift
@@ -126,13 +126,16 @@ final class CourseDetailViewController: BaseViewController {
     }
     
     func bindViewModel() {
-        
         self.courseDetailViewModel.onFailNetwork.bind { [weak self] onFailure in
-            guard let onFailure else { return }
-            if onFailure {
-                let errorVC = DRErrorViewController()
-                self?.navigationController?.pushViewController(errorVC, animated: false)
-            }
+           guard let onFailure else { return }
+           if onFailure {
+              let errorVC = DRErrorViewController()
+              errorVC.onDismiss = {
+                 self?.courseDetailViewModel.onFailNetwork.value = false
+                  self?.courseDetailViewModel.onLoading.value = false
+              }
+              self?.navigationController?.pushViewController(errorVC, animated: false)
+           }
         }
         
         self.courseDetailViewModel.onLoading.bind { [weak self] onLoading in

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/CourseDetail/Views/CourseDetailViewController.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/CourseDetail/Views/CourseDetailViewController.swift
@@ -138,8 +138,21 @@ final class CourseDetailViewController: BaseViewController {
         self.courseDetailViewModel.onLoading.bind { [weak self] onLoading in
             guard let onLoading, let onFailNetwork = self?.courseDetailViewModel.onFailNetwork.value else { return }
             if !onFailNetwork {
-                onLoading ? self?.showLoadingView() : self?.hideLoadingView()
-                self?.courseDetailView.isHidden = onLoading
+                if onLoading {
+                    self?.showLoadingView()
+                    self?.courseDetailView.isHidden = onLoading
+                } else {
+                    self?.localLikeNum = self?.courseDetailViewModel.likeSum.value ?? 0
+                    self?.setSetctionCount()
+                    self?.setTabBarVisibility()
+                    self?.setNavBarVisibility()
+                    self?.courseDetailView.mainCollectionView.reloadData()
+                    
+                    DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) {
+                        self?.courseDetailView.isHidden = onLoading
+                        self?.hideLoadingView()
+                    }
+                }
             }
         }
         
@@ -162,14 +175,6 @@ final class CourseDetailViewController: BaseViewController {
         courseDetailViewModel.isSuccessGetData.bind { [weak self] isSuccess in
             guard let isSuccess else { return }
             self?.courseDetailViewModel.setLoading()
-            
-            if isSuccess {
-                self?.localLikeNum = self?.courseDetailViewModel.likeSum.value ?? 0
-                self?.setSetctionCount()
-                self?.setTabBarVisibility()
-                self?.setNavBarVisibility()
-                self?.courseDetailView.mainCollectionView.reloadData()
-            }
         }
         
         courseDetailViewModel.isAccess.bind { [weak self] isAccess in

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/CourseDetail/Views/CourseDetailViewController.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/CourseDetail/Views/CourseDetailViewController.swift
@@ -159,7 +159,7 @@ final class CourseDetailViewController: BaseViewController {
         self.courseDetailViewModel.onReissueSuccess.bind { [weak self] onSuccess in
             guard let onSuccess else { return }
             if onSuccess {
-                // TODO: - 서버 통신 재시도
+                self?.courseDetailViewModel.getCourseDetail()
             } else {
                 self?.navigationController?.pushViewController(SplashViewController(splashViewModel: SplashViewModel()), animated: false)
             }

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/CourseDetail/Views/CourseDetailViewController.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/CourseDetail/Views/CourseDetailViewController.swift
@@ -148,7 +148,7 @@ final class CourseDetailViewController: BaseViewController {
                     self?.setNavBarVisibility()
                     self?.courseDetailView.mainCollectionView.reloadData()
                     
-                    DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) {
+                    DispatchQueue.main.asyncAfter(deadline: .now() + 0.2) {
                         self?.courseDetailView.isHidden = onLoading
                         self?.hideLoadingView()
                     }

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/CourseDetail/Views/CourseDetailViewController.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/CourseDetail/Views/CourseDetailViewController.swift
@@ -211,7 +211,7 @@ extension CourseDetailViewController: DRCustomAlertDelegate {
         case .checkCourse:
             handleCourseAccess()
         case .declareCourse:
-            present(DRWebViewController(urlString: "https://tally.so/r/w4L1a5"), animated: true)
+            present(DRWebViewController(urlString: StringLiterals.WebView.declareLink), animated: true)
         case .deleteCourse:
             deleteCourse()
         default:
@@ -226,14 +226,14 @@ extension CourseDetailViewController: DRCustomAlertDelegate {
         
         if courseDetailViewModel.haveFreeCount.value == true {
             //무료 열람 기회 사용
-            let request = PostUsePointRequest(point: 50, type: "POINT_USED", description: "무료 열람 기회 사용")
+            let request = PostUsePointRequest(point: 50, type: StringLiterals.CourseDetail.pointUsed, description: StringLiterals.CourseDetail.usedFreeView)
             self.courseDetailViewModel.postUsePoint(courseId: courseId, request: request)
             self.courseDetailViewModel.isAccess.value = true
             dismiss(animated: false)
         } else {
             if courseDetailViewModel.havePoint.value == true {
                 //포인트로 구입
-                let request = PostUsePointRequest(point: 50, type: "POINT_USED", description: StringLiterals.CourseDetail.viewCourse)
+                let request = PostUsePointRequest(point: 50, type: StringLiterals.CourseDetail.pointUsed, description: StringLiterals.CourseDetail.viewCourse)
                 self.courseDetailViewModel.postUsePoint(courseId: courseId, request: request)
                 self.courseDetailViewModel.isAccess.value = true
                 dismiss(animated: false)
@@ -255,6 +255,7 @@ extension CourseDetailViewController: DRCustomAlertDelegate {
                     self?.navigationController?.popViewController(animated: true)
                 } else {
                     print("삭제 실패 ㅠ")
+                    self?.presentAlertVC(title: StringLiterals.Alert.failToDeleteCourse)
                 }
             }
         }
@@ -325,7 +326,7 @@ extension CourseDetailViewController: ContentMaskViewDelegate {
         )
     }
     
-    func presentCustomAlert(title: String, description: String, action: RightButtonType, buttonText: String = "확인") {
+    func presentCustomAlert(title: String, description: String, action: RightButtonType, buttonText: String = StringLiterals.Alert.confirm) {
         let alertVC = DRCustomAlertViewController(
             rightActionType: action,
             alertTextType: .hasDecription,
@@ -412,7 +413,13 @@ private extension CourseDetailViewController {
         courseDetailViewModel.isUserLiked.value?.toggle()
         
         let likeAction = isLiked ? courseDetailViewModel.deleteLikeCourse : courseDetailViewModel.likeCourse
-        likeAction(courseId ?? 0)
+        likeAction(courseId ?? 0) { [weak self] isSuccess in
+            DispatchQueue.main.async {
+                if !isSuccess {
+                    isLiked ? self?.presentAlertVC(title: StringLiterals.Alert.failToDeleteLike) : self?.presentAlertVC(title: StringLiterals.Alert.failToAddLike)
+                }
+            }
+        }
         
         self.courseDetailView.mainCollectionView.reloadData()
     }

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/CourseDetail/Views/GradientView.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/CourseDetail/Views/GradientView.swift
@@ -10,7 +10,7 @@ import UIKit
 import SnapKit
 import Then
 
-class GradientView: UICollectionReusableView {
+final class GradientView: UICollectionReusableView {
     
     // MARK: - UI Properties
     

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/CourseDetail/Views/InfoBarView.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/CourseDetail/Views/InfoBarView.swift
@@ -10,7 +10,7 @@ import UIKit
 import SnapKit
 import Then
 
-class InfoBarView: UICollectionReusableView {
+final class InfoBarView: UICollectionReusableView {
     
     // MARK: - UI Properties
     

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/CourseDetail/Views/InfoHeaderView.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/CourseDetail/Views/InfoHeaderView.swift
@@ -10,7 +10,7 @@ import UIKit
 import SnapKit
 import Then
 
-class InfoHeaderView: UICollectionReusableView {
+final class InfoHeaderView: UICollectionReusableView {
     
     // MARK: - UI Properties
     

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/CourseDetail/Views/StickyHeaderNavBarView.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/CourseDetail/Views/StickyHeaderNavBarView.swift
@@ -36,10 +36,6 @@ final class StickyHeaderNavBarView: UIView {
     required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
-}
-
-
-private extension StickyHeaderNavBarView {
     
     func setHierarchy() {
         self.addSubviews(previousButton, moreButton)
@@ -77,6 +73,10 @@ private extension StickyHeaderNavBarView {
             $0.addTarget(self, action: #selector(didTapMoreButton), for: .touchUpInside)
         }
     }
+}
+
+
+private extension StickyHeaderNavBarView {
     
     @objc
     func didTapPreviousButton() {

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/CourseDetail/Views/TimelineHeaderView.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/CourseDetail/Views/TimelineHeaderView.swift
@@ -10,7 +10,7 @@ import UIKit
 import SnapKit
 import Then
 
-class TimelineHeaderView: UICollectionReusableView {
+final class TimelineHeaderView: UICollectionReusableView {
     
     // MARK: - UI Properties
     

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/CourseDetail/Views/VisitDateView.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/CourseDetail/Views/VisitDateView.swift
@@ -10,7 +10,7 @@ import UIKit
 import SnapKit
 import Then
 
-class VisitDateView: UICollectionReusableView {
+final class VisitDateView: UICollectionReusableView {
     
     // MARK: - UI Properties
     

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/DateSchedule/Model/DateScheduleModel.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/DateSchedule/Model/DateScheduleModel.swift
@@ -23,6 +23,10 @@ struct DateCardModel {
         self.tags = tags
         self.dDay = dDay
     }
+    
+    static var emptyData: DateCardModel {
+        return DateCardModel(dateID: 0, title: "", date: "", city: "", tags: [], dDay: 0)
+    }
 }
 
 struct TagsModel {

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/DateSchedule/View/DateDetailContentView.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/DateSchedule/View/DateDetailContentView.swift
@@ -7,7 +7,7 @@
 
 import UIKit
 
-class DateDetailContentView: BaseView {
+final class DateDetailContentView: BaseView {
 
     // MARK: - UI Properties
     

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/DateSchedule/View/PastDateContentView.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/DateSchedule/View/PastDateContentView.swift
@@ -10,7 +10,7 @@ import UIKit
 import SnapKit
 import Then
 
-class PastDateContentView: BaseView {
+final class PastDateContentView: BaseView {
     
     // MARK: - UI Properties
     

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/DateSchedule/View/PastDateDetailViewController.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/DateSchedule/View/PastDateDetailViewController.swift
@@ -165,25 +165,27 @@ extension PastDateDetailViewController {
             }
         }
         
-        self.pastDateDetailViewModel.isSuccessGetDateDetailData.bind { [weak self] isSuccess in
-            guard let isSuccess else { return }
+        self.pastDateDetailViewModel.isSuccessGetDateDetailData.bind { [weak self] _ in
             self?.pastDateDetailViewModel.setDateDetailLoading()
         }
         
         self.pastDateDetailViewModel.isSuccessDeleteDateScheduleData.bind { [weak self] isSuccess in
             guard let isSuccess else { return }
             if isSuccess {
-                self?.navigationController?.popViewController(animated: true)
+                self?.navigationController?.popViewController(animated: false)
             }
         }
         
         self.pastDateDetailViewModel.onFailNetwork.bind { [weak self] onFailure in
-            guard let onFailure else { return }
-            if onFailure {
-                self?.hideLoadingView()
-                let errorVC = DRErrorViewController()
-                self?.navigationController?.pushViewController(errorVC, animated: false)
-            }
+           guard let onFailure else { return }
+           if onFailure {
+              let errorVC = DRErrorViewController()
+              errorVC.onDismiss = {
+                 self?.pastDateDetailViewModel.onFailNetwork.value = false
+                 self?.pastDateDetailViewModel.onDateDetailLoading.value = false
+              }
+              self?.navigationController?.pushViewController(errorVC, animated: false)
+           }
         }
     }
     

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/DateSchedule/View/PastDateDetailViewController.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/DateSchedule/View/PastDateDetailViewController.swift
@@ -23,6 +23,8 @@ final class PastDateDetailViewController: BaseNavBarViewController {
     
     var dateID: Int
     
+    var networkType: NetworkType?
+    
     var pastDateDetailViewModel: DateDetailViewModel
     
     private let dateScheduleDeleteView = DateScheduleDeleteView()
@@ -148,9 +150,16 @@ extension PastDateDetailViewController {
          }
         
         self.pastDateDetailViewModel.onReissueSuccess.bind { [weak self] onSuccess in
-            guard let onSuccess else { return }
+            guard let onSuccess, let dateID = self?.dateID else { return }
             if onSuccess {
-                // TODO: - 서버 통신 재시도
+                switch self?.networkType {
+                case .deleteDateSchedule:
+                    self?.pastDateDetailViewModel.deleteDateSchdeuleData(dateID: dateID)
+                case .getDateDetail:
+                    self?.pastDateDetailViewModel.getDateDetailData(dateID: dateID)
+                default:
+                    self?.navigationController?.pushViewController(SplashViewController(splashViewModel: SplashViewModel()), animated: false)
+                }
             } else {
                 self?.navigationController?.pushViewController(SplashViewController(splashViewModel: SplashViewModel()), animated: false)
             }

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/DateSchedule/View/PastDateDetailViewController.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/DateSchedule/View/PastDateDetailViewController.swift
@@ -86,7 +86,7 @@ extension PastDateDetailViewController: DRCustomAlertDelegate {
                                                         alertButtonType: .twoButton,
                                                         titleText: StringLiterals.Alert.deletePastDateSchedule,
                                                         descriptionText: StringLiterals.Alert.noMercy,
-                                                        rightButtonText: "삭제")
+                                                        rightButtonText: StringLiterals.Alert.delete)
         customAlertVC.delegate = self
         customAlertVC.modalPresentationStyle = .overFullScreen
         self.present(customAlertVC, animated: false)

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/DateSchedule/View/PastDateDetailViewController.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/DateSchedule/View/PastDateDetailViewController.swift
@@ -44,7 +44,6 @@ final class PastDateDetailViewController: BaseNavBarViewController {
     override func viewWillAppear(_ animated: Bool) {
         self.navigationController?.tabBarController?.tabBar.isHidden = true
         self.tabBarController?.tabBar.isHidden = true
-        self.pastDateDetailViewModel.setDateDetailLoading()
         self.pastDateDetailViewModel.getDateDetailData(dateID: self.dateID)
     }
     
@@ -128,14 +127,20 @@ extension PastDateDetailViewController {
     
     func bindViewModel() {
         self.pastDateDetailViewModel.onDateDetailLoading.bind { [weak self] onLoading in
-            guard let onLoading, let onFailNetwork = self?.pastDateDetailViewModel.onFailNetwork.value else { return }
+            guard let onLoading,
+                    let onFailNetwork = self?.pastDateDetailViewModel.onFailNetwork.value,
+                    let data = self?.pastDateDetailViewModel.dateDetailData.value
+            else { return }
             if !onFailNetwork {
                 if onLoading {
                     self?.showLoadingView()
                     self?.pastDateDetailContentView.isHidden = true
                 } else {
-                    self?.pastDateDetailContentView.isHidden = false
+                    self?.pastDateDetailContentView.dataBind(data)
+                    self?.pastDateDetailContentView.dateTimeLineCollectionView.reloadData()
+                    
                     DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) {
+                        self?.pastDateDetailContentView.isHidden = false
                         self?.hideLoadingView()
                     }
                 }
@@ -152,12 +157,8 @@ extension PastDateDetailViewController {
         }
         
         self.pastDateDetailViewModel.isSuccessGetDateDetailData.bind { [weak self] isSuccess in
-            guard let isSuccess, let data = self?.pastDateDetailViewModel.dateDetailData.value else { return }
-            if isSuccess {
-                self?.pastDateDetailContentView.dataBind(data)
-                self?.pastDateDetailContentView.dateTimeLineCollectionView.reloadData()
-                self?.pastDateDetailViewModel.setDateDetailLoading()
-            }
+            guard let isSuccess else { return }
+            self?.pastDateDetailViewModel.setDateDetailLoading()
         }
         
         self.pastDateDetailViewModel.isSuccessDeleteDateScheduleData.bind { [weak self] isSuccess in

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/DateSchedule/View/PastDateDetailViewController.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/DateSchedule/View/PastDateDetailViewController.swift
@@ -141,7 +141,7 @@ extension PastDateDetailViewController {
                     self?.pastDateDetailContentView.dataBind(data)
                     self?.pastDateDetailContentView.dateTimeLineCollectionView.reloadData()
                     
-                    DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) {
+                    DispatchQueue.main.asyncAfter(deadline: .now() + 0.2) {
                         self?.pastDateDetailContentView.isHidden = false
                         self?.hideLoadingView()
                     }

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/DateSchedule/View/PastDateViewController.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/DateSchedule/View/PastDateViewController.swift
@@ -39,7 +39,6 @@ final class PastDateViewController: BaseNavBarViewController {
     override func viewWillAppear(_ animated: Bool) {
         self.navigationController?.tabBarController?.tabBar.isHidden = true
         self.tabBarController?.tabBar.isHidden = true
-        self.pastDateScheduleViewModel.setPastScheduleLoading()
         self.pastDateScheduleViewModel.getPastDateScheduleData()
     }
 
@@ -77,8 +76,7 @@ final class PastDateViewController: BaseNavBarViewController {
 private extension PastDateViewController {
     
     func setEmptyView() {
-        guard let dataCount = pastDateScheduleViewModel.pastDateScheduleData.value?.count
-        else { return }
+        guard let dataCount = pastDateScheduleViewModel.pastDateScheduleData.value?.count else { return }
         pastDateContentView.emptyView.isHidden = !(dataCount == 0)
     }
 
@@ -100,10 +98,12 @@ private extension PastDateViewController {
                     self?.topInsetView.isHidden = onLoading
                     self?.navigationBarView.isHidden = onLoading
                 } else {
-                    self?.pastDateContentView.isHidden = onLoading
-                    self?.topInsetView.isHidden = onLoading
-                    self?.navigationBarView.isHidden = onLoading
+                    self?.pastDateContentView.pastDateCollectionView.reloadData()
                     DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) {
+                        self?.setEmptyView()
+                        self?.pastDateContentView.isHidden = onLoading
+                        self?.topInsetView.isHidden = onLoading
+                        self?.navigationBarView.isHidden = onLoading
                         self?.hideLoadingView()
                     }
                 }
@@ -113,7 +113,6 @@ private extension PastDateViewController {
         self.pastDateScheduleViewModel.onReissueSuccess.bind { [weak self] onSuccess in
             guard let onSuccess else { return }
             if onSuccess {
-                self?.pastDateScheduleViewModel.setPastScheduleLoading()
                 self?.pastDateScheduleViewModel.getPastDateScheduleData()
             } else {
                 self?.navigationController?.pushViewController(SplashViewController(splashViewModel: SplashViewModel()), animated: false)
@@ -122,20 +121,7 @@ private extension PastDateViewController {
         
         self.pastDateScheduleViewModel.isSuccessGetPastDateScheduleData.bind { [weak self] isSuccess in
             guard let isSuccess else { return }
-            if isSuccess {
-                self?.pastDateContentView.pastDateCollectionView.reloadData()
-                self?.setEmptyView()
-                self?.pastDateScheduleViewModel.setPastScheduleLoading()
-            }
-        }
-        
-        self.pastDateScheduleViewModel.onPastScheduleFailNetwork.bind { [weak self] onFailure in
-            guard let onFailure else { return }
-            if onFailure {
-                self?.hideLoadingView()
-                let errorVC = DRErrorViewController()
-                self?.navigationController?.pushViewController(errorVC, animated: false)
-            }
+            self?.pastDateScheduleViewModel.setPastScheduleLoading()
         }
     }
 }

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/DateSchedule/View/PastDateViewController.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/DateSchedule/View/PastDateViewController.swift
@@ -99,7 +99,7 @@ private extension PastDateViewController {
                     self?.navigationBarView.isHidden = onLoading
                 } else {
                     self?.pastDateContentView.pastDateCollectionView.reloadData()
-                    DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) {
+                    DispatchQueue.main.asyncAfter(deadline: .now() + 0.2) {
                         self?.setEmptyView()
                         self?.pastDateContentView.isHidden = onLoading
                         self?.topInsetView.isHidden = onLoading

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/DateSchedule/View/PastDateViewController.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/DateSchedule/View/PastDateViewController.swift
@@ -119,8 +119,7 @@ private extension PastDateViewController {
             }
         }
         
-        self.pastDateScheduleViewModel.isSuccessGetPastDateScheduleData.bind { [weak self] isSuccess in
-            guard let isSuccess else { return }
+        self.pastDateScheduleViewModel.isSuccessGetPastDateScheduleData.bind { [weak self] _ in
             self?.pastDateScheduleViewModel.setPastScheduleLoading()
         }
     }

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/DateSchedule/View/UpcomingDateDetailViewController.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/DateSchedule/View/UpcomingDateDetailViewController.swift
@@ -186,7 +186,6 @@ extension UpcomingDateDetailViewController: DRCustomAlertDelegate {
     
     @objc
     private func tapDeleteLabel() {
-        print("dfdsf")
         let customAlertVC = DRCustomAlertViewController(rightActionType: RightButtonType.deleteCourse, alertTextType: .hasDecription, alertButtonType: .twoButton, titleText: StringLiterals.Alert.deleteDateSchedule, descriptionText: StringLiterals.Alert.noMercy, rightButtonText: "삭제")
         customAlertVC.delegate = self
         customAlertVC.modalPresentationStyle = .overFullScreen
@@ -194,13 +193,10 @@ extension UpcomingDateDetailViewController: DRCustomAlertDelegate {
     }
 
     func action(rightButtonAction: RightButtonType) {
-           print("all")
            if rightButtonAction == .deleteCourse {
-               print("zz")
                upcomingDateDetailViewModel.deleteDateSchdeuleData(dateID: upcomingDateDetailViewModel.dateDetailData.value?.dateID ?? 0)
            } else if rightButtonAction == .kakaoShare {
                upcomingDateDetailViewModel.shareToKakao(context: self)
-               print("카카오 공유하기")
            }
        }
 }
@@ -218,13 +214,11 @@ extension UpcomingDateDetailViewController: DRBottomSheetDelegate {
     }
     
     func didTapBottomButton() {
-        print("hi")
         self.dismiss(animated: false)
     }
     
     @objc
     func didTapFirstLabel() {
-        print("sdjflksd ㅇㄴㄹㅁㄴㅇㄹ")
         self.dismiss(animated: false)
         tapDeleteLabel()
     }

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/DateSchedule/View/UpcomingDateDetailViewController.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/DateSchedule/View/UpcomingDateDetailViewController.swift
@@ -92,7 +92,7 @@ extension UpcomingDateDetailViewController {
                     self?.topInsetView.isHidden = onLoading
                     self?.navigationBarView.isHidden = onLoading
                 } else {
-                    DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) {
+                    DispatchQueue.main.asyncAfter(deadline: .now() + 0.2) {
                         self?.upcomingDateDetailContentView.isHidden = false
                         self?.topInsetView.isHidden = onLoading
                         self?.navigationBarView.isHidden = onLoading

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/DateSchedule/View/UpcomingDateDetailViewController.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/DateSchedule/View/UpcomingDateDetailViewController.swift
@@ -119,12 +119,15 @@ extension UpcomingDateDetailViewController {
         }
         
         self.upcomingDateDetailViewModel.onFailNetwork.bind { [weak self] onFailure in
-            guard let onFailure else { return }
-            if onFailure {
-                self?.hideLoadingView()
-                let errorVC = DRErrorViewController()
-                self?.navigationController?.pushViewController(errorVC, animated: false)
-            }
+           guard let onFailure else { return }
+           if onFailure {
+              let errorVC = DRErrorViewController()
+              errorVC.onDismiss = {
+                 self?.upcomingDateDetailViewModel.onFailNetwork.value = false
+                 self?.upcomingDateDetailViewModel.onDateDetailLoading.value = false
+              }
+              self?.navigationController?.pushViewController(errorVC, animated: false)
+           }
         }
         
         self.upcomingDateDetailViewModel.isSuccessGetDateDetailData.bind { [weak self] isSuccess in
@@ -139,7 +142,7 @@ extension UpcomingDateDetailViewController {
         self.upcomingDateDetailViewModel.isSuccessDeleteDateScheduleData.bind { [weak self] isSuccess in
             guard let isSuccess else { return }
             if isSuccess {
-                self?.navigationController?.popViewController(animated: true)
+                self?.navigationController?.popViewController(animated: false)
             }
         }
     }

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/DateSchedule/View/UpcomingDateDetailViewController.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/DateSchedule/View/UpcomingDateDetailViewController.swift
@@ -23,6 +23,8 @@ final class UpcomingDateDetailViewController: BaseNavBarViewController {
     
     var dateID: Int
     
+    var networkType: NetworkType?
+    
     var upcomingDateDetailViewModel: DateDetailViewModel
     
     private let dateScheduleDeleteView = DateScheduleDeleteView()
@@ -79,18 +81,10 @@ final class UpcomingDateDetailViewController: BaseNavBarViewController {
 // MARK: - UI Setting Methods
 
 extension UpcomingDateDetailViewController {
+    
     func bindViewModel() {
-        
         self.upcomingDateDetailViewModel.onDateDetailLoading.bind { [weak self] onLoading in
-            guard let onLoading, 
-                    let onFailNetwork = self?.upcomingDateDetailViewModel.onFailNetwork.value
-            else { return }
-             if !onFailNetwork {
-                 onLoading ? self?.showLoadingView() : self?.hideLoadingView()
-                 self?.upcomingDateDetailContentView.isHidden = onLoading
-                 self?.topInsetView.isHidden = onLoading
-                 self?.navigationBarView.isHidden = onLoading
-             }
+            guard let onLoading,  let onFailNetwork = self?.upcomingDateDetailViewModel.onFailNetwork.value else { return }
             if !onFailNetwork {
                 if onLoading {
                     self?.showLoadingView()
@@ -109,9 +103,16 @@ extension UpcomingDateDetailViewController {
          }
         
         self.upcomingDateDetailViewModel.onReissueSuccess.bind { [weak self] onSuccess in
-            guard let onSuccess else { return }
+            guard let onSuccess, let dateID = self?.dateID else { return }
             if onSuccess {
-                // TODO: - 서버 통신 재시도
+                switch self?.networkType {
+                case .deleteDateSchedule:
+                    self?.upcomingDateDetailViewModel.deleteDateSchdeuleData(dateID: dateID)
+                case .getDateDetail:
+                    self?.upcomingDateDetailViewModel.getDateDetailData(dateID: dateID)
+                default:
+                    self?.navigationController?.pushViewController(SplashViewController(splashViewModel: SplashViewModel()), animated: false)
+                }
             } else {
                 self?.navigationController?.pushViewController(SplashViewController(splashViewModel: SplashViewModel()), animated: false)
             }

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/DateSchedule/View/UpcomingDateDetailViewController.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/DateSchedule/View/UpcomingDateDetailViewController.swift
@@ -98,7 +98,7 @@ extension UpcomingDateDetailViewController {
                     self?.topInsetView.isHidden = onLoading
                     self?.navigationBarView.isHidden = onLoading
                 } else {
-                    DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
+                    DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) {
                         self?.upcomingDateDetailContentView.isHidden = false
                         self?.topInsetView.isHidden = onLoading
                         self?.navigationBarView.isHidden = onLoading

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/DateSchedule/View/UpcomingDateScheduleView.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/DateSchedule/View/UpcomingDateScheduleView.swift
@@ -10,13 +10,13 @@ import UIKit
 import SnapKit
 import Then
 
-class UpcomingDateScheduleView: BaseView {
+final class UpcomingDateScheduleView: BaseView {
     
     // MARK: - UI Properties
     
     private let titleLabel = UILabel()
     
-var cardCollectionView = UICollectionView(frame: .zero, collectionViewLayout: UICollectionViewFlowLayout())
+    var cardCollectionView = UICollectionView(frame: .zero, collectionViewLayout: UICollectionViewFlowLayout())
     
     var cardPageControl = UIPageControl()
     
@@ -26,9 +26,6 @@ var cardCollectionView = UICollectionView(frame: .zero, collectionViewLayout: UI
     
     var pastDateButton = UIButton()
     
-    // MARK: - Properties
-    
-//    static var dateCardCollectionViewLayout = UICollectionViewFlowLayout()
     
     // MARK: - LifeCycle
     

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/DateSchedule/View/UpcomingDateScheduleView.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/DateSchedule/View/UpcomingDateScheduleView.swift
@@ -102,12 +102,6 @@ var cardCollectionView = UICollectionView(frame: .zero, collectionViewLayout: UI
             $0.collectionViewLayout = layout
         }
         
-//        UpcomingDateScheduleView.dateCardCollectionViewLayout.do {
-//            $0.scrollDirection = .horizontal
-//            $0.minimumLineSpacing = ScreenUtils.width * 0.0693
-//            $0.itemSize = CGSize(width: ScreenUtils.width * 0.776, height: ScreenUtils.height*0.5)
-//        }
-        
         cardPageControl.do {
             $0.currentPage = 0
             $0.pageIndicatorTintColor = UIColor(resource: .gray200)

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/DateSchedule/View/UpcomingDateScheduleViewController.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/DateSchedule/View/UpcomingDateScheduleViewController.swift
@@ -227,7 +227,7 @@ extension UpcomingDateScheduleViewController: UICollectionViewDataSource {
     }
     
     func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
-        let data = upcomingDateScheduleViewModel.upcomingDateScheduleData.value?[indexPath.item] ?? DateCardModel(dateID: 0, title: "", date: "", city: "", tags: [], dDay: 0)
+        let data = upcomingDateScheduleViewModel.upcomingDateScheduleData.value?[indexPath.item] ?? DateCardModel.emptyData
         print(data)
         guard let cell = collectionView.dequeueReusableCell(withReuseIdentifier: DateCardCollectionViewCell.cellIdentifier, for: indexPath) as? DateCardCollectionViewCell else {
             return UICollectionViewCell()
@@ -243,7 +243,7 @@ extension UpcomingDateScheduleViewController: UICollectionViewDataSource {
     func pushToUpcomingDateDetailVC(_ sender: UITapGestureRecognizer) {
         let location = sender.location(in: upcomingDateScheduleView.cardCollectionView)
         if let indexPath = upcomingDateScheduleView.cardCollectionView.indexPathForItem(at: location) {
-            let data = upcomingDateScheduleViewModel.upcomingDateScheduleData.value?[indexPath.item] ?? DateCardModel(dateID: 0, title: "", date: "", city: "", tags: [], dDay: 0)
+            let data = upcomingDateScheduleViewModel.upcomingDateScheduleData.value?[indexPath.item] ?? DateCardModel.emptyData
             let upcomingDateDetailVC = UpcomingDateDetailViewController(dateID: data.dateID, upcomingDateDetailViewModel: DateDetailViewModel()
             )
             upcomingDateDetailVC.setColor(index: indexPath.item)

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/DateSchedule/View/UpcomingDateScheduleViewController.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/DateSchedule/View/UpcomingDateScheduleViewController.swift
@@ -115,7 +115,7 @@ private extension UpcomingDateScheduleViewController {
                     self?.tabBarController?.tabBar.isHidden = true
                 } else {
                     self?.drawDateCardView()
-                    DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
+                    DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) {
                         self?.upcomingDateScheduleView.isHidden = false
                         self?.tabBarController?.tabBar.isHidden = false
                         self?.hideLoadingView()
@@ -193,7 +193,6 @@ extension UpcomingDateScheduleViewController: UICollectionViewDelegateFlowLayout
     
     func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, sizeForItemAt indexPath: IndexPath) -> CGSize {
         return CGSize(width: ScreenUtils.width * 0.776, height: ScreenUtils.height*0.5)
-//        return UpcomingDateScheduleView.dateCardCollectionViewLayout.itemSize
     }
     
     func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, insetForSectionAt section: Int) -> UIEdgeInsets {
@@ -206,8 +205,6 @@ extension UpcomingDateScheduleViewController: UICollectionViewDelegateFlowLayout
     }
     
     func scrollViewWillEndDragging(_ scrollView: UIScrollView, withVelocity velocity: CGPoint, targetContentOffset: UnsafeMutablePointer<CGPoint>) {
-//        let layout = UpcomingDateScheduleView.dateCardCollectionViewLayout
-        
         let cellWidthIncludingSpacing = ScreenUtils.width * 0.776 + ScreenUtils.width * 0.0693
         
         var offset = targetContentOffset.pointee
@@ -218,7 +215,6 @@ extension UpcomingDateScheduleViewController: UICollectionViewDelegateFlowLayout
         targetContentOffset.pointee = offset
         self.upcomingDateScheduleViewModel.currentIndex.value = Int(roundedIndex)
         upcomingDateScheduleView.cardPageControl.currentPage = Int(roundedIndex)
-        // upcomingDateScheduleView.updatePageControlSelectedIndex(index: Int(roundedIndex))
     }
 }
 
@@ -252,7 +248,6 @@ extension UpcomingDateScheduleViewController: UICollectionViewDataSource {
             )
             upcomingDateDetailVC.setColor(index: indexPath.item)
             self.navigationController?.pushViewController(upcomingDateDetailVC, animated: false)
-//            upcomingDateDetailVC.upcomingDateScheduleView = upcomingDateScheduleView
         }
     }
     

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/DateSchedule/View/UpcomingDateScheduleViewController.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/DateSchedule/View/UpcomingDateScheduleViewController.swift
@@ -115,7 +115,7 @@ private extension UpcomingDateScheduleViewController {
                     self?.tabBarController?.tabBar.isHidden = true
                 } else {
                     self?.drawDateCardView()
-                    DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) {
+                    DispatchQueue.main.asyncAfter(deadline: .now() + 0.2) {
                         self?.upcomingDateScheduleView.isHidden = false
                         self?.tabBarController?.tabBar.isHidden = false
                         self?.hideLoadingView()

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/DateSchedule/View/UpcomingDateScheduleViewController.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/DateSchedule/View/UpcomingDateScheduleViewController.swift
@@ -127,7 +127,7 @@ private extension UpcomingDateScheduleViewController {
         self.upcomingDateScheduleViewModel.onReissueSuccess.bind { [weak self] onSuccess in
             guard let onSuccess else { return }
             if onSuccess {
-                // TODO: - 서버 통신 재시도
+                self?.upcomingDateScheduleViewModel.getUpcomingDateScheduleData()
             } else {
                 self?.navigationController?.pushViewController(SplashViewController(splashViewModel: SplashViewModel()), animated: false)
             }

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/DateSchedule/ViewModel/DateDetailViewModel.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/DateSchedule/ViewModel/DateDetailViewModel.swift
@@ -29,6 +29,8 @@ final class DateDetailViewModel: Serviceable {
     
     var isSuccessDeleteDateScheduleData: ObservablePattern<Bool> = ObservablePattern(nil)
     
+    var onDeleteDateDetailLoading: ObservablePattern<Bool> = ObservablePattern(true)
+    
     var onDateDetailLoading: ObservablePattern<Bool> = ObservablePattern(true)
     
     var onFailNetwork: ObservablePattern<Bool> = ObservablePattern(false)
@@ -81,6 +83,8 @@ extension DateDetailViewModel {
      }
     
     func deleteDateSchdeuleData(dateID: Int) {
+        self.onFailNetwork.value = false
+        
         NetworkService.shared.dateScheduleService.deleteDateSchedule(dateID: dateID) { response in
             switch response {
             case .success:
@@ -92,7 +96,7 @@ extension DateDetailViewModel {
                     self.onReissueSuccess.value = isSuccess
                 }
             default:
-                self.isSuccessDeleteDateScheduleData.value = false
+                self.onFailNetwork.value = true
             }
         }
     }
@@ -107,7 +111,7 @@ extension DateDetailViewModel {
                 kakaoShareInfo["name\(i+1)"] = dateDetailData.value?.places[i].name
                 kakaoShareInfo["duration\(i+1)"] = "\(dateDetailData.value?.places[i].duration ?? "") 시간"
             }
-            for i in maxPlaces...5 {
+            for _ in maxPlaces...5 {
                 kakaoPlacesInfo.append(KakaoPlaceModel(name: nil, duration: nil))
             }
         case false:

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/DateSchedule/ViewModel/DateDetailViewModel.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/DateSchedule/ViewModel/DateDetailViewModel.swift
@@ -62,16 +62,13 @@ extension DateDetailViewModel {
                 }
                 self.dateDetailData.value = DateDetailModel(dateID: data.dateID, title: data.title, startAt: data.startAt, city: data.city, tags: tagsInfo, date: data.date.formatDateFromString(inputFormat: "yyyy.MM.dd", outputFormat: "yyyy년 M월 d일") ?? "", places: datePlaceInfo, dDay: data.dDay)
                 self.isSuccessGetDateDetailData.value = true
-            case .serverErr:
-                self.onFailNetwork.value = true
             case .reIssueJWT:
                 self.patchReissue { isSuccess in
                     self.onReissueSuccess.value = isSuccess
                 }
             default:
-                self.isSuccessGetDateDetailData.value = false
+                self.onFailNetwork.value = true
             }
-            self.setDateDetailLoading()
         }
     }
     

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/DateSchedule/ViewModel/DateDetailViewModel.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/DateSchedule/ViewModel/DateDetailViewModel.swift
@@ -13,7 +13,9 @@ import KakaoSDKCommon
 import KakaoSDKAuth
 import KakaoSDKUser
 
-class DateDetailViewModel: Serviceable {
+final class DateDetailViewModel: Serviceable {
+    
+    var type: ObservablePattern<NetworkType> = ObservablePattern(nil)
     
     var onReissueSuccess: ObservablePattern<Bool> = ObservablePattern(nil)
     
@@ -64,6 +66,7 @@ extension DateDetailViewModel {
                 self.isSuccessGetDateDetailData.value = true
             case .reIssueJWT:
                 self.patchReissue { isSuccess in
+                    self.type.value = NetworkType.getDateDetail
                     self.onReissueSuccess.value = isSuccess
                 }
             default:
@@ -80,11 +83,12 @@ extension DateDetailViewModel {
     func deleteDateSchdeuleData(dateID: Int) {
         NetworkService.shared.dateScheduleService.deleteDateSchedule(dateID: dateID) { response in
             switch response {
-            case .success(let data):
+            case .success:
                 self.isSuccessDeleteDateScheduleData.value = true
                 print("success", self.isSuccessDeleteDateScheduleData.value)
             case .reIssueJWT:
                 self.patchReissue { isSuccess in
+                    self.type.value = NetworkType.deleteDateSchedule
                     self.onReissueSuccess.value = isSuccess
                 }
             default:

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/DateSchedule/ViewModel/DateDetailViewModel.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/DateSchedule/ViewModel/DateDetailViewModel.swift
@@ -64,7 +64,14 @@ extension DateDetailViewModel {
                 let datePlaceInfo: [DatePlaceModel] = data.places.map { place in
                     DatePlaceModel(name: place.title, duration: (place.duration).formatFloatTime(), sequence: place.sequence)
                 }
-                self.dateDetailData.value = DateDetailModel(dateID: data.dateID, title: data.title, startAt: data.startAt, city: data.city, tags: tagsInfo, date: data.date.formatDateFromString(inputFormat: "yyyy.MM.dd", outputFormat: "yyyy년 M월 d일") ?? "", places: datePlaceInfo, dDay: data.dDay)
+                self.dateDetailData.value = DateDetailModel(dateID: data.dateID, 
+                                                            title: data.title,
+                                                            startAt: data.startAt,
+                                                            city: data.city,
+                                                            tags: tagsInfo,
+                                                            date: data.date.formatDateFromString(inputFormat: "yyyy.MM.dd", outputFormat: "yyyy년 M월 d일") ?? "",
+                                                            places: datePlaceInfo,
+                                                            dDay: data.dDay)
                 self.isSuccessGetDateDetailData.value = true
             case .reIssueJWT:
                 self.patchReissue { isSuccess in

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/DateSchedule/ViewModel/DateScheduleViewModel.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/DateSchedule/ViewModel/DateScheduleViewModel.swift
@@ -40,6 +40,7 @@ final class DateScheduleViewModel: Serviceable {
     
     func getPastDateScheduleData() {
         self.isSuccessGetPastDateScheduleData.value = false
+        self.setPastScheduleLoading()
         self.onPastScheduleFailNetwork.value = false
         
         NetworkService.shared.dateScheduleService.getDateSchdeule(time: "PAST") { response in
@@ -54,14 +55,12 @@ final class DateScheduleViewModel: Serviceable {
                 
                 self.pastDateScheduleData.value = dateScheduleInfo
                 self.isSuccessGetPastDateScheduleData.value = true
-            case .serverErr:
-                self.onPastScheduleFailNetwork.value = true
             case .reIssueJWT:
                 self.patchReissue { isSuccess in
                     self.onReissueSuccess.value = isSuccess
                 }
             default:
-                self.isSuccessGetPastDateScheduleData.value = false
+                self.onPastScheduleFailNetwork.value = true
             }
         }
     }

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/DateSchedule/ViewModel/DateScheduleViewModel.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/DateSchedule/ViewModel/DateScheduleViewModel.swift
@@ -50,7 +50,12 @@ final class DateScheduleViewModel: Serviceable {
                     let tagsModel: [TagsModel] = date.tags.map { tag in
                         TagsModel(tag: tag.tag)
                     }
-                    return DateCardModel(dateID: date.dateID, title: date.title, date: date.date.formatDateFromString(inputFormat: "yyyy.MM.dd", outputFormat: "yyyy년 M월 d일") ?? "", city: date.city, tags: tagsModel, dDay: date.dDay)
+                    return DateCardModel(dateID: date.dateID, 
+                                         title: date.title,
+                                         date: date.date.formatDateFromString(inputFormat: "yyyy.MM.dd", outputFormat: "yyyy년 M월 d일") ?? "",
+                                         city: date.city,
+                                         tags: tagsModel,
+                                         dDay: date.dDay)
                 }
                 
                 self.pastDateScheduleData.value = dateScheduleInfo

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/Main/Views/Cells/NewDateCourseCell.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/Main/Views/Cells/NewDateCourseCell.swift
@@ -219,7 +219,6 @@ final class NewDateCourseCell: BaseCollectionViewCell {
 
 extension NewDateCourseCell {
     
-    // TODO: - 비용 분기 처리 해주기
     func bindData(newDateData: DateCourseModel?) {
         guard let newDateData else { return }
         self.countryLabel.text = newDateData.city

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/Main/Views/Cells/UpcomingDateCell.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/Main/Views/Cells/UpcomingDateCell.swift
@@ -100,7 +100,6 @@ final class UpcomingDateCell: BaseCollectionViewCell {
 
 extension UpcomingDateCell {
     
-    // TODO: - 0일 때 D-Day 변환 하는 거 수정 & 다가오는 일정 없는 경우 수정
     func bindData(upcomingData: UpcomingDateModel?, mainUserData: MainUserModel?) {
         if let upcomingData {
             emptyTicketView.isHidden = true
@@ -121,5 +120,6 @@ extension UpcomingDateCell {
         let url = URL(string: imageUrl)
         profileImage.kf.setImage(with: url)
         profileImage.layer.cornerRadius = profileImage.frame.size.width / 2
+        profileImage.backgroundColor = .clear
     }
 }

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/Main/Views/MainViewController.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/Main/Views/MainViewController.swift
@@ -100,7 +100,7 @@ extension MainViewController {
                     self?.mainView.mainCollectionView.scrollToItem(at: initialIndexPath, at: .centeredHorizontally, animated: false)
                     self?.startAutoScrollTimer()
                     
-                    DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) {
+                    DispatchQueue.main.asyncAfter(deadline: .now() + 0.2) {
                         self?.mainView.isHidden = onLoading
                         self?.tabBarController?.tabBar.isHidden = onLoading
                         self?.hideLoadingView()

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/Main/Views/MainViewController.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/Main/Views/MainViewController.swift
@@ -257,7 +257,8 @@ extension MainViewController: UICollectionViewDataSource {
     func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
         switch self.mainViewModel.sectionData[indexPath.section] {
         case .upcomingDate:
-            guard let cell = collectionView.dequeueReusableCell(withReuseIdentifier: UpcomingDateCell.cellIdentifier, for: indexPath) as? UpcomingDateCell else { return UICollectionViewCell() }
+            guard let cell = collectionView.dequeueReusableCell(withReuseIdentifier: UpcomingDateCell.cellIdentifier, for: indexPath) as? UpcomingDateCell 
+            else { return UICollectionViewCell() }
             cell.bindData(upcomingData: mainViewModel.upcomingData.value, mainUserData: mainViewModel.mainUserData.value)
             // Set button actions
             let pointLabelTapGesture = UITapGestureRecognizer(target: self, action: #selector(pushToPointDetailVC))
@@ -268,19 +269,22 @@ extension MainViewController: UICollectionViewDataSource {
             return cell
             
         case .hotDateCourse:
-            guard let cell = collectionView.dequeueReusableCell(withReuseIdentifier: HotDateCourseCell.cellIdentifier, for: indexPath) as? HotDateCourseCell else { return UICollectionViewCell() }
+            guard let cell = collectionView.dequeueReusableCell(withReuseIdentifier: HotDateCourseCell.cellIdentifier, for: indexPath) as? HotDateCourseCell 
+            else { return UICollectionViewCell() }
             cell.bindData(hotDateData: mainViewModel.hotCourseData.value?[indexPath.row])
             return cell
             
         case .banner:
-            guard let cell = collectionView.dequeueReusableCell(withReuseIdentifier: BannerCell.cellIdentifier, for: indexPath) as? BannerCell else { return UICollectionViewCell() }
+            guard let cell = collectionView.dequeueReusableCell(withReuseIdentifier: BannerCell.cellIdentifier, for: indexPath) as? BannerCell 
+            else { return UICollectionViewCell() }
             cell.bindData(bannerData: mainViewModel.bannerData.value?[indexPath.row])
             let longPressGesture = UISwipeGestureRecognizer(target: self, action: #selector(handleLongPress(_:)))
             cell.addGestureRecognizer(longPressGesture)
             return cell
             
         case .newDateCourse:
-            guard let cell = collectionView.dequeueReusableCell(withReuseIdentifier: NewDateCourseCell.cellIdentifier, for: indexPath) as? NewDateCourseCell else { return UICollectionViewCell() }
+            guard let cell = collectionView.dequeueReusableCell(withReuseIdentifier: NewDateCourseCell.cellIdentifier, for: indexPath) as? NewDateCourseCell 
+            else { return UICollectionViewCell() }
             cell.bindData(newDateData: mainViewModel.newCourseData.value?[indexPath.row])
             return cell
         }
@@ -288,8 +292,8 @@ extension MainViewController: UICollectionViewDataSource {
     
     func collectionView(_ collectionView: UICollectionView, viewForSupplementaryElementOfKind kind: String, at indexPath: IndexPath) -> UICollectionReusableView {
         if kind == StringLiterals.Common.header {
-            guard let header = collectionView.dequeueReusableSupplementaryView(ofKind: kind, withReuseIdentifier: MainHeaderView.identifier, for: indexPath)
-                    as? MainHeaderView else { return UICollectionReusableView() }
+            guard let header = collectionView.dequeueReusableSupplementaryView(ofKind: kind, withReuseIdentifier: MainHeaderView.identifier, for: indexPath) as? MainHeaderView
+            else { return UICollectionReusableView() }
             
             switch mainViewModel.sectionData[indexPath.section] {
             case .upcomingDate, .banner:
@@ -305,8 +309,8 @@ extension MainViewController: UICollectionViewDataSource {
             }
             return header
         } else {
-            guard let footer = collectionView.dequeueReusableSupplementaryView(ofKind: kind, withReuseIdentifier: BannerIndexFooterView.identifier, for: indexPath)
-                    as? BannerIndexFooterView else { return UICollectionReusableView() }
+            guard let footer = collectionView.dequeueReusableSupplementaryView(ofKind: kind, withReuseIdentifier: BannerIndexFooterView.identifier, for: indexPath) as? BannerIndexFooterView
+            else { return UICollectionReusableView() }
             let index = mainViewModel.currentIndex.value?.row ?? 0
             footer.bindIndexData(currentIndex: index, count: 5)
             return footer

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/Main/Views/MainViewController.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/Main/Views/MainViewController.swift
@@ -79,12 +79,15 @@ extension MainViewController {
     
     func bindViewModel() {
         self.mainViewModel.onFailNetwork.bind { [weak self] onFailure in
-            guard let onFailure else { return }
-            if onFailure {
-                self?.mainViewModel.totalFetchCount = 0
-                let errorVC = DRErrorViewController()
-                self?.navigationController?.pushViewController(errorVC, animated: false)
-            }
+           guard let onFailure else { return }
+           if onFailure {
+              let errorVC = DRErrorViewController()
+              errorVC.onDismiss = {
+                 self?.mainViewModel.onFailNetwork.value = false
+                 self?.mainViewModel.onLoading.value = false
+              }
+              self?.navigationController?.pushViewController(errorVC, animated: false)
+           }
         }
         
         self.mainViewModel.onLoading.bind { [weak self] onLoading in

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/MyCourse/ViewModels/MyCourseListViewModel.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/MyCourse/ViewModels/MyCourseListViewModel.swift
@@ -61,8 +61,6 @@ final class MyCourseListViewModel: Serviceable {
                 self.patchReissue { isSuccess in
                     self.onReissueSuccess.value = isSuccess
                 }
-            case .serverErr:
-                self.onViewedCourseFailNetwork.value = true
             default:
                 print("내가 열람한 코스 에러")
                 self.onViewedCourseFailNetwork.value = true //TODO: - 확인
@@ -96,8 +94,6 @@ final class MyCourseListViewModel: Serviceable {
                 self.patchReissue { isSuccess in
                     self.onReissueSuccess.value = isSuccess
                 }
-            case .serverErr:
-                self.onNavViewedCourseFailNetwork.value = true
             default:
                 print("내가 열람한 코스 에러")
                 self.onNavViewedCourseFailNetwork.value = true //TODO: - 확인
@@ -113,6 +109,7 @@ final class MyCourseListViewModel: Serviceable {
     
     func setMyRegisterCourseData() {
         self.isSuccessGetMyRegisterCourseInfo.value = false
+        self.setMyRegisterCourseLoading()
         self.onMyRegisterCourseFailNetwork.value = false
         
         NetworkService.shared.myCourseService.getMyRegisterCourse() { response in
@@ -133,8 +130,6 @@ final class MyCourseListViewModel: Serviceable {
                 self.patchReissue { isSuccess in
                     self.onReissueSuccess.value = isSuccess
                 }
-            case .serverErr:
-                self.onMyRegisterCourseFailNetwork.value = true
             default:
                 print("내가 등록한 코스 에러")
                 self.onMyRegisterCourseFailNetwork.value = true //TODO: - 확인

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/MyCourse/Views/Cells/MyCourseListCollectionViewCell.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/MyCourse/Views/Cells/MyCourseListCollectionViewCell.swift
@@ -11,7 +11,7 @@ import SnapKit
 import Then
 import Kingfisher
 
-class MyCourseListCollectionViewCell: BaseCollectionViewCell {
+final class MyCourseListCollectionViewCell: BaseCollectionViewCell {
 
     // MARK: - UI Properties
     
@@ -65,7 +65,6 @@ class MyCourseListCollectionViewCell: BaseCollectionViewCell {
         heartButton.snp.makeConstraints {
             $0.leading.equalTo(thumbnailImageView.snp.leading).inset(5)
             $0.bottom.equalTo(thumbnailImageView.snp.bottom).inset(5)
-            // $0.width.equalTo(43) TODO: 나중에 확정되면 지우기
             $0.height.equalTo(22)
         }
         
@@ -91,7 +90,6 @@ class MyCourseListCollectionViewCell: BaseCollectionViewCell {
             $0.leading.equalToSuperview()
             $0.top.equalTo(titleLabel.snp.bottom).offset(10)
             $0.height.equalTo(26)
-           //$0.width.equalTo(150)
         }
         
         timeButton.snp.makeConstraints {
@@ -163,6 +161,7 @@ class MyCourseListCollectionViewCell: BaseCollectionViewCell {
 }
 
 extension MyCourseListCollectionViewCell {
+    
     func dataBind(_ viewedCourseData: MyCourseModel?, _ viewedCourseItemRow: Int?) {
         guard let viewedCourseData else { return }
         self.courseID = viewedCourseData.courseId

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/MyCourse/Views/MyCourseListView.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/MyCourse/Views/MyCourseListView.swift
@@ -7,7 +7,7 @@
 
 import UIKit
 
-class MyCourseListView: BaseView {
+final class MyCourseListView: BaseView {
 
     // MARK: - UI Properties
     

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/MyCourse/Views/MyRegisterCourseViewController.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/MyCourse/Views/MyRegisterCourseViewController.swift
@@ -109,7 +109,7 @@ extension MyRegisterCourseViewController {
                     self?.setEmptyView()
                     self?.myRegisterCourseView.myCourseListCollectionView.reloadData()
                     
-                    DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) {
+                    DispatchQueue.main.asyncAfter(deadline: .now() + 0.2) {
                         self?.contentView.isHidden = onLoading
                         self?.hideLoadingView()
                     }

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/MyCourse/Views/MyRegisterCourseViewController.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/MyCourse/Views/MyRegisterCourseViewController.swift
@@ -25,7 +25,6 @@ final class MyRegisterCourseViewController: BaseNavBarViewController {
     // MARK: - LifeCycle
     
     override func viewWillAppear(_ animated: Bool) {
-        self.myRegisterCourseViewModel.setMyRegisterCourseLoading()
         self.myRegisterCourseViewModel.setMyRegisterCourseData()
     }
 
@@ -103,20 +102,24 @@ extension MyRegisterCourseViewController {
         self.myRegisterCourseViewModel.onMyRegisterCourseLoading.bind { [weak self] onLoading in
             guard let onLoading, let onFailNetwork = self?.myRegisterCourseViewModel.onMyRegisterCourseFailNetwork.value else { return }
             if !onFailNetwork {
-                onLoading ? self?.showLoadingView() : self?.hideLoadingView()
-                self?.contentView.isHidden = onLoading
+                if onLoading {
+                    self?.showLoadingView()
+                    self?.contentView.isHidden = onLoading
+                } else {
+                    self?.setEmptyView()
+                    self?.myRegisterCourseView.myCourseListCollectionView.reloadData()
+                    
+                    DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) {
+                        self?.contentView.isHidden = onLoading
+                        self?.hideLoadingView()
+                    }
+                }
             }
         }
         
         self.myRegisterCourseViewModel.isSuccessGetMyRegisterCourseInfo.bind { [weak self] isSuccess in
             guard let isSuccess else { return }
-            if isSuccess {
-                self?.setEmptyView()
-                self?.myRegisterCourseView.myCourseListCollectionView.reloadData()
-                DispatchQueue.main.asyncAfter(deadline: .now() + 1.0) {
-                    self?.myRegisterCourseViewModel.setMyRegisterCourseLoading()
-                }
-            }
+            self?.myRegisterCourseViewModel.setMyRegisterCourseLoading()
         }
     }
     

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/MyCourse/Views/MyRegisterCourseViewController.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/MyCourse/Views/MyRegisterCourseViewController.swift
@@ -84,7 +84,7 @@ extension MyRegisterCourseViewController {
         self.myRegisterCourseViewModel.onReissueSuccess.bind { [weak self] onSuccess in
             guard let onSuccess else { return }
             if onSuccess {
-                // TODO: - 서버 통신 재시도
+                self?.myRegisterCourseViewModel.setMyRegisterCourseData()
             } else {
                 self?.navigationController?.pushViewController(SplashViewController(splashViewModel: SplashViewModel()), animated: false)
             }

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/MyCourse/Views/MyRegisterCourseViewController.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/MyCourse/Views/MyRegisterCourseViewController.swift
@@ -66,7 +66,7 @@ final class MyRegisterCourseViewController: BaseNavBarViewController {
 
 extension MyRegisterCourseViewController {
     private func setEmptyView() {
-        var isEmpty = (myRegisterCourseViewModel.myRegisterCourseData.value?.count == 0)
+        let isEmpty = (myRegisterCourseViewModel.myRegisterCourseData.value?.count == 0)
         myRegisterCourseView.emptyView.isHidden = !isEmpty
         if isEmpty {
             myRegisterCourseView.emptyView.do {
@@ -91,12 +91,15 @@ extension MyRegisterCourseViewController {
         }
         
         self.myRegisterCourseViewModel.onMyRegisterCourseFailNetwork.bind { [weak self] onFailure in
-            guard let onFailure else { return }
-            if onFailure {
-                self?.hideLoadingView()
-                let errorVC = DRErrorViewController()
-                self?.navigationController?.pushViewController(errorVC, animated: false)
-            }
+           guard let onFailure else { return }
+           if onFailure {
+              let errorVC = DRErrorViewController()
+              errorVC.onDismiss = {
+                 self?.myRegisterCourseViewModel.onMyRegisterCourseFailNetwork.value = false
+                  self?.myRegisterCourseViewModel.onMyRegisterCourseLoading.value = false
+              }
+              self?.navigationController?.pushViewController(errorVC, animated: false)
+           }
         }
 
         self.myRegisterCourseViewModel.onMyRegisterCourseLoading.bind { [weak self] onLoading in
@@ -117,8 +120,7 @@ extension MyRegisterCourseViewController {
             }
         }
         
-        self.myRegisterCourseViewModel.isSuccessGetMyRegisterCourseInfo.bind { [weak self] isSuccess in
-            guard let isSuccess else { return }
+        self.myRegisterCourseViewModel.isSuccessGetMyRegisterCourseInfo.bind { [weak self] _ in
             self?.myRegisterCourseViewModel.setMyRegisterCourseLoading()
         }
     }

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/MyCourse/Views/NavViewedCourseViewController.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/MyCourse/Views/NavViewedCourseViewController.swift
@@ -113,7 +113,7 @@ extension NavViewedCourseViewController {
                     self?.navViewedCourseView.isHidden = onLoading
                 } else {
                     self?.setEmptyView()
-                    DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) {
+                    DispatchQueue.main.asyncAfter(deadline: .now() + 0.2) {
                         self?.navViewedCourseView.isHidden = onLoading
                         self?.tabBarController?.tabBar.isHidden = false
                         self?.hideLoadingView()

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/MyCourse/Views/NavViewedCourseViewController.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/MyCourse/Views/NavViewedCourseViewController.swift
@@ -89,7 +89,8 @@ extension NavViewedCourseViewController {
         self.viewedCourseViewModel.onReissueSuccess.bind { [weak self] onSuccess in
             guard let onSuccess else { return }
             if onSuccess {
-                // TODO: - 서버 통신 재시도
+                self?.viewedCourseViewModel.setNavViewedCourseLoading()
+                self?.viewedCourseViewModel.setNavViewedCourseData()
             } else {
                 self?.navigationController?.pushViewController(SplashViewController(splashViewModel: SplashViewModel()), animated: false)
             }

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/MyCourse/Views/NavViewedCourseViewController.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/MyCourse/Views/NavViewedCourseViewController.swift
@@ -97,12 +97,15 @@ extension NavViewedCourseViewController {
         }
         
         self.viewedCourseViewModel.onNavViewedCourseFailNetwork.bind { [weak self] onFailure in
-            guard let onFailure else { return }
-            if onFailure {
-                self?.hideLoadingView()
-                let errorVC = DRErrorViewController()
-                self?.navigationController?.pushViewController(errorVC, animated: false)
-            }
+           guard let onFailure else { return }
+           if onFailure {
+              let errorVC = DRErrorViewController()
+              errorVC.onDismiss = {
+                 self?.viewedCourseViewModel.onNavViewedCourseFailNetwork.value = false
+                  self?.viewedCourseViewModel.onNavViewedCourseLoading.value = false
+              }
+              self?.navigationController?.pushViewController(errorVC, animated: false)
+           }
         }
 
         self.viewedCourseViewModel.onNavViewedCourseLoading.bind { [weak self] onLoading in
@@ -122,8 +125,7 @@ extension NavViewedCourseViewController {
             }
         }
         
-        self.viewedCourseViewModel.isSuccessGetNavViewedCourseInfo.bind { [weak self] isSuccess in
-            guard let isSuccess else { return }
+        self.viewedCourseViewModel.isSuccessGetNavViewedCourseInfo.bind { [weak self] _ in
             self?.viewedCourseViewModel.setNavViewedCourseLoading()
         }
     }
@@ -172,7 +174,7 @@ extension NavViewedCourseViewController : UICollectionViewDataSource {
         let location = sender.location(in: navViewedCourseView.myCourseListCollectionView)
         let indexPath = navViewedCourseView.myCourseListCollectionView.indexPathForItem(at: location)
        
-       if let index = indexPath {
+        if indexPath != nil {
           guard let courseId = viewedCourseViewModel.viewedCourseData.value?[indexPath?.item ?? 0].courseId else {return}
           
           let courseDetailViewModel = CourseDetailViewModel(courseId: courseId)

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/MyCourse/Views/NavViewedCourseViewController.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/MyCourse/Views/NavViewedCourseViewController.swift
@@ -107,19 +107,23 @@ extension NavViewedCourseViewController {
         self.viewedCourseViewModel.onNavViewedCourseLoading.bind { [weak self] onLoading in
             guard let onLoading, let onFailNetwork = self?.viewedCourseViewModel.onViewedCourseFailNetwork.value else { return }
             if !onFailNetwork {
-                onLoading ? self?.showLoadingView() : self?.hideLoadingView()
-                self?.navViewedCourseView.isHidden = onLoading
+                if onLoading {
+                    self?.showLoadingView()
+                    self?.navViewedCourseView.isHidden = onLoading
+                } else {
+                    self?.setEmptyView()
+                    DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) {
+                        self?.navViewedCourseView.isHidden = onLoading
+                        self?.tabBarController?.tabBar.isHidden = false
+                        self?.hideLoadingView()
+                    }
+                }
             }
         }
         
         self.viewedCourseViewModel.isSuccessGetNavViewedCourseInfo.bind { [weak self] isSuccess in
             guard let isSuccess else { return }
-            if isSuccess {
-                self?.setEmptyView()
-                DispatchQueue.main.asyncAfter(deadline: .now() + 1.4) {
-                    self?.viewedCourseViewModel.setNavViewedCourseLoading()
-                }
-            }
+            self?.viewedCourseViewModel.setNavViewedCourseLoading()
         }
     }
 }

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/MyCourse/Views/ViewedCourseViewController.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/MyCourse/Views/ViewedCourseViewController.swift
@@ -198,8 +198,8 @@ extension ViewedCourseViewController {
                     self?.contentView.isHidden = true
                     self?.tabBarController?.tabBar.isHidden = true
                 } else {
-                    self?.setEmptyView()
-                    DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
+                    DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) {
+                        self?.setEmptyView()
                         self?.contentView.isHidden = false
                         self?.tabBarController?.tabBar.isHidden = false
                         self?.hideLoadingView()
@@ -210,9 +210,7 @@ extension ViewedCourseViewController {
         
         self.viewedCourseViewModel.isSuccessGetViewedCourseInfo.bind { [weak self] isSuccess in
             guard let isSuccess else { return }
-            if isSuccess {
-                self?.viewedCourseViewModel.setViewedCourseLoading()
-            }
+            self?.viewedCourseViewModel.setViewedCourseLoading()
         }
     }
 }

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/MyCourse/Views/ViewedCourseViewController.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/MyCourse/Views/ViewedCourseViewController.swift
@@ -198,7 +198,7 @@ extension ViewedCourseViewController {
                     self?.contentView.isHidden = true
                     self?.tabBarController?.tabBar.isHidden = true
                 } else {
-                    DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) {
+                    DispatchQueue.main.asyncAfter(deadline: .now() + 0.2) {
                         self?.setEmptyView()
                         self?.contentView.isHidden = false
                         self?.tabBarController?.tabBar.isHidden = false

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/MyCourse/Views/ViewedCourseViewController.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/MyCourse/Views/ViewedCourseViewController.swift
@@ -262,6 +262,7 @@ extension ViewedCourseViewController : UICollectionViewDataSource {
 }
 
 extension ViewedCourseViewController {
+    
     @objc
     func pushToCourseUploadVC(_ gesture: UITapGestureRecognizer) {
         goToUpcomingDateScheduleVC()

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/MyCourse/Views/ViewedCourseViewController.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/MyCourse/Views/ViewedCourseViewController.swift
@@ -182,12 +182,15 @@ extension ViewedCourseViewController {
         }
         
         self.viewedCourseViewModel.onViewedCourseFailNetwork.bind { [weak self] onFailure in
-            guard let onFailure else { return }
-            if onFailure {
-                self?.hideLoadingView()
-                let errorVC = DRErrorViewController()
-                self?.navigationController?.pushViewController(errorVC, animated: false)
-            }
+           guard let onFailure else { return }
+           if onFailure {
+              let errorVC = DRErrorViewController()
+              errorVC.onDismiss = {
+                 self?.viewedCourseViewModel.onViewedCourseFailNetwork.value = false
+                  self?.viewedCourseViewModel.onViewedCourseLoading.value = false
+              }
+              self?.navigationController?.pushViewController(errorVC, animated: false)
+           }
         }
         
         self.viewedCourseViewModel.onViewedCourseLoading.bind { [weak self] onLoading in
@@ -208,8 +211,7 @@ extension ViewedCourseViewController {
             }
         }
         
-        self.viewedCourseViewModel.isSuccessGetViewedCourseInfo.bind { [weak self] isSuccess in
-            guard let isSuccess else { return }
+        self.viewedCourseViewModel.isSuccessGetViewedCourseInfo.bind { [weak self] _ in
             self?.viewedCourseViewModel.setViewedCourseLoading()
         }
     }

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/MyPage/Views/MyPageViewController.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/MyPage/Views/MyPageViewController.swift
@@ -14,7 +14,7 @@ final class MyPageViewController: BaseNavBarViewController {
     // MARK: - UI Properties
     
     private let myPageView: MyPageView = MyPageView()
-        
+    
     private let errorView: DRErrorViewController = DRErrorViewController()
     
     
@@ -64,7 +64,7 @@ final class MyPageViewController: BaseNavBarViewController {
     
     override func setLayout() {
         super.setLayout()
-
+        
         myPageView.snp.makeConstraints {
             $0.edges.equalToSuperview()
         }
@@ -116,21 +116,20 @@ private extension MyPageViewController {
         }
         
         self.myPageViewModel.onLoading.bind { [weak self] onLoading in
-            guard let onLoading, let onFailNetwork = self?.myPageViewModel.onFailNetwork.value else { return }
+            guard let onLoading,
+                  let data = self?.myPageViewModel.userInfoData.value,
+                  let onFailNetwork = self?.myPageViewModel.onFailNetwork.value
+            else { return }
             if !onFailNetwork {
-                if onLoading  {
-                    self?.showLoadingView()
-                    self?.myPageView.isHidden = onLoading
-                    self?.topInsetView.isHidden = onLoading
-                    self?.navigationBarView.isHidden = onLoading
-                    self?.tabBarController?.tabBar.isHidden = onLoading
-                } else {
-                    self?.myPageView.isHidden = onLoading
-                    self?.topInsetView.isHidden = onLoading
-                    self?.navigationBarView.isHidden = onLoading
-                    self?.tabBarController?.tabBar.isHidden = onLoading
-                    self?.hideLoadingView()
-                }
+                onLoading ? self?.showLoadingView() : self?.hideLoadingView()
+                self?.myPageView.isHidden = onLoading
+                self?.topInsetView.isHidden = onLoading
+                self?.navigationBarView.isHidden = onLoading
+                self?.tabBarController?.tabBar.isHidden = onLoading
+                
+                // `onDismiss` 설정 이후 `bindData` 호출
+                self?.myPageView.userInfoView.bindData(userInfo: data)
+                self?.myPageView.userInfoView.tagCollectionView.reloadData()
             }
         }
         
@@ -160,14 +159,6 @@ private extension MyPageViewController {
                 self?.navigationController?.popToRootViewController(animated: false)
             } else {
                 self?.presentAlertVC(title: StringLiterals.Alert.failToWithdrawal)
-            }
-        }
-        
-        self.myPageViewModel.onSuccessGetUserProfile.bind { [weak self] isSuccess in
-            guard let isSuccess, let data = self?.myPageViewModel.userInfoData.value else { return }
-            if isSuccess {
-                self?.myPageView.userInfoView.bindData(userInfo: data)
-                self?.myPageView.userInfoView.tagCollectionView.reloadData()
             }
         }
         
@@ -276,7 +267,7 @@ extension MyPageViewController: DRCustomAlertDelegate {
             }
         }
     }
-
+    
 }
 
 // MARK: - UICollectionView Delegates

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/MyPage/Views/MyPageViewController.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/MyPage/Views/MyPageViewController.swift
@@ -136,7 +136,7 @@ private extension MyPageViewController {
                     self?.tabBarController?.tabBar.isHidden = onLoading
                 } else {
                     self?.myPageView.userInfoView.onLoading = {
-                        DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) {
+                        DispatchQueue.main.asyncAfter(deadline: .now() + 0.2) {
                             self?.myPageView.isHidden = onLoading
                             self?.topInsetView.isHidden = onLoading
                             self?.navigationBarView.isHidden = onLoading

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/MyPage/Views/MyPageViewController.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/MyPage/Views/MyPageViewController.swift
@@ -106,7 +106,7 @@ private extension MyPageViewController {
                     self?.showLoadingView()
                     self?.tabBarController?.tabBar.isHidden = onAuthLoading
                 } else {
-                    DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) {
+                    DispatchQueue.main.asyncAfter(deadline: .now() + 0.2) {
                         self?.tabBarController?.tabBar.isHidden = onAuthLoading
                         self?.hideLoadingView()
                     }
@@ -115,11 +115,15 @@ private extension MyPageViewController {
         }
         
         self.myPageViewModel.onFailNetwork.bind { [weak self] onFailure in
-            guard let onFailure else { return }
-            if onFailure {
-                let errorVC = DRErrorViewController()
-                self?.navigationController?.pushViewController(errorVC, animated: false)
-            }
+           guard let onFailure else { return }
+           if onFailure {
+              let errorVC = DRErrorViewController()
+              errorVC.onDismiss = {
+                 self?.myPageViewModel.onFailNetwork.value = false
+                 self?.myPageViewModel.onLoading.value = false
+              }
+              self?.navigationController?.pushViewController(errorVC, animated: false)
+           }
         }
         
         self.myPageViewModel.onLoading.bind { [weak self] onLoading in

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/MyPage/Views/MyPageViewController.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/MyPage/Views/MyPageViewController.swift
@@ -102,8 +102,15 @@ private extension MyPageViewController {
         self.myPageViewModel.onAuthLoading.bind { [weak self] onAuthLoading in
             guard let onAuthLoading, let onFailNetwork = self?.myPageViewModel.onFailNetwork.value else { return }
             if !onFailNetwork {
-                onAuthLoading ? self?.showLoadingView() : self?.hideLoadingView()
-                self?.tabBarController?.tabBar.isHidden = onAuthLoading
+                if onAuthLoading {
+                    self?.showLoadingView()
+                    self?.tabBarController?.tabBar.isHidden = onAuthLoading
+                } else {
+                    DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) {
+                        self?.tabBarController?.tabBar.isHidden = onAuthLoading
+                        self?.hideLoadingView()
+                    }
+                }
             }
         }
         
@@ -121,15 +128,27 @@ private extension MyPageViewController {
                   let onFailNetwork = self?.myPageViewModel.onFailNetwork.value
             else { return }
             if !onFailNetwork {
-                onLoading ? self?.showLoadingView() : self?.hideLoadingView()
-                self?.myPageView.isHidden = onLoading
-                self?.topInsetView.isHidden = onLoading
-                self?.navigationBarView.isHidden = onLoading
-                self?.tabBarController?.tabBar.isHidden = onLoading
-                
-                // `onDismiss` 설정 이후 `bindData` 호출
-                self?.myPageView.userInfoView.bindData(userInfo: data)
-                self?.myPageView.userInfoView.tagCollectionView.reloadData()
+                if onLoading {
+                    self?.showLoadingView()
+                    self?.myPageView.isHidden = onLoading
+                    self?.topInsetView.isHidden = onLoading
+                    self?.navigationBarView.isHidden = onLoading
+                    self?.tabBarController?.tabBar.isHidden = onLoading
+                } else {
+                    self?.myPageView.userInfoView.onLoading = {
+                        DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) {
+                            self?.myPageView.isHidden = onLoading
+                            self?.topInsetView.isHidden = onLoading
+                            self?.navigationBarView.isHidden = onLoading
+                            self?.tabBarController?.tabBar.isHidden = onLoading
+                            self?.hideLoadingView()
+                        }
+                    }
+                    
+                    // `onDismiss` 설정 이후 `bindData` 호출
+                    self?.myPageView.userInfoView.bindData(userInfo: data)
+                    self?.myPageView.userInfoView.tagCollectionView.reloadData()
+                }
             }
         }
         

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/MyPage/Views/UserInfoView.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/MyPage/Views/UserInfoView.swift
@@ -34,6 +34,11 @@ final class UserInfoView: BaseView {
     private let rightArrowButton: UIImageView = UIImageView()
     
     
+    // MARK: - UI Properties
+    
+    var onLoading: (() -> (Void))?
+    
+    
     // MARK: - Life Cycle
     
     override func setHierarchy() {
@@ -178,6 +183,13 @@ extension UserInfoView {
             return
         }
         let url = URL(string: imageURL)
-        self.profileImageView.kf.setImage(with: url)
+        self.profileImageView.kf.setImage(with: url) { result in
+            switch result {
+            case .success:
+                self.onLoading?()
+            case .failure(let error):
+                print(error)
+            }
+        }
     }
 }

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/Onboarding/Views/BottomControlView.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/Onboarding/Views/BottomControlView.swift
@@ -54,7 +54,9 @@ final class BottomControlView: BaseView {
 }
 
 extension BottomControlView {
+    
     func updateBottomButtonText(buttonText: String) {
         self.nextButton.setTitle(buttonText, for: .normal)
     }
+    
 }

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/PointDetail/Views/Cells/PointCollectionViewCell.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/PointDetail/Views/Cells/PointCollectionViewCell.swift
@@ -10,7 +10,7 @@ import UIKit
 import SnapKit
 import Then
 
-class PointCollectionViewCell: BaseCollectionViewCell {
+final class PointCollectionViewCell: BaseCollectionViewCell {
     
     // MARK: - UI Properties
     

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/PointDetail/Views/PointDetailView.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/PointDetail/Views/PointDetailView.swift
@@ -7,7 +7,7 @@
 
 import UIKit
 
-class PointDetailView: BaseView {
+final class PointDetailView: BaseView {
 
     // MARK: - UI Properties
     

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/PointDetail/Views/PointDetailViewController.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/PointDetail/Views/PointDetailViewController.swift
@@ -87,21 +87,25 @@ extension PointDetailViewController {
         self.pointViewModel.onLoading.bind { [weak self] onLoading in
             guard let onLoading, let onFailNetwork = self?.pointViewModel.onFailNetwork.value else { return }
             if !onFailNetwork {
-                onLoading ? self?.showLoadingView() : self?.hideLoadingView()
-                self?.pointDetailView.isHidden = onLoading
+                if onLoading {
+                    self?.showLoadingView()
+                    self?.pointDetailView.isHidden = onLoading
+                } else {
+                    self?.pointDetailView.pointCollectionView.reloadData()
+                    self?.pointViewModel.updateData(nowEarnedPointHidden: false)
+                    self?.changeSelectedSegmentLayout(isEarnedPointHidden: false)
+                    
+                    DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) {
+                        self?.pointDetailView.isHidden = onLoading
+                        self?.hideLoadingView()
+                    }
+                }
             }
         }
         
         self.pointViewModel.isSuccessGetPointInfo.bind { [weak self] isSuccess in
             guard let isSuccess else { return }
-            if isSuccess {
-                self?.pointDetailView.pointCollectionView.reloadData()
-                self?.pointViewModel.updateData(nowEarnedPointHidden: false)
-                self?.changeSelectedSegmentLayout(isEarnedPointHidden: false)
-                DispatchQueue.main.asyncAfter(deadline: .now() + 1.0) {
-                    self?.pointViewModel.setPointDetailLoading()
-                }
-            }
+            self?.pointViewModel.setPointDetailLoading()
         }
         
     }

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/PointDetail/Views/PointDetailViewController.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/PointDetail/Views/PointDetailViewController.swift
@@ -74,14 +74,18 @@ class PointDetailViewController: BaseNavBarViewController {
 
 
 extension PointDetailViewController {
+    
     func bindViewModel() {
         self.pointViewModel.onFailNetwork.bind { [weak self] onFailure in
-            guard let onFailure else { return }
-            if onFailure {
-                self?.hideLoadingView()
-                let errorVC = DRErrorViewController()
-                self?.navigationController?.pushViewController(errorVC, animated: false)
-            }
+           guard let onFailure else { return }
+           if onFailure {
+              let errorVC = DRErrorViewController()
+              errorVC.onDismiss = {
+                 self?.pointViewModel.onFailNetwork.value = false
+                  self?.pointViewModel.onLoading.value = false
+              }
+              self?.navigationController?.pushViewController(errorVC, animated: false)
+           }
         }
 
         self.pointViewModel.onLoading.bind { [weak self] onLoading in
@@ -103,8 +107,7 @@ extension PointDetailViewController {
             }
         }
         
-        self.pointViewModel.isSuccessGetPointInfo.bind { [weak self] isSuccess in
-            guard let isSuccess else { return }
+        self.pointViewModel.isSuccessGetPointInfo.bind { [weak self] _ in
             self?.pointViewModel.setPointDetailLoading()
         }
         

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/PointDetail/Views/PointDetailViewController.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/PointDetail/Views/PointDetailViewController.swift
@@ -126,6 +126,7 @@ extension PointDetailViewController {
 // MARK: - Private Method
 
 private extension PointDetailViewController {
+    
     @objc
     func didChangeValue(segment: UISegmentedControl) {
         pointViewModel.changeSegment(segmentIndex: pointDetailView.segmentControl.selectedSegmentIndex)

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/PointDetail/Views/PointDetailViewController.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/PointDetail/Views/PointDetailViewController.swift
@@ -95,7 +95,7 @@ extension PointDetailViewController {
                     self?.pointViewModel.updateData(nowEarnedPointHidden: false)
                     self?.changeSelectedSegmentLayout(isEarnedPointHidden: false)
                     
-                    DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) {
+                    DispatchQueue.main.asyncAfter(deadline: .now() + 0.2) {
                         self?.pointDetailView.isHidden = onLoading
                         self?.hideLoadingView()
                     }

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/PointSystem/ViewModels/PointSystemViewModel.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/PointSystem/ViewModels/PointSystemViewModel.swift
@@ -11,10 +11,6 @@ final class PointSystemViewModel {
     
     var pointSystemData: [PointSystemModel] = []
     
-//    init() {
-//        fetchData()
-//    }
-    
 }
 
 extension PointSystemViewModel {

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/PointSystem/Views/PointSystemView.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/PointSystem/Views/PointSystemView.swift
@@ -18,8 +18,6 @@ final class PointSystemView: BaseView {
     let pointSystemCollectionView: UICollectionView = UICollectionView(frame: .zero, collectionViewLayout: UICollectionViewFlowLayout())
 
     
-    // MARK: - Properties
-    
     // MARK: - Life Cycle
     
     override func setHierarchy() {

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/Profile/ViewModels/ProfileViewModel.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/Profile/ViewModels/ProfileViewModel.swift
@@ -123,10 +123,7 @@ extension ProfileViewModel {
         
         guard let name = self.nickname.value else { return }
 
-        let requestBody = PostSignUpRequest(userSignUpReq: UserSignUpReq(name: name,
-                                                                         platform: socialType 
-                                                                         ? SocialType.KAKAO.rawValue
-                                                                         : SocialType.APPLE.rawValue),
+        let requestBody = PostSignUpRequest(userSignUpReq: UserSignUpReq(name: name, platform: socialType ? SocialType.KAKAO.rawValue : SocialType.APPLE.rawValue),
                                             image: image,
                                             tag: self.selectedTagData)
         

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/Profile/Views/EditProfileViewController.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/Profile/Views/EditProfileViewController.swift
@@ -125,7 +125,7 @@ private extension EditProfileViewController {
         self.profileViewModel.onReissueSuccess.bind { [weak self] onSuccess in
             guard let onSuccess else { return }
             if onSuccess {
-                // TODO: - 서버 통신 재시도
+                self?.profileViewModel.patchEditProfile()
             } else {
                 self?.navigationController?.pushViewController(SplashViewController(splashViewModel: SplashViewModel()), animated: false)
             }

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/Profile/Views/ProfileViewController.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/Profile/Views/ProfileViewController.swift
@@ -110,7 +110,7 @@ private extension ProfileViewController {
         self.profileViewModel.onReissueSuccess.bind { [weak self] onSuccess in
             guard let onSuccess else { return }
             if onSuccess {
-                // TODO: - 서버 통신 재시도
+                self?.profileViewModel.postSignUp(image: self?.profileView.profileImageView.image)
             } else {
                 self?.navigationController?.pushViewController(SplashViewController(splashViewModel: SplashViewModel()), animated: false)
             }

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/Profile/Views/ProfileViewController.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/Profile/Views/ProfileViewController.swift
@@ -179,7 +179,7 @@ private extension ProfileViewController {
 
         self.profileViewModel.onSuccessRegister = { [weak self] isSuccess in
             if isSuccess {
-                guard let userId = UserDefaults.standard.string(forKey: "userID") else { return }
+                guard let userId = UserDefaults.standard.string(forKey: StringLiterals.Network.userID) else { return }
                 AmplitudeManager.shared.setUserId(userId)
                 
                 let mainVC = TabBarController()


### PR DESCRIPTION
# 🔥*Pull requests*
## 📢 서버 통신 결과 처리를 좀 더 신경써주면 좋을 것 같아요!
제가 보이는 건 다 수정하고 있지만 이런 부분들도 신경써서 고민해보고 직접 구현해보는 것도 중요해요! 
다들 한 번씩 확인하고 수정할 부분 있으면 수정해주세요! 좀만 더 화이팅🫶🏻 

## ⛳ **작업한 브랜치**
- fix/#228

## 👷 **작업한 내용**
<!-- 작업한 내용을 적어주세요. -->
- [x] 메인 유저 프로필 외부 검정색 배경 제거
- [x] 메인 Hot 코스 스크롤 걸리지 않도록 수정
- [x] 나머지 로딩뷰 로직 리팩
- [x] 나머지 에러뷰 로직 리팩



## 🚨 참고 사항
<!-- 참고할 사항이 있다면 적어주세요. -->
### 1️⃣ 로딩뷰 & 에러뷰 로직 리팩 및 전체 적용
- 수정한 로딩뷰 로직은 로딩뷰가 사용되는 모든 뷰에 적용해둔 상태입니다
- 마찬가지로 에러뷰 또한 모든 뷰에 적용해두었습니다

### 2️⃣ 로딩뷰 & 에러뷰 로직 리팩 및 전체 적용
- 토큰 재발급 후 서버 통신 재시도 처리가 되어 있지 않은 부분도 모두 구현해두었습니다
- 하나의 뷰컨에서 여러 개의 서버 통신을 하는 경우, 어떤 서버 통신에서 토큰 재발급이 필요한지 구분할 수 없기 때문에 따로 NetworkType enum을 만들어 구분해주었습니다
``` Swift
self.pastDateDetailViewModel.onReissueSuccess.bind { [weak self] onSuccess in
    guard let onSuccess, let dateID = self?.dateID else { return }
    if onSuccess {
        switch self?.networkType {
        case .deleteDateSchedule:
            self?.pastDateDetailViewModel.deleteDateSchdeuleData(dateID: dateID)
        case .getDateDetail:
            self?.pastDateDetailViewModel.getDateDetailData(dateID: dateID)
        default:
            self?.navigationController?.pushViewController(SplashViewController(splashViewModel: SplashViewModel()), animated: false)
        }
    } else {
        self?.navigationController?.pushViewController(SplashViewController(splashViewModel: SplashViewModel()), animated: false)
    }
}
```



## 📟 관련 이슈
- Resolved: #228 
