### PR TITLE
[FEAT] 데이트일정 및 열람한 코스 Amplitude 적용 (#218)

### DIFF
--- a/DATEROAD-iOS/DATEROAD-iOS/Global/Literals/StringLiterals.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Global/Literals/StringLiterals.swift
@@ -298,6 +298,7 @@ enum StringLiterals {
             static let clickAddSchedule = "click_add_schedule"
             static let clickKakaoShare = "click_kakao_share"
             static let clickOpenKakao = "click_open_kakao"
+            static let viewPurchasedCourse = "view_purchased_course"
         }
         
         enum Property {

--- a/DATEROAD-iOS/DATEROAD-iOS/Global/Literals/StringLiterals.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Global/Literals/StringLiterals.swift
@@ -296,6 +296,7 @@ enum StringLiterals {
             static let viewDateSchedule = "view_date_schedule"
             static let countDateSchedule = "count_date_schedule"
             static let clickAddSchedule = "click_add_schedule"
+            static let viewScheduleDetails = "view_schedule_details"
             static let clickKakaoShare = "click_kakao_share"
             static let clickOpenKakao = "click_open_kakao"
             static let clickCloseKakao = "click_close_kakao"
@@ -308,6 +309,7 @@ enum StringLiterals {
             static let courseListLocation = "course_list_location"
             static let courseListCost = "course_list_cost"
             static let dateScheduleNum = "date_schedule_num"
+            static let viewPath = "view_path"
             static let dateCourseNum = "date_course_num"
             static let dateTotalDuration = "date_total_duration"
         }

--- a/DATEROAD-iOS/DATEROAD-iOS/Global/Literals/StringLiterals.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Global/Literals/StringLiterals.swift
@@ -293,6 +293,7 @@ enum StringLiterals {
     enum Amplitude {
         enum EventName {
             static let viewMain = "view_main"
+            static let viewDateSchedule = "view_date_schedule"
         }
         
         enum Property {

--- a/DATEROAD-iOS/DATEROAD-iOS/Global/Literals/StringLiterals.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Global/Literals/StringLiterals.swift
@@ -294,6 +294,7 @@ enum StringLiterals {
         enum EventName {
             static let viewMain = "view_main"
             static let viewDateSchedule = "view_date_schedule"
+            static let countDateSchedule = "count_date_schedule"
         }
         
         enum Property {
@@ -301,6 +302,7 @@ enum StringLiterals {
             static let courseListTitle = "course_list_title"
             static let courseListLocation = "course_list_location"
             static let courseListCost = "course_list_cost"
+            static let dateScheduleNum = "date_schedule_num"
         }
         
         enum UserProperty {

--- a/DATEROAD-iOS/DATEROAD-iOS/Global/Literals/StringLiterals.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Global/Literals/StringLiterals.swift
@@ -296,6 +296,7 @@ enum StringLiterals {
             static let viewDateSchedule = "view_date_schedule"
             static let countDateSchedule = "count_date_schedule"
             static let clickAddSchedule = "click_add_schedule"
+            static let clickKakaoShare = "click_kakao_share"
         }
         
         enum Property {
@@ -304,6 +305,8 @@ enum StringLiterals {
             static let courseListLocation = "course_list_location"
             static let courseListCost = "course_list_cost"
             static let dateScheduleNum = "date_schedule_num"
+            static let dateCourseNum = "date_course_num"
+            static let dateTotalDuration = "date_total_duration"
         }
         
         enum UserProperty {

--- a/DATEROAD-iOS/DATEROAD-iOS/Global/Literals/StringLiterals.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Global/Literals/StringLiterals.swift
@@ -298,6 +298,7 @@ enum StringLiterals {
             static let clickAddSchedule = "click_add_schedule"
             static let clickKakaoShare = "click_kakao_share"
             static let clickOpenKakao = "click_open_kakao"
+            static let clickCloseKakao = "click_close_kakao"
             static let viewPurchasedCourse = "view_purchased_course"
         }
         

--- a/DATEROAD-iOS/DATEROAD-iOS/Global/Literals/StringLiterals.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Global/Literals/StringLiterals.swift
@@ -295,6 +295,7 @@ enum StringLiterals {
             static let viewMain = "view_main"
             static let viewDateSchedule = "view_date_schedule"
             static let countDateSchedule = "count_date_schedule"
+            static let clickAddSchedule = "click_add_schedule"
         }
         
         enum Property {

--- a/DATEROAD-iOS/DATEROAD-iOS/Global/Literals/StringLiterals.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Global/Literals/StringLiterals.swift
@@ -297,6 +297,7 @@ enum StringLiterals {
             static let countDateSchedule = "count_date_schedule"
             static let clickAddSchedule = "click_add_schedule"
             static let clickKakaoShare = "click_kakao_share"
+            static let clickOpenKakao = "click_open_kakao"
         }
         
         enum Property {

--- a/DATEROAD-iOS/DATEROAD-iOS/Global/Literals/StringLiterals.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Global/Literals/StringLiterals.swift
@@ -301,6 +301,7 @@ enum StringLiterals {
             static let clickOpenKakao = "click_open_kakao"
             static let clickCloseKakao = "click_close_kakao"
             static let viewPurchasedCourse = "view_purchased_course"
+            static let clickPurchasedBack = "click_purchased_back"
         }
         
         enum Property {

--- a/DATEROAD-iOS/DATEROAD-iOS/Global/UIComponents/CustomAlert/DRCustomAlertViewController.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Global/UIComponents/CustomAlert/DRCustomAlertViewController.swift
@@ -12,11 +12,13 @@ import SnapKit
 protocol DRCustomAlertDelegate {
     func action(rightButtonAction: RightButtonType)
     func exit()
+    func leftButtonAction(rightButtonAction: RightButtonType)
 }
 
 extension DRCustomAlertDelegate {
     func action(rightButtonAction: RightButtonType) {}
     func exit() {}
+    func leftButtonAction(rightButtonAction: RightButtonType) {}
 }
 
 class DRCustomAlertViewController: BaseViewController {
@@ -153,6 +155,7 @@ private extension DRCustomAlertViewController {
     @objc
     func leftButtonTapped() {
         self.dismiss(animated: false) {
+            self.delegate?.leftButtonAction(rightButtonAction: self.rightActionType)
             self.delegate?.exit()
         }
     }

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/Base/BaseNavBarViewController.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/Base/BaseNavBarViewController.swift
@@ -117,7 +117,6 @@ extension BaseNavBarViewController {
       leftButton.do {
          $0.isHidden = false
          $0.setImage(image, for: .normal)
-         setLeftButtonAction(target: self, action: #selector(backButtonTapped))
       }
    }
    

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/DateSchedule/Model/DateScheduleModel.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/DateSchedule/Model/DateScheduleModel.swift
@@ -23,6 +23,10 @@ struct DateCardModel {
         self.tags = tags
         self.dDay = dDay
     }
+    
+    static var emptyModel: DateCardModel {
+        return DateCardModel(dateID: 0, title: "", date: "", city: "", tags: [], dDay: 0)
+    }
 }
 
 struct TagsModel {

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/DateSchedule/View/UpcomingDateDetailViewController.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/DateSchedule/View/UpcomingDateDetailViewController.swift
@@ -188,7 +188,6 @@ extension UpcomingDateDetailViewController: DRCustomAlertDelegate {
     
     @objc
     private func tapDeleteLabel() {
-        print("dfdsf")
         let customAlertVC = DRCustomAlertViewController(rightActionType: RightButtonType.deleteCourse, alertTextType: .hasDecription, alertButtonType: .twoButton, titleText: StringLiterals.Alert.deleteDateSchedule, descriptionText: StringLiterals.Alert.noMercy, rightButtonText: "삭제")
         customAlertVC.delegate = self
         customAlertVC.modalPresentationStyle = .overFullScreen
@@ -196,14 +195,11 @@ extension UpcomingDateDetailViewController: DRCustomAlertDelegate {
     }
 
     func action(rightButtonAction: RightButtonType) {
-           print("all")
            if rightButtonAction == .deleteCourse {
-               print("zz")
                upcomingDateDetailViewModel.deleteDateSchdeuleData(dateID: upcomingDateDetailViewModel.dateDetailData.value?.dateID ?? 0)
            } else if rightButtonAction == .kakaoShare {
                upcomingDateDetailViewModel.shareToKakao(context: self)
                AmplitudeManager.shared.trackEventWithProperties(StringLiterals.Amplitude.EventName.clickOpenKakao, properties: [StringLiterals.Amplitude.Property.dateCourseNum : upcomingDateDetailViewModel.dateCourseNum, StringLiterals.Amplitude.Property.dateTotalDuration : upcomingDateDetailViewModel.dateTotalDuration])
-               print("카카오 공유하기")
            }
        }
     
@@ -228,13 +224,11 @@ extension UpcomingDateDetailViewController: DRBottomSheetDelegate {
     }
     
     func didTapBottomButton() {
-        print("hi")
         self.dismiss(animated: false)
     }
     
     @objc
     func didTapFirstLabel() {
-        print("sdjflksd ㅇㄴㄹㅁㄴㅇㄹ")
         self.dismiss(animated: false)
         tapDeleteLabel()
     }

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/DateSchedule/View/UpcomingDateDetailViewController.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/DateSchedule/View/UpcomingDateDetailViewController.swift
@@ -195,13 +195,13 @@ extension UpcomingDateDetailViewController: DRCustomAlertDelegate {
     }
 
     func action(rightButtonAction: RightButtonType) {
-           if rightButtonAction == .deleteCourse {
-               upcomingDateDetailViewModel.deleteDateSchdeuleData(dateID: upcomingDateDetailViewModel.dateDetailData.value?.dateID ?? 0)
-           } else if rightButtonAction == .kakaoShare {
-               upcomingDateDetailViewModel.shareToKakao(context: self)
-               AmplitudeManager.shared.trackEventWithProperties(StringLiterals.Amplitude.EventName.clickOpenKakao, properties: [StringLiterals.Amplitude.Property.dateCourseNum : upcomingDateDetailViewModel.dateCourseNum, StringLiterals.Amplitude.Property.dateTotalDuration : upcomingDateDetailViewModel.dateTotalDuration])
-           }
-       }
+        if rightButtonAction == .deleteCourse {
+            upcomingDateDetailViewModel.deleteDateSchdeuleData(dateID: upcomingDateDetailViewModel.dateDetailData.value?.dateID ?? 0)
+        } else if rightButtonAction == .kakaoShare {
+            upcomingDateDetailViewModel.shareToKakao(context: self)
+            AmplitudeManager.shared.trackEventWithProperties(StringLiterals.Amplitude.EventName.clickOpenKakao, properties: [StringLiterals.Amplitude.Property.dateCourseNum : upcomingDateDetailViewModel.dateCourseNum, StringLiterals.Amplitude.Property.dateTotalDuration : upcomingDateDetailViewModel.dateTotalDuration])
+        }
+   }
     
     func leftButtonAction(rightButtonAction: RightButtonType) {
         if rightButtonAction == .kakaoShare {

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/DateSchedule/View/UpcomingDateDetailViewController.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/DateSchedule/View/UpcomingDateDetailViewController.swift
@@ -201,6 +201,13 @@ extension UpcomingDateDetailViewController: DRCustomAlertDelegate {
                print("카카오 공유하기")
            }
        }
+    
+    func leftButtonAction(rightButtonAction: RightButtonType) {
+        if rightButtonAction == .kakaoShare {
+            AmplitudeManager.shared.trackEventWithProperties(StringLiterals.Amplitude.EventName.clickCloseKakao, properties: [StringLiterals.Amplitude.Property.dateCourseNum : upcomingDateDetailViewModel.dateCourseNum, StringLiterals.Amplitude.Property.dateTotalDuration : upcomingDateDetailViewModel.dateTotalDuration])
+        }
+    }
+
 }
 
 

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/DateSchedule/View/UpcomingDateDetailViewController.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/DateSchedule/View/UpcomingDateDetailViewController.swift
@@ -23,6 +23,8 @@ final class UpcomingDateDetailViewController: BaseNavBarViewController {
     
     var dateID: Int
     
+    var viewPath: String
+    
     var upcomingDateDetailViewModel: DateDetailViewModel
     
     private let dateScheduleDeleteView = DateScheduleDeleteView()
@@ -30,8 +32,9 @@ final class UpcomingDateDetailViewController: BaseNavBarViewController {
     
     // MARK: - LifeCycle
     
-    init(dateID: Int, upcomingDateDetailViewModel: DateDetailViewModel) {
+    init(dateID: Int, viewPath: String, upcomingDateDetailViewModel: DateDetailViewModel) {
         self.dateID = dateID
+        self.viewPath = viewPath
         self.upcomingDateDetailViewModel = upcomingDateDetailViewModel
         
         super.init(nibName: nil, bundle: nil)
@@ -59,6 +62,8 @@ final class UpcomingDateDetailViewController: BaseNavBarViewController {
         self.tabBarController?.tabBar.isHidden = true
         self.upcomingDateDetailViewModel.setDateDetailLoading()
         self.upcomingDateDetailViewModel.getDateDetailData(dateID: self.dateID)
+        
+        AmplitudeManager.shared.trackEventWithProperties(StringLiterals.Amplitude.EventName.viewScheduleDetails, properties: [StringLiterals.Amplitude.Property.viewPath: viewPath])
     }
     
     override func setHierarchy() {

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/DateSchedule/View/UpcomingDateDetailViewController.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/DateSchedule/View/UpcomingDateDetailViewController.swift
@@ -197,6 +197,7 @@ extension UpcomingDateDetailViewController: DRCustomAlertDelegate {
                upcomingDateDetailViewModel.deleteDateSchdeuleData(dateID: upcomingDateDetailViewModel.dateDetailData.value?.dateID ?? 0)
            } else if rightButtonAction == .kakaoShare {
                upcomingDateDetailViewModel.shareToKakao(context: self)
+               AmplitudeManager.shared.trackEventWithProperties(StringLiterals.Amplitude.EventName.clickOpenKakao, properties: [StringLiterals.Amplitude.Property.dateCourseNum : upcomingDateDetailViewModel.dateCourseNum, StringLiterals.Amplitude.Property.dateTotalDuration : upcomingDateDetailViewModel.dateTotalDuration])
                print("카카오 공유하기")
            }
        }

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/DateSchedule/View/UpcomingDateDetailViewController.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/DateSchedule/View/UpcomingDateDetailViewController.swift
@@ -170,6 +170,7 @@ extension UpcomingDateDetailViewController {
 extension UpcomingDateDetailViewController: DRCustomAlertDelegate {
     @objc
     private func tapKakaoButton() {
+        AmplitudeManager.shared.trackEventWithProperties(StringLiterals.Amplitude.EventName.clickKakaoShare, properties: [StringLiterals.Amplitude.Property.dateCourseNum : upcomingDateDetailViewModel.dateCourseNum, StringLiterals.Amplitude.Property.dateTotalDuration : upcomingDateDetailViewModel.dateTotalDuration])
         let customAlertVC = DRCustomAlertViewController(rightActionType: RightButtonType.kakaoShare,
                                                       alertTextType: .noDescription,
                                                       alertButtonType: .twoButton,

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/DateSchedule/View/UpcomingDateScheduleViewController.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/DateSchedule/View/UpcomingDateScheduleViewController.swift
@@ -227,7 +227,7 @@ extension UpcomingDateScheduleViewController: UICollectionViewDataSource {
     }
     
     func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
-        let data = upcomingDateScheduleViewModel.upcomingDateScheduleData.value?[indexPath.item] ?? DateCardModel(dateID: 0, title: "", date: "", city: "", tags: [], dDay: 0)
+        let data = upcomingDateScheduleViewModel.upcomingDateScheduleData.value?[indexPath.item] ?? DateCardModel.emptyModel
         guard let cell = collectionView.dequeueReusableCell(withReuseIdentifier: DateCardCollectionViewCell.cellIdentifier, for: indexPath) as? DateCardCollectionViewCell else {
             return UICollectionViewCell()
         }
@@ -241,7 +241,7 @@ extension UpcomingDateScheduleViewController: UICollectionViewDataSource {
     func pushToUpcomingDateDetailVC(_ sender: UITapGestureRecognizer) {
         let location = sender.location(in: upcomingDateScheduleView.cardCollectionView)
         if let indexPath = upcomingDateScheduleView.cardCollectionView.indexPathForItem(at: location) {
-            let data = upcomingDateScheduleViewModel.upcomingDateScheduleData.value?[indexPath.item] ?? DateCardModel(dateID: 0, title: "", date: "", city: "", tags: [], dDay: 0)
+            let data = upcomingDateScheduleViewModel.upcomingDateScheduleData.value?[indexPath.item] ?? DateCardModel.emptyModel
             let upcomingDateDetailVC = UpcomingDateDetailViewController(dateID: data.dateID, viewPath: StringLiterals.TabBar.date, upcomingDateDetailViewModel: DateDetailViewModel()
             )
             upcomingDateDetailVC.setColor(index: indexPath.item)

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/DateSchedule/View/UpcomingDateScheduleViewController.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/DateSchedule/View/UpcomingDateScheduleViewController.swift
@@ -67,7 +67,6 @@ final class UpcomingDateScheduleViewController: BaseViewController {
     }
     
     func drawDateCardView() {
-        print("draw date card view")
         let isEmpty = upcomingDateScheduleViewModel.upcomingDateScheduleData.value?.count == 0
         upcomingDateScheduleView.emptyView.isHidden = !isEmpty
         upcomingDateScheduleView.cardCollectionView.isHidden = isEmpty
@@ -141,10 +140,8 @@ private extension UpcomingDateScheduleViewController {
         }
         
         self.upcomingDateScheduleViewModel.onUpcomingScheduleFailNetwork.bind { [weak self] onFailure in
-            print("아아아아아아ㅏ아아아아아아아아아아아아ㅏ앙", onFailure ?? "없지롱")
             guard let onFailure else { return }
             if onFailure {
-                print("됨 !!")
                 self?.hideLoadingView()
                 let errorVC = DRErrorViewController()
                 self?.navigationController?.pushViewController(errorVC, animated: false)
@@ -165,7 +162,6 @@ extension UpcomingDateScheduleViewController: DRCustomAlertDelegate {
             customAlertVC.modalPresentationStyle = .overFullScreen
             self.present(customAlertVC, animated: false)
         } else {
-            print("push to 일정등록하기")
            let vc = AddScheduleFirstViewController(viewModel: AddScheduleViewModel())
            self.navigationController?.pushViewController(vc, animated: false)
         }
@@ -232,11 +228,9 @@ extension UpcomingDateScheduleViewController: UICollectionViewDataSource {
     
     func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
         let data = upcomingDateScheduleViewModel.upcomingDateScheduleData.value?[indexPath.item] ?? DateCardModel(dateID: 0, title: "", date: "", city: "", tags: [], dDay: 0)
-        print(data)
         guard let cell = collectionView.dequeueReusableCell(withReuseIdentifier: DateCardCollectionViewCell.cellIdentifier, for: indexPath) as? DateCardCollectionViewCell else {
             return UICollectionViewCell()
         }
-        print("🥵셀configure중🥵")
         cell.dataBind(data, indexPath.item)
         cell.setColor(index: indexPath.item)
         cell.addGestureRecognizer(UITapGestureRecognizer(target: self, action: #selector(pushToUpcomingDateDetailVC(_:))))

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/DateSchedule/View/UpcomingDateScheduleViewController.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/DateSchedule/View/UpcomingDateScheduleViewController.swift
@@ -169,7 +169,7 @@ extension UpcomingDateScheduleViewController: DRCustomAlertDelegate {
            let vc = AddScheduleFirstViewController(viewModel: AddScheduleViewModel())
            self.navigationController?.pushViewController(vc, animated: false)
         }
-        
+        AmplitudeManager.shared.trackEvent(StringLiterals.Amplitude.EventName.clickAddSchedule)
     }
 }
 

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/DateSchedule/View/UpcomingDateScheduleViewController.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/DateSchedule/View/UpcomingDateScheduleViewController.swift
@@ -248,7 +248,7 @@ extension UpcomingDateScheduleViewController: UICollectionViewDataSource {
         let location = sender.location(in: upcomingDateScheduleView.cardCollectionView)
         if let indexPath = upcomingDateScheduleView.cardCollectionView.indexPathForItem(at: location) {
             let data = upcomingDateScheduleViewModel.upcomingDateScheduleData.value?[indexPath.item] ?? DateCardModel(dateID: 0, title: "", date: "", city: "", tags: [], dDay: 0)
-            let upcomingDateDetailVC = UpcomingDateDetailViewController(dateID: data.dateID, upcomingDateDetailViewModel: DateDetailViewModel()
+            let upcomingDateDetailVC = UpcomingDateDetailViewController(dateID: data.dateID, viewPath: StringLiterals.TabBar.date, upcomingDateDetailViewModel: DateDetailViewModel()
             )
             upcomingDateDetailVC.setColor(index: indexPath.item)
             self.navigationController?.pushViewController(upcomingDateDetailVC, animated: false)

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/DateSchedule/ViewModel/DateDetailViewModel.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/DateSchedule/ViewModel/DateDetailViewModel.swift
@@ -91,7 +91,6 @@ extension DateDetailViewModel {
             switch response {
             case .success(let data):
                 self.isSuccessDeleteDateScheduleData.value = true
-                print("success", self.isSuccessDeleteDateScheduleData.value)
             case .reIssueJWT:
                 self.patchReissue { isSuccess in
                     self.onReissueSuccess.value = isSuccess
@@ -105,7 +104,6 @@ extension DateDetailViewModel {
     func setTempArgs() {
         kakaoShareInfo[StringLiterals.Network.userName] = userName
         kakaoShareInfo["startAt"] = dateDetailData.value?.startAt
-        print(dateDetailData.value?.places.count)
         switch dateDetailData.value?.places.count ?? 0 <= 5 {
         case true:
             for i in 0...maxPlaces-1 {
@@ -127,7 +125,6 @@ extension DateDetailViewModel {
 
         if !AuthApi.hasToken() {
             // Generate Redirect URI
-            print("is 1")
             let redirectURI = "kakao\(Config.kakaoNativeAppKey)://oauth"
             // Redirect to Kakao login page
             let loginUrl = "https://kauth.kakao.com/oauth/authorize?client_id=\(Config.kakaoNativeAppKey)&redirect_uri=\(redirectURI)&response_type=code"

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/DateSchedule/ViewModel/DateDetailViewModel.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/DateSchedule/ViewModel/DateDetailViewModel.swift
@@ -64,7 +64,15 @@ extension DateDetailViewModel {
                 let datePlaceInfo: [DatePlaceModel] = data.places.map { place in
                     DatePlaceModel(name: place.title, duration: (place.duration).formatFloatTime(), sequence: place.sequence)
                 }
-                self.dateDetailData.value = DateDetailModel(dateID: data.dateID, title: data.title, startAt: data.startAt, city: data.city, tags: tagsInfo, date: data.date.formatDateFromString(inputFormat: "yyyy.MM.dd", outputFormat: "yyyy년 M월 d일") ?? "", places: datePlaceInfo, dDay: data.dDay)
+                self.dateDetailData.value = DateDetailModel(dateID: data.dateID,
+                                                            title: data.title,
+                                                            startAt: data.startAt,
+                                                            city: data.city,
+                                                            tags: tagsInfo,
+                                                            date: data.date.formatDateFromString(inputFormat: "yyyy.MM.dd",
+                                                                                                 outputFormat: "yyyy년 M월 d일") ?? "",
+                                                            places: datePlaceInfo,
+                                                            dDay: data.dDay)
                 self.isSuccessGetDateDetailData.value = true
                 self.dateCourseNum = self.dateDetailData.value?.places.count ?? 0
                 self.dateTotalDuration = datePlaceInfo.map { Float($0.duration) ?? 0 }.reduce(0, +)

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/DateSchedule/ViewModel/DateDetailViewModel.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/DateSchedule/ViewModel/DateDetailViewModel.swift
@@ -41,7 +41,11 @@ class DateDetailViewModel: Serviceable {
     
     var isMoreThanFiveSchedule : Bool {
         return (dateDetailData.value?.places.count ?? 0 >= 5)
-    }    
+    }
+    
+    var dateCourseNum : Int = 0
+    
+    var dateTotalDuration : Float = 0
 }
 
 extension DateDetailViewModel {
@@ -62,6 +66,8 @@ extension DateDetailViewModel {
                 }
                 self.dateDetailData.value = DateDetailModel(dateID: data.dateID, title: data.title, startAt: data.startAt, city: data.city, tags: tagsInfo, date: data.date.formatDateFromString(inputFormat: "yyyy.MM.dd", outputFormat: "yyyy년 M월 d일") ?? "", places: datePlaceInfo, dDay: data.dDay)
                 self.isSuccessGetDateDetailData.value = true
+                self.dateCourseNum = self.dateDetailData.value?.places.count ?? 0
+                self.dateTotalDuration = datePlaceInfo.map { Float($0.duration) ?? 0 }.reduce(0, +)
             case .serverErr:
                 self.onFailNetwork.value = true
             case .reIssueJWT:

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/DateSchedule/ViewModel/DateScheduleViewModel.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/DateSchedule/ViewModel/DateScheduleViewModel.swift
@@ -91,7 +91,6 @@ final class DateScheduleViewModel: Serviceable {
                 AmplitudeManager.shared.trackEventWithProperties(StringLiterals.Amplitude.EventName.countDateSchedule, properties: [StringLiterals.Amplitude.Property.dateScheduleNum : dateScheduleNum])
                 self.upcomingDateScheduleData.value = dateScheduleInfo
                 self.isSuccessGetUpcomingDateScheduleData.value = true
-                print("🍎🍎뷰모델 서버통신 성공🍎🍎", self.isSuccessGetUpcomingDateScheduleData.value)
             case .serverErr:
                 self.onUpcomingScheduleFailNetwork.value = true
             case .reIssueJWT:
@@ -100,7 +99,6 @@ final class DateScheduleViewModel: Serviceable {
                 }
             default:
                 self.isSuccessGetUpcomingDateScheduleData.value = false
-                print("false?")
             }
             self.setUpcomingScheduleLoading()
         }

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/DateSchedule/ViewModel/DateScheduleViewModel.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/DateSchedule/ViewModel/DateScheduleViewModel.swift
@@ -85,9 +85,10 @@ final class DateScheduleViewModel: Serviceable {
                     }
                     return DateCardModel(dateID: date.dateID, title: date.title, date: (date.date).toReadableDate() ?? "", city: date.city , tags: tagsModel, dDay: date.dDay)
                 }
-                
+                let dateScheduleNum = data.dates.count
                 AmplitudeManager.shared.setUserProperty(userProperties: [StringLiterals.Amplitude.UserProperty.dateScheduleNum : dateScheduleInfo.count])
                 AmplitudeManager.shared.trackEvent(StringLiterals.Amplitude.EventName.viewDateSchedule)
+                AmplitudeManager.shared.trackEventWithProperties(StringLiterals.Amplitude.EventName.countDateSchedule, properties: [StringLiterals.Amplitude.Property.dateScheduleNum : dateScheduleNum])
                 self.upcomingDateScheduleData.value = dateScheduleInfo
                 self.isSuccessGetUpcomingDateScheduleData.value = true
                 print("🍎🍎뷰모델 서버통신 성공🍎🍎", self.isSuccessGetUpcomingDateScheduleData.value)

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/DateSchedule/ViewModel/DateScheduleViewModel.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/DateSchedule/ViewModel/DateScheduleViewModel.swift
@@ -87,6 +87,7 @@ final class DateScheduleViewModel: Serviceable {
                 }
                 
                 AmplitudeManager.shared.setUserProperty(userProperties: [StringLiterals.Amplitude.UserProperty.dateScheduleNum : dateScheduleInfo.count])
+                AmplitudeManager.shared.trackEvent(StringLiterals.Amplitude.EventName.viewDateSchedule)
                 self.upcomingDateScheduleData.value = dateScheduleInfo
                 self.isSuccessGetUpcomingDateScheduleData.value = true
                 print("🍎🍎뷰모델 서버통신 성공🍎🍎", self.isSuccessGetUpcomingDateScheduleData.value)

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/Main/Views/MainViewController.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/Main/Views/MainViewController.swift
@@ -196,7 +196,7 @@ extension MainViewController {
     @objc
     func pushToDateDetailVC(_ sender: UIButton) {
         let dateID = sender.tag
-        let upcomingDateDetailVC = UpcomingDateDetailViewController(dateID: dateID, upcomingDateDetailViewModel: DateDetailViewModel())
+        let upcomingDateDetailVC = UpcomingDateDetailViewController(dateID: dateID, viewPath: StringLiterals.TabBar.home, upcomingDateDetailViewModel: DateDetailViewModel())
         upcomingDateDetailVC.setColor(index: dateID)
         self.navigationController?.pushViewController(upcomingDateDetailVC, animated: false)
     }

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/MyCourse/ViewModels/MyCourseListViewModel.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/MyCourse/ViewModels/MyCourseListViewModel.swift
@@ -64,7 +64,6 @@ final class MyCourseListViewModel: Serviceable {
             case .serverErr:
                 self.onViewedCourseFailNetwork.value = true
             default:
-                print("내가 열람한 코스 에러")
                 self.onViewedCourseFailNetwork.value = true //TODO: - 확인
                 return
             }
@@ -99,7 +98,6 @@ final class MyCourseListViewModel: Serviceable {
             case .serverErr:
                 self.onNavViewedCourseFailNetwork.value = true
             default:
-                print("내가 열람한 코스 에러")
                 self.onNavViewedCourseFailNetwork.value = true //TODO: - 확인
                 return
             }
@@ -128,7 +126,6 @@ final class MyCourseListViewModel: Serviceable {
                 AmplitudeManager.shared.setUserProperty(userProperties: [StringLiterals.Amplitude.UserProperty.userCourseCount: myRegisterCourseInfo.count])
                 self.myRegisterCourseData.value = myRegisterCourseInfo
                 self.isSuccessGetMyRegisterCourseInfo.value = true
-                print("isUpdate>", self.myRegisterCourseData)
             case .reIssueJWT:
                 self.patchReissue { isSuccess in
                     self.onReissueSuccess.value = isSuccess
@@ -136,7 +133,6 @@ final class MyCourseListViewModel: Serviceable {
             case .serverErr:
                 self.onMyRegisterCourseFailNetwork.value = true
             default:
-                print("내가 등록한 코스 에러")
                 self.onMyRegisterCourseFailNetwork.value = true //TODO: - 확인
                 return
             }

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/MyCourse/Views/NavViewedCourseViewController.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/MyCourse/Views/NavViewedCourseViewController.swift
@@ -42,7 +42,8 @@ final class NavViewedCourseViewController: BaseNavBarViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         
-        setLeftBackButton()
+        setLeftButtonStyle(image: UIImage(named: "leftArrow"))
+        setLeftButtonAction(target: self, action: #selector(leftButtonTapped))
         setTitleLabelStyle(title: StringLiterals.ViewedCourse.title, alignment: .center)
         register()
         setDelegate()
@@ -63,6 +64,14 @@ final class NavViewedCourseViewController: BaseNavBarViewController {
         }
     }
 
+}
+
+extension NavViewedCourseViewController {
+    @objc
+    func leftButtonTapped() {
+        navigationController?.popViewController(animated: false)
+        AmplitudeManager.shared.trackEvent(StringLiterals.Amplitude.EventName.clickPurchasedBack)
+    }
 }
 
 // MARK: - EmptyView Methods

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/MyCourse/Views/ViewedCourseViewController.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/MyCourse/Views/ViewedCourseViewController.swift
@@ -49,6 +49,7 @@ final class ViewedCourseViewController: BaseViewController {
     
     override func viewWillAppear(_ animated: Bool) {
         self.viewedCourseViewModel.setViewedCourseData()
+        AmplitudeManager.shared.trackEvent(StringLiterals.Amplitude.EventName.viewPurchasedCourse)
     }
     
     override func viewDidLoad() {

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/PointDetail/ViewModels/PointViewModel.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/PointDetail/ViewModels/PointViewModel.swift
@@ -75,7 +75,6 @@ final class PointViewModel: Serviceable {
             case .serverErr:
                 self.onFailNetwork.value = true
              default:
-                print("포인트내역 에러")
                 self.onFailNetwork.value = true //TODO: - 확인
                 return
             }

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/PointDetail/Views/PointDetailViewController.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/PointDetail/Views/PointDetailViewController.swift
@@ -134,7 +134,6 @@ private extension PointDetailViewController {
     
     func changeSelectedSegmentLayout(isEarnedPointHidden: Bool?) {
         guard let isEarnedPointHidden = isEarnedPointHidden else { return }
-        print(isEarnedPointHidden)
         if isEarnedPointHidden {
             switch pointViewModel.usedPointData.value?.count == 0 {
             case true:


### PR DESCRIPTION
# 🔥*Pull requests*

## ⛳ **작업한 브랜치**
- #218 

## 👷 **작업한 내용**
데이트일정 및 열람한 코스 Amplitude을 적용하였습니다

## 🚨 참고 사항
적용 과정에서 공용 컴포넌트인 DRCustomAlertVC를 수정했는데, DRCustomAlertVC를 사용하는 다른 뷰컨들에게 영향이 가지 않게 수정했습니다 ! 테스트도 해보았지만 혹시 문제가 있으면 알려주시면 감사하겠습니다 !!

## 📸 스크린샷


## 📟 관련 이슈
- Resolved: #218
