### PR TITLE
[FEAT] '일정 등록' & '코스 등록' 관련 Amplitude 적용 (#215)

### DIFF
--- a/DATEROAD-iOS/DATEROAD-iOS/Global/Literals/StringLiterals.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Global/Literals/StringLiterals.swift
@@ -300,6 +300,10 @@ enum StringLiterals {
            static let clickBringCourse = "click_bring_course"
            static let viewAddBringcourse = "view_add_bringcourse"
            static let viewAddBringcourse2 = "view_add_bringcourse2"
+           static let viewCourse1 = "view_course1"
+           static let clickCourse1Back = "click_course1_back"
+           static let clickCourse2Back = "click_course2_back"
+           static let clickCourse3Back = "click_course3_back"
         }
         
         enum Property {
@@ -316,6 +320,18 @@ enum StringLiterals {
            static let dateDetailLocation = "date_detail_location"
            static let dateDetailTime = "date_detail_time"
            static let dateCourseNum = "date_course_num"
+           static let courseImage = "course_image"
+           static let courseTitle = "course_title"
+           static let courseDate = "course_date"
+           static let courseStartTime = "course_start_time"
+           static let courseTags = "course_tags"
+           static let courseLocation = "course_location"
+           static let dateLocation = "date_location"
+           static let dateSpendTime = "date_spend_time"
+           static let locationNum = "location_num"
+           static let courseContentBool = "course_content_bool"
+           static let courseContentNum = "course_content_num"
+           static let courseCost = "course_cost"
         }
         
         enum UserProperty {
@@ -327,6 +343,8 @@ enum StringLiterals {
         }
        
        enum ViewPath {
+          static let home = "홈"
+          static let exploreCourse = "코스 둘러보기"
           static let dateSchedule = "데이트 일정"
           static let viewedCourse = "내가 열람한 코스"
           static let courseDetail = "코스 상세"

--- a/DATEROAD-iOS/DATEROAD-iOS/Global/Literals/StringLiterals.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Global/Literals/StringLiterals.swift
@@ -293,6 +293,8 @@ enum StringLiterals {
     enum Amplitude {
         enum EventName {
             static let viewMain = "view_main"
+           static let viewAddSchedule = "view_add_schedule"
+           static let clickSchedule1Back = "click_schedule1_back"
         }
         
         enum Property {
@@ -300,6 +302,12 @@ enum StringLiterals {
             static let courseListTitle = "course_list_title"
             static let courseListLocation = "course_list_location"
             static let courseListCost = "course_list_cost"
+           static let viewPath = "view_path"
+           static let dateTitle = "date_title"
+           static let dateDate = "date_date"
+           static let dateTime = "date_time"
+           static let dateTagNum = "date_tag_num"
+           static let dateArea = "date_area"
         }
         
         enum UserProperty {

--- a/DATEROAD-iOS/DATEROAD-iOS/Global/Literals/StringLiterals.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Global/Literals/StringLiterals.swift
@@ -295,6 +295,8 @@ enum StringLiterals {
             static let viewMain = "view_main"
            static let viewAddSchedule = "view_add_schedule"
            static let clickSchedule1Back = "click_schedule1_back"
+           static let viewAddSchedule2 = "view_add_schedule2"
+           static let clickSchedule2Back = "click_schedule2_back"
         }
         
         enum Property {
@@ -308,6 +310,9 @@ enum StringLiterals {
            static let dateTime = "date_time"
            static let dateTagNum = "date_tag_num"
            static let dateArea = "date_area"
+           static let dateDetailLocation = "date_detail_location"
+           static let dateDetailTime = "date_detail_time"
+           static let dateCourseNum = "date_course_num"
         }
         
         enum UserProperty {

--- a/DATEROAD-iOS/DATEROAD-iOS/Global/Literals/StringLiterals.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Global/Literals/StringLiterals.swift
@@ -325,5 +325,11 @@ enum StringLiterals {
             static let userCourseCount = "user_course_count"
             static let dateScheduleNum = "date_schedule_num"
         }
+       
+       enum ViewPath {
+          static let dateSchedule = "데이트 일정"
+          static let viewedCourse = "내가 열람한 코스"
+          static let courseDetail = "코스 상세"
+       }
     }
 }

--- a/DATEROAD-iOS/DATEROAD-iOS/Global/Literals/StringLiterals.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Global/Literals/StringLiterals.swift
@@ -297,6 +297,9 @@ enum StringLiterals {
            static let clickSchedule1Back = "click_schedule1_back"
            static let viewAddSchedule2 = "view_add_schedule2"
            static let clickSchedule2Back = "click_schedule2_back"
+           static let clickBringCourse = "click_bring_course"
+           static let viewAddBringcourse = "view_add_bringcourse"
+           static let viewAddBringcourse2 = "view_add_bringcourse2"
         }
         
         enum Property {

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/AddCourse/Cells/AddCourseImageCollectionViewCell.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/AddCourse/Cells/AddCourseImageCollectionViewCell.swift
@@ -114,7 +114,7 @@ final class AddCourseImageCollectionViewCell: BaseCollectionViewCell {
 }
 
 
-// MARK: - CollectionViewCell Methods
+// MARK: - Extension Methods
 
 extension AddCourseImageCollectionViewCell {
    

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/AddCourse/Cells/AddSecondViewTableViewCell.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/AddCourse/Cells/AddSecondViewTableViewCell.swift
@@ -95,7 +95,7 @@ final class AddSecondViewCollectionViewCell: BaseCollectionViewCell {
 }
 
 
-// MARK: - CollectionViewCell Methods
+// MARK: - Extension Methods
 
 extension AddSecondViewCollectionViewCell {
    

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/AddCourse/ViewModels/AddCourseViewModel.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/AddCourse/ViewModels/AddCourseViewModel.swift
@@ -342,7 +342,7 @@ extension AddCourseViewModel {
    func isSourceMoreThanOne() {
       let cnt = addPlaceCollectionViewDataSource.count
       self.locationNum = cnt
-      let flag = (cnt >= 2) ? true : false
+      let flag = (cnt >= 2)
       print("지금 데이터소스 개수 : \(addPlaceCollectionViewDataSource.count)\nflag: \(flag)")
       isValidOfSecondNextBtn.value = flag
    }

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/AddCourse/ViewModels/AddCourseViewModel.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/AddCourse/ViewModels/AddCourseViewModel.swift
@@ -173,9 +173,6 @@ extension AddCourseViewModel {
             StringLiterals.Amplitude.Property.locationNum: self.locationNum
          ]
       )
-      print("🔥\ndateLocation : \(dateLocation)")
-      print("dateSpendTime : \(dateSpendTime)")
-      print("locationNum : \(locationNum)\n🔥")
    }
    
    func course3BackAmplitude() {

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/AddCourse/ViewModels/AddCourseViewModel.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/AddCourse/ViewModels/AddCourseViewModel.swift
@@ -164,6 +164,31 @@ extension AddCourseViewModel {
       )
    }
    
+   func course2BackAmplitude() {
+      AmplitudeManager.shared.trackEventWithProperties(
+         StringLiterals.Amplitude.EventName.clickCourse2Back,
+         properties: [
+            StringLiterals.Amplitude.Property.dateLocation: self.dateLocation,
+            StringLiterals.Amplitude.Property.dateSpendTime: self.dateSpendTime,
+            StringLiterals.Amplitude.Property.locationNum: self.locationNum
+         ]
+      )
+      print("🔥\ndateLocation : \(dateLocation)")
+      print("dateSpendTime : \(dateSpendTime)")
+      print("locationNum : \(locationNum)\n🔥")
+   }
+   
+   func course3BackAmplitude() {
+      AmplitudeManager.shared.trackEventWithProperties(
+         StringLiterals.Amplitude.EventName.clickCourse3Back,
+         properties: [
+            StringLiterals.Amplitude.Property.courseContentBool: self.courseContentBool,
+            StringLiterals.Amplitude.Property.courseContentNum: self.courseContentNum,
+            StringLiterals.Amplitude.Property.courseCost: self.courseCost
+         ]
+      )
+   }
+   
    func getTagIndices(from tags: [String]) -> [Int] {
       return tags.compactMap { tag in
          TendencyTag.allCases.firstIndex { $0.tag.english == tag }
@@ -318,7 +343,9 @@ extension AddCourseViewModel {
    
    /// dataSource 개수 >= 2 라면 (다음 2/3) 버튼 활성화
    func isSourceMoreThanOne() {
-      let flag = (addPlaceCollectionViewDataSource.count >= 2) ? true : false
+      let cnt = addPlaceCollectionViewDataSource.count
+      self.locationNum = cnt
+      let flag = (cnt >= 2) ? true : false
       print("지금 데이터소스 개수 : \(addPlaceCollectionViewDataSource.count)\nflag: \(flag)")
       isValidOfSecondNextBtn.value = flag
    }

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/AddCourse/ViewModels/AddCourseViewModel.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/AddCourse/ViewModels/AddCourseViewModel.swift
@@ -245,7 +245,6 @@ extension AddCourseViewModel {
       if let result = pastDateDetailData?.places {
          pastDatePlaces = result
       }
-      
    }
    
    
@@ -282,7 +281,6 @@ extension AddCourseViewModel {
             selectedTagData.remove(at: index)
          }
       }
-      
       checkTagCount(min: minTagCnt, max: maxTagCnt)
    }
    
@@ -350,6 +348,8 @@ extension AddCourseViewModel {
       //viewmodel 값 초기화
       self.datePlace.value = ""
       self.timeRequire.value = ""
+      self.dateLocation = false
+      self.dateSpendTime = false
       self.isChange?()
    }
    

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/AddCourse/ViewModels/AddCourseViewModel.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/AddCourse/ViewModels/AddCourseViewModel.swift
@@ -75,8 +75,6 @@ final class AddCourseViewModel: Serviceable {
    
    var addPlaceCollectionViewDataSource: [AddCoursePlaceModel] = []
    
-   let changeTableViewData: ObservablePattern<Int> = ObservablePattern(0)
-   
    let datePlace: ObservablePattern<String> = ObservablePattern(nil)
    
    let timeRequire: ObservablePattern<String> = ObservablePattern(nil)

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/AddCourse/ViewModels/AddCourseViewModel.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/AddCourse/ViewModels/AddCourseViewModel.swift
@@ -101,34 +101,44 @@ final class AddCourseViewModel: Serviceable {
    
    //MARK: - AddCourse Amplitude 관련 변수
    
-   var courseImage: Bool
+   var courseImage = false
    
-   var courseTitle: Bool
+   var courseTitle = false
    
-   var courseDate: Bool
+   var courseDate = false
    
-   var courseStartTime: Bool
+   var courseStartTime = false
    
-   var courseTags: Bool
+   var courseTags = false
    
-   var courseLocation: Bool
+   var courseLocation = false
    
-   var dateLocation: Bool
+   var dateLocation = false
    
-   var dateSpendTime: Bool
+   var dateSpendTime = false
    
-   var locationNum: Int
+   var locationNum = 0
    
-   var courseContentBool: Bool
+   var courseContentBool = false
    
-   var courseContentNum: Int
+   var courseContentNum = 0
    
-   var courseCost: Bool
+   var courseCost = false
    
    
    // MARK: - Initializer
    
    init(pastDateDetailData: DateDetailModel? = nil) {
+      initAmplitudeVar()
+      fetchTagData()
+      self.pastDateDetailData = pastDateDetailData
+   }
+   
+}
+
+extension AddCourseViewModel {
+   
+   func initAmplitudeVar() {
       courseImage = false
       courseTitle = false
       courseDate = false
@@ -141,14 +151,7 @@ final class AddCourseViewModel: Serviceable {
       courseContentBool = false
       courseContentNum = 0
       courseCost = false
-      
-      fetchTagData()
-      self.pastDateDetailData = pastDateDetailData
    }
-   
-}
-
-extension AddCourseViewModel {
    
    func course1BackAmplitude() {
       AmplitudeManager.shared.trackEventWithProperties(

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/AddCourse/ViewModels/AddCourseViewModel.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/AddCourse/ViewModels/AddCourseViewModel.swift
@@ -318,12 +318,9 @@ extension AddCourseViewModel {
    
    func updateTimeRequireTextField(text: String) {
       if let doubleValue = Double(text) {
-         let text = doubleValue.truncatingRemainder(dividingBy: 1) == 0 ?
-         String(Int(doubleValue)) : String(doubleValue)
-         timeRequire.value = "\(text) 시간"
-      } else {
-         timeRequire.value = "\(text) 시간"
+         let text = doubleValue.truncatingRemainder(dividingBy: 1) == 0 ? String(Int(doubleValue)) : String(doubleValue)
       }
+      timeRequire.value = "(text) 시간"
    }
    
    func isAbleAddBtn() -> Bool {
@@ -360,12 +357,7 @@ extension AddCourseViewModel {
    //MARK: - AddThirdView 전용 func
    
    func isDoneBtnValid() {
-      if contentFlag && priceFlag {
-         print("contentFlag : \(contentFlag)\npriceFlag : \(priceFlag)")
-         isDoneBtnOK.value = true
-      } else {
-         isDoneBtnOK.value = false
-      }
+      isDoneBtnOK.value = contentFlag && priceFlag
    }
    
    /// 로딩뷰 세팅 함수
@@ -416,15 +408,12 @@ extension AddCourseViewModel {
             print("Success: \(response)")
             self.setLoading(isPostLoading: false)
             self.isSuccessPostData.value = true
-         case .serverErr:
-            self.onFailNetwork.value = true
-         case . requestErr:
-            self.onFailNetwork.value = true
          case .reIssueJWT:
              self.patchReissue { isSuccess in
                  self.onReissueSuccess.value = isSuccess
              }
          default:
+            self.onFailNetwork.value = true
             print("Failed to another reason")
             return
          }

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/AddCourse/ViewModels/AddCourseViewModel.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/AddCourse/ViewModels/AddCourseViewModel.swift
@@ -45,12 +45,12 @@ final class AddCourseViewModel: Serviceable {
    var tagData: [ProfileTagModel] = []
    let isOverCount: ObservablePattern<Bool> = ObservablePattern(false)
    let isValidTag: ObservablePattern<Bool> = ObservablePattern(nil)
-   let tagCount: ObservablePattern<Int> = ObservablePattern(0)
+   let tagCount: ObservablePattern<Int> = ObservablePattern(nil)
    private let minTagCnt = 1
    private let maxTagCnt = 3
    
    /// 코스 지역 유효성 판별
-   let dateLocation: ObservablePattern<String> = ObservablePattern("")
+   let dateLocations: ObservablePattern<String> = ObservablePattern(nil)
    let isDateLocationVaild: ObservablePattern<Bool> = ObservablePattern(nil)
    
    var isTimePicker: Bool?
@@ -65,9 +65,9 @@ final class AddCourseViewModel: Serviceable {
    
    let changeTableViewData: ObservablePattern<Int> = ObservablePattern(0)
    
-   let datePlace: ObservablePattern<String> = ObservablePattern("")
+   let datePlace: ObservablePattern<String> = ObservablePattern(nil)
    
-   let timeRequire: ObservablePattern<String> = ObservablePattern("")
+   let timeRequire: ObservablePattern<String> = ObservablePattern(nil)
    
    let isValidOfSecondNextBtn: ObservablePattern<Bool> = ObservablePattern(false)
    
@@ -80,7 +80,7 @@ final class AddCourseViewModel: Serviceable {
    
    //MARK: - AddThirdView 전용 Viewmodel 변수
    
-   let contentTextCount: ObservablePattern<Int> = ObservablePattern(0)
+   let contentTextCount: ObservablePattern<Int> = ObservablePattern(nil)
    var contentText = ""
    var contentFlag = false
    
@@ -98,7 +98,50 @@ final class AddCourseViewModel: Serviceable {
    
    let onFailNetwork: ObservablePattern<Bool> = ObservablePattern(false)
    
+   
+   //MARK: - AddCourse Amplitude 관련 변수
+   
+   var courseImage: Bool
+   
+   var courseTitle: Bool
+   
+   var courseDate: Bool
+   
+   var courseStartTime: Bool
+   
+   var courseTags: Bool
+   
+   var courseLocation: Bool
+   
+   var dateLocation: Bool
+   
+   var dateSpendTime: Bool
+   
+   var locationNum: Int
+   
+   var courseContentBool: Bool
+   
+   var courseContentNum: Int
+   
+   var courseCost: Bool
+   
+   
+   // MARK: - Initializer
+   
    init(pastDateDetailData: DateDetailModel? = nil) {
+      courseImage = false
+      courseTitle = false
+      courseDate = false
+      courseStartTime = false
+      courseTags = false
+      courseLocation = false
+      dateLocation = false
+      dateSpendTime = false
+      locationNum = 0
+      courseContentBool = false
+      courseContentNum = 0
+      courseCost = false
+      
       fetchTagData()
       self.pastDateDetailData = pastDateDetailData
    }
@@ -122,7 +165,7 @@ extension AddCourseViewModel {
       visitDate.value = formattedDate
       
       dateStartAt.value = pastDateDetailData?.startAt
-      dateLocation.value = pastDateDetailData?.city
+      dateLocations.value = pastDateDetailData?.city
       
       //동네.KOR 불러와서 지역, 동네 ENG 버전 알아내는 미친 로직
       let cityName = pastDateDetailData?.city ?? ""

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/AddCourse/ViewModels/AddCourseViewModel.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/AddCourse/ViewModels/AddCourseViewModel.swift
@@ -56,6 +56,7 @@ final class AddCourseViewModel: Serviceable {
    let tagCount: ObservablePattern<Int> = ObservablePattern(nil)
    
    private let minTagCnt = 1
+   
    private let maxTagCnt = 3
    
    // 코스 지역 유효성 판별
@@ -248,7 +249,7 @@ extension AddCourseViewModel {
    }
    
    
-   //MARK: - AddCourse First 함수
+   //MARK: - AddCourse FirstView 관련 함수
    
    func satisfyDateName(str: String) {
       isDateNameVaild.value = str.count >= minimumDateNameLength
@@ -323,17 +324,18 @@ extension AddCourseViewModel {
    }
    
    
-   //MARK: - AddSecondView 전용 func
+   //MARK: - AddCourse SecondView 관련 함수
    
    func updatePlaceCollectionView() {
       print(addPlaceCollectionViewDataSource)
    }
    
    func updateTimeRequireTextField(text: String) {
+      var formattedText = text
       if let doubleValue = Double(text) {
-         let text = doubleValue.truncatingRemainder(dividingBy: 1) == 0 ? String(Int(doubleValue)) : String(doubleValue)
+         formattedText = doubleValue.truncatingRemainder(dividingBy: 1) == 0 ? String(Int(doubleValue)) : String(doubleValue)
       }
-      timeRequire.value = "\(text) 시간"
+      timeRequire.value = "\(formattedText) 시간"
    }
    
    func isAbleAddBtn() -> Bool {
@@ -348,6 +350,7 @@ extension AddCourseViewModel {
       //viewmodel 값 초기화
       self.datePlace.value = ""
       self.timeRequire.value = ""
+      
       self.dateLocation = false
       self.dateSpendTime = false
       self.isChange?()
@@ -369,7 +372,7 @@ extension AddCourseViewModel {
    }
    
    
-   //MARK: - AddThirdView 전용 func
+   //MARK: - AddCourse ThirdView 관련 함수
    
    func isDoneBtnValid() {
       isDoneBtnOK.value = contentFlag && priceFlag

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/AddCourse/ViewModels/AddCourseViewModel.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/AddCourse/ViewModels/AddCourseViewModel.swift
@@ -150,6 +150,20 @@ final class AddCourseViewModel: Serviceable {
 
 extension AddCourseViewModel {
    
+   func course1BackAmplitude() {
+      AmplitudeManager.shared.trackEventWithProperties(
+         StringLiterals.Amplitude.EventName.clickCourse1Back,
+         properties: [
+            StringLiterals.Amplitude.Property.courseImage: self.courseImage,
+            StringLiterals.Amplitude.Property.courseTitle: self.courseTitle,
+            StringLiterals.Amplitude.Property.courseDate: self.courseDate,
+            StringLiterals.Amplitude.Property.courseStartTime: self.courseStartTime,
+            StringLiterals.Amplitude.Property.courseTags: self.courseTags,
+            StringLiterals.Amplitude.Property.courseLocation: self.courseLocation
+         ]
+      )
+   }
+   
    func getTagIndices(from tags: [String]) -> [Int] {
       return tags.compactMap { tag in
          TendencyTag.allCases.firstIndex { $0.tag.english == tag }

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/AddCourse/ViewModels/AddCourseViewModel.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/AddCourse/ViewModels/AddCourseViewModel.swift
@@ -337,7 +337,7 @@ extension AddCourseViewModel {
       if let doubleValue = Double(text) {
          let text = doubleValue.truncatingRemainder(dividingBy: 1) == 0 ? String(Int(doubleValue)) : String(doubleValue)
       }
-      timeRequire.value = "(text) 시간"
+      timeRequire.value = "\(text) 시간"
    }
    
    func isAbleAddBtn() -> Bool {

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/AddCourse/ViewModels/AddCourseViewModel.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/AddCourse/ViewModels/AddCourseViewModel.swift
@@ -406,9 +406,7 @@ extension AddCourseViewModel {
       }
       
       var postAddCourseTag = PostAddCourseTag()
-      
       postAddCourseTag.addTags(from: selectedTagData)
-      
       
       guard let dateName = dateName.value else {return}
       guard let visitDate = visitDate.value else {return}

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/AddCourse/ViewModels/AddCourseViewModel.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/AddCourse/ViewModels/AddCourseViewModel.swift
@@ -24,38 +24,50 @@ final class AddCourseViewModel: Serviceable {
    
    //MARK: - AddFirstCourse 사용되는 ViewModel
    
-   /// ImageCollection 유효성 판별
+   // ImageCollection 유효성 판별
    var pickedImageArr = [UIImage]()
+   
    let isPickedImageVaild: ObservablePattern<Bool> = ObservablePattern(false)
    
-   /// 데이트 이름 유효성 판별 (true는 통과)
+   // 데이트 이름 유효성 판별 (true는 통과)
    let dateName: ObservablePattern<String> = ObservablePattern(nil)
+   
    let isDateNameVaild: ObservablePattern<Bool> = ObservablePattern(nil)
+   
    private let minimumDateNameLength = 5
    
-   /// 방문 일자 유효성 판별 (true는 통과)
+   // 방문 일자 유효성 판별 (true는 통과)
    let visitDate: ObservablePattern<String> = ObservablePattern(nil)
+   
    let isVisitDateVaild: ObservablePattern<Bool> = ObservablePattern(nil)
    
-   /// 데이트 시작시간 유효성 판별 (self.count > 0 인지)
+   // 데이트 시작시간 유효성 판별 (self.count > 0 인지)
    let dateStartAt: ObservablePattern<String> = ObservablePattern(nil)
+   
    let isDateStartAtVaild: ObservablePattern<Bool> = ObservablePattern(nil)
    
-   /// 코스 등록 태그
+   // 코스 등록 태그
    var tagData: [ProfileTagModel] = []
+   
    let isOverCount: ObservablePattern<Bool> = ObservablePattern(false)
+   
    let isValidTag: ObservablePattern<Bool> = ObservablePattern(nil)
+   
    let tagCount: ObservablePattern<Int> = ObservablePattern(nil)
+   
    private let minTagCnt = 1
    private let maxTagCnt = 3
    
-   /// 코스 지역 유효성 판별
+   // 코스 지역 유효성 판별
    let dateLocations: ObservablePattern<String> = ObservablePattern(nil)
+   
    let isDateLocationVaild: ObservablePattern<Bool> = ObservablePattern(nil)
    
+   // 기타
    var isTimePicker: Bool?
    
    var country = ""
+   
    var city = ""
    
    
@@ -81,11 +93,15 @@ final class AddCourseViewModel: Serviceable {
    //MARK: - AddThirdView 전용 Viewmodel 변수
    
    let contentTextCount: ObservablePattern<Int> = ObservablePattern(nil)
+   
    var contentText = ""
+   
    var contentFlag = false
    
    let priceText: ObservablePattern<Int> = ObservablePattern(nil)
+   
    var priceFlag = false
+   
    var price = 0
    
    let isDoneBtnOK: ObservablePattern<Bool> = ObservablePattern(false)
@@ -233,6 +249,7 @@ extension AddCourseViewModel {
       }
       
    }
+   
    
    //MARK: - AddCourse First 함수
    
@@ -409,9 +426,9 @@ extension AddCourseViewModel {
             self.setLoading(isPostLoading: false)
             self.isSuccessPostData.value = true
          case .reIssueJWT:
-             self.patchReissue { isSuccess in
-                 self.onReissueSuccess.value = isSuccess
-             }
+            self.patchReissue { isSuccess in
+               self.onReissueSuccess.value = isSuccess
+            }
          default:
             self.onFailNetwork.value = true
             print("Failed to another reason")

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/AddCourse/Views/AddCourseFirst/AddCourseFirstView.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/AddCourse/Views/AddCourseFirst/AddCourseFirstView.swift
@@ -36,9 +36,13 @@ final class AddCourseFirstView: BaseView {
    
    private let warningType: DRErrorType = Warning()
    
+   
+   // MARK: - Methods
+   
    override func setHierarchy() {
       self.addSubview(scrollView)
       scrollView.addSubview(scrollContentView)
+      
       scrollContentView.addSubviews(
          collectionView,
          imageAccessoryView,
@@ -46,6 +50,7 @@ final class AddCourseFirstView: BaseView {
          dateNameErrorLabel,
          visitDateErrorLabel
       )
+      
       imageAccessoryView.addSubviews(cameraBtn, imageCountLabelContainer)
       imageCountLabelContainer.addSubview(imageCountLabel)
    }

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/AddCourse/Views/AddCourseFirst/AddCourseFirstView.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/AddCourse/Views/AddCourseFirst/AddCourseFirstView.swift
@@ -160,9 +160,10 @@ final class AddCourseFirstView: BaseView {
    
 }
 
+
+// MARK: - Extension Methods
+
 extension AddCourseFirstView {
-   
-   // MARK: - Methods
    
    func updateDateNameTextField(isPassValid: Bool) {
       dateNameErrorLabel.isHidden = isPassValid

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/AddCourse/Views/AddCourseFirst/AddCourseFirstViewController.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/AddCourse/Views/AddCourseFirst/AddCourseFirstViewController.swift
@@ -46,6 +46,10 @@ final class AddCourseFirstViewController: BaseNavBarViewController {
    
    // MARK: - Life Cycle
    
+   override func viewWillAppear(_ animated: Bool) {
+      self.tabBarController?.tabBar.isHidden = true
+   }
+   
    override func viewDidLoad() {
       super.viewDidLoad()
       
@@ -61,10 +65,6 @@ final class AddCourseFirstViewController: BaseNavBarViewController {
       pastDateBindViewModel()
       setupKeyboardDismissRecognizer()
       AmplitudeManager.shared.trackEventWithProperties(StringLiterals.Amplitude.EventName.viewCourse1, properties: [StringLiterals.Amplitude.Property.viewPath: viewPath])
-   }
-   
-   override func viewWillAppear(_ animated: Bool) {
-      self.tabBarController?.tabBar.isHidden = true
    }
    
    
@@ -120,12 +120,14 @@ private extension AddCourseFirstViewController {
          self.viewModel.fetchPastDate()
          self.addCourseFirstView.addFirstView.tendencyTagCollectionView.reloadData()
       }
+      
       viewModel.isPickedImageVaild.bind { date in
          guard let value = self.viewModel.isPickedImageVaild.value else {return}
          self.viewModel.courseImage = value
          let flag = self.viewModel.isOkSixBtn()
          self.addCourseFirstView.addFirstView.updateSixCheckButton(isValid: flag)
       }
+      
       viewModel.isDateNameVaild.bind { date in
          guard let date else {return}
          self.addCourseFirstView.updateDateNameTextField(isPassValid: date)
@@ -133,6 +135,7 @@ private extension AddCourseFirstViewController {
          let flag = self.viewModel.isOkSixBtn()
          self.addCourseFirstView.addFirstView.updateSixCheckButton(isValid: flag)
       }
+      
       viewModel.isVisitDateVaild.bind { date in
          guard let date else {return}
          self.addCourseFirstView.updateVisitDateTextField(isPassValid: date)
@@ -140,10 +143,12 @@ private extension AddCourseFirstViewController {
          let flag = self.viewModel.isOkSixBtn()
          self.addCourseFirstView.addFirstView.updateSixCheckButton(isValid: flag)
       }
+      
       viewModel.isDateStartAtVaild.bind { date in
          let flag = self.viewModel.isOkSixBtn()
          self.addCourseFirstView.addFirstView.updateSixCheckButton(isValid: flag)
       }
+      
       viewModel.isValidTag.bind { date in
          guard let value = self.viewModel.isValidTag.value else {return}
          //코스는 아직 불러오기 기능이 없기에 isValidTag 속에 아래 코드 적용
@@ -151,6 +156,7 @@ private extension AddCourseFirstViewController {
          let flag = self.viewModel.isOkSixBtn()
          self.addCourseFirstView.addFirstView.updateSixCheckButton(isValid: flag)
       }
+      
       viewModel.isDateLocationVaild.bind { date in
          let flag = self.viewModel.isOkSixBtn()
          self.addCourseFirstView.addFirstView.updateSixCheckButton(isValid: flag)
@@ -160,19 +166,23 @@ private extension AddCourseFirstViewController {
          guard let text = date else {return}
          self.addCourseFirstView.addFirstView.updateDateName(text: text)
       }
+      
       viewModel.visitDate.bind { date in
          guard let text = date else {return}
          self.addCourseFirstView.addFirstView.updateVisitDate(text: text)
          self.viewModel.courseDate = true
       }
+      
       viewModel.dateStartAt.bind { date in
          guard let text = date else {return}
          self.addCourseFirstView.addFirstView.updatedateStartTime(text: text)
          self.viewModel.courseStartTime = true
       }
+      
       viewModel.tagCount.bind { count in
          self.addCourseFirstView.addFirstView.updateTagCount(count: count ?? 0)
       }
+      
       viewModel.dateLocations.bind { date in
          guard let date else {return}
          self.addCourseFirstView.addFirstView.updateDateLocation(text: date)
@@ -190,10 +200,12 @@ private extension AddCourseFirstViewController {
          $0.delegate = self
          $0.dataSource = self
       }
+      
       addCourseFirstView.addFirstView.tendencyTagCollectionView.do {
          $0.delegate = self
          $0.dataSource = self
       }
+      
       addCourseFirstView.addFirstView.dateNameTextField.delegate = self
       imagePickerViewController.delegate = self
    }

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/AddCourse/Views/AddCourseFirst/AddCourseFirstViewController.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/AddCourse/Views/AddCourseFirst/AddCourseFirstViewController.swift
@@ -121,6 +121,8 @@ private extension AddCourseFirstViewController {
          self.addCourseFirstView.addFirstView.tendencyTagCollectionView.reloadData()
       }
       viewModel.isPickedImageVaild.bind { date in
+         guard let value = self.viewModel.isPickedImageVaild.value else {return}
+         self.viewModel.courseImage = value
          let flag = self.viewModel.isOkSixBtn()
          self.addCourseFirstView.addFirstView.updateSixCheckButton(isValid: flag)
       }
@@ -143,6 +145,8 @@ private extension AddCourseFirstViewController {
          self.addCourseFirstView.addFirstView.updateSixCheckButton(isValid: flag)
       }
       viewModel.isValidTag.bind { date in
+         guard let value = self.viewModel.isValidTag.value else {return}
+         self.viewModel.courseTags = value
          let flag = self.viewModel.isOkSixBtn()
          self.addCourseFirstView.addFirstView.updateSixCheckButton(isValid: flag)
       }
@@ -154,21 +158,25 @@ private extension AddCourseFirstViewController {
       viewModel.dateName.bind { date in
          guard let text = date else {return}
          self.addCourseFirstView.addFirstView.updateDateName(text: text)
+         self.viewModel.courseTitle = true
       }
       viewModel.visitDate.bind { date in
          guard let text = date else {return}
          self.addCourseFirstView.addFirstView.updateVisitDate(text: text)
+         self.viewModel.courseDate = true
       }
       viewModel.dateStartAt.bind { date in
          guard let text = date else {return}
          self.addCourseFirstView.addFirstView.updatedateStartTime(text: text)
+         self.viewModel.courseStartTime = true
       }
       viewModel.tagCount.bind { count in
          self.addCourseFirstView.addFirstView.updateTagCount(count: count ?? 0)
       }
-      viewModel.dateLocation.bind { date in
+      viewModel.dateLocations.bind { date in
          guard let date else {return}
          self.addCourseFirstView.addFirstView.updateDateLocation(text: date)
+         self.viewModel.courseLocation = true
       }
    }
    
@@ -310,6 +318,17 @@ private extension AddCourseFirstViewController {
    }
    
 }
+
+extension AddCourseFirstViewController {
+   
+   @objc
+   override func backButtonTapped() {
+      viewModel.course1BackAmplitude()
+      super.backButtonTapped()
+   }
+   
+}
+
 extension AddCourseFirstViewController: UICollectionViewDelegateFlowLayout {
    
    func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, sizeForItemAt indexPath: IndexPath) -> CGSize {
@@ -474,7 +493,7 @@ extension AddCourseFirstViewController: LocationFilterDelegate {
    func didSelectCity(_ country: LocationModel.Country, _ city: LocationModel.City) {
       print("selected : \(city)")
       print("Selected city: \(city.rawValue)")
-      viewModel.dateLocation.value = city.rawValue
+      viewModel.dateLocations.value = city.rawValue
       viewModel.satisfyDateLocation(str: city.rawValue)
       viewModel.country = country.rawValue
       viewModel.city = city.rawValue

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/AddCourse/Views/AddCourseFirst/AddCourseFirstViewController.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/AddCourse/Views/AddCourseFirst/AddCourseFirstViewController.swift
@@ -27,11 +27,15 @@ final class AddCourseFirstViewController: BaseNavBarViewController {
    
    let viewModel: AddCourseViewModel
    
+   var viewPath: String
+   
    
    // MARK: - Initializer
    
-   init(viewModel: AddCourseViewModel) {
+   init(viewModel: AddCourseViewModel, viewPath: String) {
       self.viewModel = viewModel
+      self.viewPath = viewPath
+      
       super.init(nibName: nil, bundle: nil)
    }
    
@@ -56,6 +60,7 @@ final class AddCourseFirstViewController: BaseNavBarViewController {
       bindViewModel()
       pastDateBindViewModel()
       setupKeyboardDismissRecognizer()
+      AmplitudeManager.shared.trackEventWithProperties(StringLiterals.Amplitude.EventName.viewCourse1, properties: [StringLiterals.Amplitude.Property.viewPath: viewPath])
    }
    
    override func viewWillAppear(_ animated: Bool) {

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/AddCourse/Views/AddCourseFirst/AddCourseFirstViewController.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/AddCourse/Views/AddCourseFirst/AddCourseFirstViewController.swift
@@ -146,6 +146,7 @@ private extension AddCourseFirstViewController {
       }
       viewModel.isValidTag.bind { date in
          guard let value = self.viewModel.isValidTag.value else {return}
+         //코스는 아직 불러오기 기능이 없기에 isValidTag 속에 아래 코드 적용
          self.viewModel.courseTags = value
          let flag = self.viewModel.isOkSixBtn()
          self.addCourseFirstView.addFirstView.updateSixCheckButton(isValid: flag)
@@ -158,7 +159,6 @@ private extension AddCourseFirstViewController {
       viewModel.dateName.bind { date in
          guard let text = date else {return}
          self.addCourseFirstView.addFirstView.updateDateName(text: text)
-         self.viewModel.courseTitle = true
       }
       viewModel.visitDate.bind { date in
          guard let text = date else {return}
@@ -243,8 +243,10 @@ private extension AddCourseFirstViewController {
    
    @objc
    func textFieldDidChanacge(_ textField: UITextField) {
-      viewModel.dateName.value = textField.text ?? ""
-      viewModel.satisfyDateName(str: textField.text ?? "")
+      guard let text = textField.text else {return}
+      viewModel.dateName.value = text
+      viewModel.satisfyDateName(str: text)
+      self.viewModel.courseTitle = !text.isEmpty ? true : false
    }
    
    @objc

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/AddCourse/Views/AddCourseFirst/AddCourseFirstViewController.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/AddCourse/Views/AddCourseFirst/AddCourseFirstViewController.swift
@@ -300,7 +300,7 @@ private extension AddCourseFirstViewController {
    }
    
    @objc
-   func importingTagBtn(_ sender: UIButton) {
+   func broughtTagBtn(_ sender: UIButton) {
       self.addCourseFirstView.addFirstView.updateTag(button: sender, buttonType: SelectedButton())
       self.viewModel.isValidTag.value = true
    }
@@ -312,7 +312,7 @@ private extension AddCourseFirstViewController {
    }
    
    @objc
-   private func datePlaceContainerTapped() {
+   func datePlaceContainerTapped() {
       // datePlaceContainer가 탭되었을 때 수행할 동작을 여기에 구현합니다.
       print("datePlaceContainer tapped!")
       let locationFilterVC = LocationFilterViewController()
@@ -367,7 +367,20 @@ extension AddCourseFirstViewController: UICollectionViewDelegateFlowLayout {
    
 }
 
-extension AddCourseFirstViewController: UICollectionViewDataSource, UICollectionViewDelegate {
+extension AddCourseFirstViewController: UICollectionViewDelegate {
+   
+   func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
+      if collectionView == addCourseFirstView.collectionView {
+         let isImageEmpty = (viewModel.pickedImageArr.count<1) ? true : false
+         if isImageEmpty  && collectionView == addCourseFirstView.collectionView {
+            imagePickerViewController.presentPicker(from: self)
+         }
+      }
+   }
+   
+}
+
+extension AddCourseFirstViewController: UICollectionViewDataSource {
    
    func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
       if collectionView == addCourseFirstView.collectionView {
@@ -425,15 +438,6 @@ extension AddCourseFirstViewController: UICollectionViewDataSource, UICollection
          }
          
          return cell
-      }
-   }
-   
-   func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
-      if collectionView == addCourseFirstView.collectionView {
-         let isImageEmpty = (viewModel.pickedImageArr.count<1) ? true : false
-         if isImageEmpty  && collectionView == addCourseFirstView.collectionView {
-            imagePickerViewController.presentPicker(from: self)
-         }
       }
    }
    

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/AddCourse/Views/AddCourseFirst/AddFirstView.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/AddCourse/Views/AddCourseFirst/AddFirstView.swift
@@ -154,7 +154,6 @@ final class AddFirstView: BaseView {
          $0.height.equalTo(52)
          $0.bottom.horizontalEdges.equalToSuperview()
       }
-      
    }
    
    override func setStyle() {
@@ -245,9 +244,10 @@ final class AddFirstView: BaseView {
    
 }
 
+
+// MARK: - Extension Methods
+
 extension AddFirstView {
-   
-   // MARK: - Methods
    
    func updateDateName(text: String) {
       dateNameTextField.text = text

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/AddCourse/Views/AddCourseSecond/AddCourseSecondView.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/AddCourse/Views/AddCourseSecond/AddCourseSecondView.swift
@@ -115,7 +115,7 @@ final class AddCourseSecondView: BaseView {
 }
 
 
-// MARK: - View Methods
+// MARK: - Extension Methods
 
 extension AddCourseSecondView {
    

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/AddCourse/Views/AddCourseSecond/AddCourseSecondViewController.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/AddCourse/Views/AddCourseSecond/AddCourseSecondViewController.swift
@@ -76,7 +76,7 @@ final class AddCourseSecondViewController: BaseNavBarViewController {
 }
 
 
-// MARK: - ViewController Methods
+// MARK: - Extension Methods
 
 private extension AddCourseSecondViewController {
    
@@ -182,6 +182,20 @@ private extension AddCourseSecondViewController {
    // MARK: - @objc Methods
    
    @objc
+   func textFieldTapped(_ textField: UITextField) {
+      let alertVC = AddSheetViewController(viewModel: viewModel)
+      alertVC.addSheetView = AddSheetView(isCustomPicker: true)
+      
+      self.alertVC = alertVC // alertVC를 인스턴스 변수에 저장
+      addCourseSecondView.addSecondView.datePlaceTextField.resignFirstResponder()
+      
+      DispatchQueue.main.async {
+         alertVC.modalPresentationStyle = .overFullScreen
+         self.present(alertVC, animated: true, completion: nil)
+      }
+   }
+   
+   @objc
    func tapAddPlaceBtn() {
       viewModel.tapAddBtn(datePlace: viewModel.datePlace.value ?? "", timeRequire: viewModel.timeRequire.value ?? "")
    }
@@ -282,33 +296,24 @@ extension AddCourseSecondViewController: UITextFieldDelegate {
       print(textField.text ?? "")
    }
    
-   @objc
-   private func textFieldTapped(_ textField: UITextField) {
-      let alertVC = AddSheetViewController(viewModel: viewModel)
-      alertVC.addSheetView = AddSheetView(isCustomPicker: true)
-      
-      self.alertVC = alertVC // alertVC를 인스턴스 변수에 저장
-      addCourseSecondView.addSecondView.datePlaceTextField.resignFirstResponder()
-      
-      DispatchQueue.main.async {
-         alertVC.modalPresentationStyle = .overFullScreen
-         self.present(alertVC, animated: true, completion: nil)
-      }
-   }
-   
 }
 
 
-// MARK: - UICollectionViewDataSource, UICollectionViewDelegate Methods
+// MARK: - UICollectionViewDelegate Methods
 
-extension AddCourseSecondViewController: UICollectionViewDataSource, UICollectionViewDelegate {
-   
+extension AddCourseSecondViewController: UICollectionViewDelegate {
    func collectionView(_ collectionView: UICollectionView, canMoveItemAt indexPath: IndexPath) -> Bool {
       collectionView == addCourseSecondView.collectionView ? false : true
    }
    
    func collectionView(_ collectionView: UICollectionView, moveItemAt sourceIndexPath: IndexPath, to destinationIndexPath: IndexPath) {
    }
+}
+
+
+// MARK: - UICollectionViewDataSource Methods
+
+extension AddCourseSecondViewController: UICollectionViewDataSource {
    
    func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
       if collectionView == addCourseSecondView.collectionView {

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/AddCourse/Views/AddCourseSecond/AddCourseSecondViewController.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/AddCourse/Views/AddCourseSecond/AddCourseSecondViewController.swift
@@ -152,8 +152,8 @@ private extension AddCourseSecondViewController {
       }
       
       viewModel.timeRequire.bind { [weak self] date in
-         guard let text = date else {return}
-         self?.addCourseSecondView.addSecondView.updatetimeRequire(text: text)
+         guard let date else {return}
+         self?.addCourseSecondView.addSecondView.updatetimeRequire(text: date)
          self?.viewModel.dateSpendTime = true
          if let flag = self?.viewModel.isAbleAddBtn() {
             self?.addCourseSecondView.addSecondView.changeAddPlaceButtonState(flag: flag)

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/AddCourse/Views/AddCourseSecond/AddCourseSecondViewController.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/AddCourse/Views/AddCourseSecond/AddCourseSecondViewController.swift
@@ -18,6 +18,7 @@ final class AddCourseSecondViewController: BaseNavBarViewController {
    
    init(viewModel: AddCourseViewModel) {
       self.viewModel = viewModel
+      
       super.init(nibName: nil, bundle: nil)
    }
    
@@ -247,7 +248,7 @@ private extension AddCourseSecondViewController {
          collectionView.reloadData()
       }
    }
-   // 얘 통과 진짜 미친놈
+   
 }
 
 extension AddCourseSecondViewController {

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/AddCourse/Views/AddCourseSecond/AddCourseSecondViewController.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/AddCourse/Views/AddCourseSecond/AddCourseSecondViewController.swift
@@ -108,6 +108,8 @@ private extension AddCourseSecondViewController {
       }
    }
    
+   //TODO: - 추후 데이트코스 공유 코스 등록 기능 살아날 시 수정해야함.
+   // isImporting 변수 생성하여 AddSchedule과 동일하게 수행하도록 수정
    func pastDateBindViewModel() {
       if viewModel.pastDatePlaces.count > 0  {
          for i in viewModel.pastDatePlaces {

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/AddCourse/Views/AddCourseSecond/AddCourseSecondViewController.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/AddCourse/Views/AddCourseSecond/AddCourseSecondViewController.swift
@@ -138,6 +138,7 @@ private extension AddCourseSecondViewController {
       viewModel.datePlace.bind { [weak self] date in
          guard let text = date else {return}
          self?.addCourseSecondView.addSecondView.updateDatePlace(text: text)
+         self?.viewModel.dateLocation = true
          if let flag = self?.viewModel.isAbleAddBtn() {
             self?.addCourseSecondView.addSecondView.changeAddPlaceButtonState(flag: flag)
          }
@@ -146,13 +147,13 @@ private extension AddCourseSecondViewController {
       viewModel.timeRequire.bind { [weak self] date in
          guard let text = date else {return}
          self?.addCourseSecondView.addSecondView.updatetimeRequire(text: text)
+         self?.viewModel.dateSpendTime = true
          if let flag = self?.viewModel.isAbleAddBtn() {
             self?.addCourseSecondView.addSecondView.changeAddPlaceButtonState(flag: flag)
          }
       }
       
       self.viewModel.isChange = { [weak self] in
-         print(self?.viewModel.addPlaceCollectionViewDataSource ?? "")
          self?.viewModel.isDataSourceNotEmpty()
          
          let state = self?.viewModel.editBtnEnableState.value ?? false
@@ -162,11 +163,8 @@ private extension AddCourseSecondViewController {
          // 텍스트필드 초기화 및 addPlace버튼 비활성화
          self?.addCourseSecondView.addSecondView.finishAddPlace()
          
-         
          // 다음 버튼 활성화 여부 판별 함수
          self?.viewModel.isSourceMoreThanOne()
-         
-         
          self?.addCourseSecondView.addPlaceCollectionView.reloadData()
       }
       
@@ -250,6 +248,16 @@ private extension AddCourseSecondViewController {
       }
    }
    // 얘 통과 진짜 미친놈
+}
+
+extension AddCourseSecondViewController {
+   
+   @objc
+   override func backButtonTapped() {
+      viewModel.course2BackAmplitude()
+      super.backButtonTapped()
+   }
+   
 }
 
 

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/AddCourse/Views/AddCourseSecond/AddCourseSecondViewController.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/AddCourse/Views/AddCourseSecond/AddCourseSecondViewController.swift
@@ -109,7 +109,7 @@ private extension AddCourseSecondViewController {
    }
    
    //TODO: - 추후 데이트코스 공유 코스 등록 기능 살아날 시 수정해야함.
-   // isImporting 변수 생성하여 AddSchedule과 동일하게 수행하도록 수정
+   // isBroughtData 변수 생성하여 AddSchedule과 동일하게 수행하도록 수정
    func pastDateBindViewModel() {
       if viewModel.pastDatePlaces.count > 0  {
          for i in viewModel.pastDatePlaces {

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/AddCourse/Views/AddCourseSecond/AddSecondView.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/AddCourse/Views/AddCourseSecond/AddSecondView.swift
@@ -178,7 +178,7 @@ final class AddSecondView: BaseView {
 }
 
 
-// MARK: - View Methods
+// MARK: - Extension Methods
 
 extension AddSecondView {
    

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/AddCourse/Views/AddCourseThird/AddCourseThirdView.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/AddCourse/Views/AddCourseThird/AddCourseThirdView.swift
@@ -90,7 +90,6 @@ final class AddCourseThirdView: BaseView {
          $0.setTitle(StringLiterals.AddCourseOrSchedule.AddThirdView.addThirdDoneBtn, for: .normal)
          $0.titleLabel?.font = .suit(.body_bold_15)
       }
-      
    }
    
 }

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/AddCourse/Views/AddCourseThird/AddCourseThirdViewController.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/AddCourse/Views/AddCourseThird/AddCourseThirdViewController.swift
@@ -211,6 +211,18 @@ private extension AddCourseThirdViewController {
       navigationController?.popToPreviousViewController(ofType: AddCourseFirstViewController.self, defaultViewController: tabbarVC)
    }
    
+   func adjustScrollViewForKeyboard(showKeyboard: Bool) {
+      let maxKeyboardHeight: CGFloat = 45
+      
+      let contentInsets = UIEdgeInsets(top: 0, left: 0, bottom: showKeyboard ? min(keyboardHeight, maxKeyboardHeight) : 0, right: 0)
+      addCourseThirdView.scrollView.contentInset = contentInsets
+      addCourseThirdView.scrollView.scrollIndicatorInsets = contentInsets
+      
+      var visibleRect = CGRect()
+      visibleRect.size = addCourseThirdView.scrollView.contentSize
+      addCourseThirdView.scrollView.scrollRectToVisible(visibleRect, animated: true)
+   }
+   
    @objc
    func keyboardWillShow(_ notification: Notification) {
       if let keyboardSize = (notification.userInfo?[UIResponder.keyboardFrameEndUserInfoKey] as? NSValue)?.cgRectValue {
@@ -222,18 +234,6 @@ private extension AddCourseThirdViewController {
    @objc
    func keyboardWillHide(_ notification: Notification) {
       adjustScrollViewForKeyboard(showKeyboard: false)
-   }
-   
-   func adjustScrollViewForKeyboard(showKeyboard: Bool) {
-      let maxKeyboardHeight: CGFloat = 45
-      
-      let contentInsets = UIEdgeInsets(top: 0, left: 0, bottom: showKeyboard ? min(keyboardHeight, maxKeyboardHeight) : 0, right: 0)
-      addCourseThirdView.scrollView.contentInset = contentInsets
-      addCourseThirdView.scrollView.scrollIndicatorInsets = contentInsets
-      
-      var visibleRect = CGRect()
-      visibleRect.size = addCourseThirdView.scrollView.contentSize
-      addCourseThirdView.scrollView.scrollRectToVisible(visibleRect, animated: true)
    }
    
 }
@@ -338,7 +338,11 @@ extension AddCourseThirdViewController: UITextFieldDelegate {
 
 // MARK: - UICollectionViewDataSource, UICollectionViewDelegate Methods
 
-extension AddCourseThirdViewController: UICollectionViewDataSource, UICollectionViewDelegate {
+extension AddCourseThirdViewController: UICollectionViewDelegate {
+   
+}
+
+extension AddCourseThirdViewController: UICollectionViewDataSource {
    
    func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
       return viewModel.pickedImageArr.count

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/AddCourse/Views/AddCourseThird/AddCourseThirdViewController.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/AddCourse/Views/AddCourseThird/AddCourseThirdViewController.swift
@@ -175,9 +175,11 @@ private extension AddCourseThirdViewController {
          self?.viewModel.isDoneBtnValid()
       }
       viewModel.priceText.bind { [weak self] date in
-         self?.addCourseThirdView.addThirdView.updatePriceText(price: date ?? 0)
-         let flag = (date ?? 0 > 0) ? true : false
-         self?.viewModel.price = date ?? 0
+         guard let date = date else {return}
+         self?.addCourseThirdView.addThirdView.updatePriceText(price: date)
+         let flag = (date >= 0) ? true : false
+         self?.viewModel.courseCost = flag
+         self?.viewModel.price = date
          self?.viewModel.priceFlag = flag
          self?.viewModel.isDoneBtnValid()
       }
@@ -234,6 +236,16 @@ private extension AddCourseThirdViewController {
    
 }
 
+extension AddCourseThirdViewController {
+   
+   @objc
+   override func backButtonTapped() {
+      viewModel.course3BackAmplitude()
+      super.backButtonTapped()
+   }
+   
+}
+
 
 extension AddCourseThirdViewController: UITextViewDelegate {
    
@@ -269,7 +281,9 @@ extension AddCourseThirdViewController: UITextViewDelegate {
       viewModel.contentText = changedText
       let filteredTextCount = changedText.filter { $0 != "\n" }.count
       viewModel.contentTextCount.value = filteredTextCount
+      viewModel.courseContentNum = filteredTextCount
       print("🎉🎉🎉🎉\(changedText)🎉🎉🎉🎉")
+      viewModel.courseContentBool = filteredTextCount > 0 ? true : false
       
       // 리턴 키 입력을 처리합니다.
       if text == "\n" {

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/AddCourse/Views/AddCourseThird/AddCourseThirdViewController.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/AddCourse/Views/AddCourseThird/AddCourseThirdViewController.swift
@@ -17,7 +17,7 @@ final class AddCourseThirdViewController: BaseNavBarViewController {
    private var addCourseThirdView = AddCourseThirdView()
    
    private let viewModel: AddCourseViewModel
-      
+   
    private let errorView: DRErrorViewController = DRErrorViewController()
    
    
@@ -30,6 +30,7 @@ final class AddCourseThirdViewController: BaseNavBarViewController {
    
    init(viewModel: AddCourseViewModel) {
       self.viewModel = viewModel
+      
       super.init(nibName: nil, bundle: nil)
    }
    
@@ -79,7 +80,7 @@ final class AddCourseThirdViewController: BaseNavBarViewController {
    
    override func setLayout() {
       super.setLayout()
-
+      
       addCourseThirdView.snp.makeConstraints {
          $0.top.equalToSuperview().offset(4)
          $0.horizontalEdges.equalToSuperview()
@@ -150,10 +151,10 @@ private extension AddCourseThirdViewController {
       }
       
       self.viewModel.onLoading.bind { [weak self] onLoading in
-          guard let onLoading, let onFailNetwork = self?.viewModel.onFailNetwork.value else { return }
+         guard let onLoading, let onFailNetwork = self?.viewModel.onFailNetwork.value else { return }
          
          if !onFailNetwork {
-             onLoading ? self?.showLoadingView() : self?.hideLoadingView()
+            onLoading ? self?.showLoadingView() : self?.hideLoadingView()
             self?.addCourseThirdView.isHidden = onLoading
             self?.tabBarController?.tabBar.isHidden = onLoading
          }
@@ -174,6 +175,7 @@ private extension AddCourseThirdViewController {
          self?.viewModel.contentFlag = flag
          self?.viewModel.isDoneBtnValid()
       }
+      
       viewModel.priceText.bind { [weak self] date in
          guard let date = date else {return}
          self?.addCourseThirdView.addThirdView.updatePriceText(price: date)

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/AddCourse/Views/AddCourseThird/AddThirdView.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/AddCourse/Views/AddCourseThird/AddThirdView.swift
@@ -160,9 +160,7 @@ extension AddThirdView {
    }
    
    func updatePriceText(price: Int) {
-      if price != 0 {
-         priceTextField.text = String(price.formattedWithSeparator)
-      }
+      priceTextField.text = String(price.formattedWithSeparator)
    }
    
    func updateContentTextView(_ textView: UITextView, withText text: String, placeholder: String) {

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/AddCourse/Views/AddCourseThird/AddThirdView.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/AddCourse/Views/AddCourseThird/AddThirdView.swift
@@ -152,7 +152,6 @@ final class AddThirdView: BaseView {
    
 }
 
-
 extension AddThirdView {
    
    func updateContentTextCount(textCnt: Int) {

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/AddCourse/Views/AddSheetView.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/AddCourse/Views/AddSheetView.swift
@@ -54,6 +54,7 @@ final class AddSheetView: BaseView {
          addSubviews(bottomSheetView)
          bottomSheetView.addSubviews(doneBtn, customPickerView)
          doneBtn.addSubview(doneBtnTitleLabel)
+      
       case false:
          self.addSubviews(datePicker)
          
@@ -118,7 +119,6 @@ final class AddSheetView: BaseView {
             $0.isHidden = isCustomPicker  // 초기 설정에 따라 숨김
          }
       }
-      
    }
    
 }

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/AddCourse/Views/AddSheetView.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/AddCourse/Views/AddSheetView.swift
@@ -124,7 +124,7 @@ final class AddSheetView: BaseView {
 }
 
 
-// MARK: - View Methods
+// MARK: - Extension Methods
 
 extension AddSheetView {
    

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/AddCourse/Views/AddSheetViewController.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/AddCourse/Views/AddSheetViewController.swift
@@ -29,6 +29,7 @@ final class AddSheetViewController: BaseViewController {
    
    init(viewModel: AddCourseViewModel) {
       self.viewModel = viewModel
+      
       super.init(nibName: nil, bundle: nil)
    }
    
@@ -70,7 +71,7 @@ final class AddSheetViewController: BaseViewController {
 
 private extension AddSheetViewController {
    
-   private func setCustomPicker() {
+   func setCustomPicker() {
       customPickerValues = Array(stride(from: 0.5, to: 6.5, by: 0.5))
       addSheetView.customPickerView.dataSource = self
       addSheetView.customPickerView.delegate = self
@@ -78,10 +79,11 @@ private extension AddSheetViewController {
       addSheetView.doneBtn.addTarget(self, action: #selector(didTapDoneBtn), for: .touchUpInside)
    }
    
+   
    // MARK: - @objc Methods
    
    @objc
-   private func didTapDoneBtn() {
+   func didTapDoneBtn() {
       let selectedRow = addSheetView.customPickerView.selectedRow(inComponent: 0)
       let selectedValue = customPickerValues[selectedRow]
       viewModel?.updateTimeRequireTextField(text: String(selectedValue))

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/AddCourse/Views/AddSheetViewController.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/AddCourse/Views/AddSheetViewController.swift
@@ -95,7 +95,15 @@ private extension AddSheetViewController {
 
 // MARK: - UIPickerViewDataSource, UIPickerViewDelegate Methods
 
-extension AddSheetViewController: UIPickerViewDataSource, UIPickerViewDelegate {
+extension AddSheetViewController: UIPickerViewDelegate {
+   
+   func pickerView(_ pickerView: UIPickerView, titleForRow row: Int, forComponent component: Int) -> String? {
+      return String(customPickerValues[row])
+   }
+   
+}
+
+extension AddSheetViewController: UIPickerViewDataSource {
    
    func numberOfComponents(in pickerView: UIPickerView) -> Int {
       return 1
@@ -103,10 +111,6 @@ extension AddSheetViewController: UIPickerViewDataSource, UIPickerViewDelegate {
    
    func pickerView(_ pickerView: UIPickerView, numberOfRowsInComponent component: Int) -> Int {
       return customPickerValues.count
-   }
-   
-   func pickerView(_ pickerView: UIPickerView, titleForRow row: Int, forComponent component: Int) -> String? {
-      return String(customPickerValues[row])
    }
    
 }

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/AddSchedule/ViewModels/AddScheduleViewModel.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/AddSchedule/ViewModels/AddScheduleViewModel.swift
@@ -9,7 +9,7 @@ import UIKit
 
 final class AddScheduleViewModel: Serviceable {
    
-   var isImporting = false
+   var isBroughtData = false
    
    var viewedDateCourseByMeData: CourseDetailViewModel?
    

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/AddSchedule/ViewModels/AddScheduleViewModel.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/AddSchedule/ViewModels/AddScheduleViewModel.swift
@@ -132,6 +132,20 @@ extension AddScheduleViewModel {
       dateArea = false
    }
    
+   func schedule1BackAmplitude() {
+      AmplitudeManager.shared.trackEventWithProperties(
+         StringLiterals.Amplitude.EventName.clickSchedule1Back,
+         properties: [
+            StringLiterals.Amplitude.Property.dateTitle: self.dateTitle,
+            StringLiterals.Amplitude.Property.dateDate: self.dateDate,
+            StringLiterals.Amplitude.Property.dateTime: self.dateTime,
+            StringLiterals.Amplitude.Property.dateTagNum: self.dateTagNum,
+            StringLiterals.Amplitude.Property.dateArea: self.dateArea
+         ]
+      )
+      self.resetAddFirstScheduleAmplitude()
+   }
+   
    func getTagIndices(from tags: [String]) -> [Int] {
       return tags.compactMap { tag in
          TendencyTag.allCases.firstIndex { $0.tag.english == tag }

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/AddSchedule/ViewModels/AddScheduleViewModel.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/AddSchedule/ViewModels/AddScheduleViewModel.swift
@@ -320,6 +320,8 @@ extension AddScheduleViewModel {
       //viewmodel 값 초기화
       self.datePlace.value = ""
       self.timeRequire.value = ""
+      self.dateDetailLocation = false
+      self.dateDetailTime = false
       self.isChange?()
    }
    

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/AddSchedule/ViewModels/AddScheduleViewModel.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/AddSchedule/ViewModels/AddScheduleViewModel.swift
@@ -26,37 +26,48 @@ final class AddScheduleViewModel: Serviceable {
    
    //MARK: - AddFirstCourse 사용되는 ViewModel
    
-   /// 데이트 이름 유효성 판별 (true는 통과)
+   // 데이트 이름 유효성 판별 (true는 통과)
    let dateName: ObservablePattern<String> = ObservablePattern(nil)
+   
    let isDateNameVaild: ObservablePattern<Bool> = ObservablePattern(nil)
+   
    private let minimumDateNameLength = 5
    
-   /// 방문 일자 유효성 판별 (true는 통과)
+   // 방문 일자 유효성 판별 (true는 통과)
    let visitDate: ObservablePattern<String> = ObservablePattern(nil)
+   
    let isVisitDateVaild: ObservablePattern<Bool> = ObservablePattern(nil)
    
-   /// 데이트 시작시간 유효성 판별 (self.count > 0 인지)
+   // 데이트 시작시간 유효성 판별 (self.count > 0 인지)
    let dateStartAt: ObservablePattern<String> = ObservablePattern(nil)
+   
    let isDateStartAtVaild: ObservablePattern<Bool> = ObservablePattern(nil)
    
-   /// 코스 등록 태그 생성
+   // 코스 등록 태그 생성
    var tagData: [ProfileTagModel] = []
    
-   /// 선택된 태그
+   // 선택된 태그
    let isOverCount: ObservablePattern<Bool> = ObservablePattern(false)
+   
    let isValidTag: ObservablePattern<Bool> = ObservablePattern(nil)
+   
    let tagCount: ObservablePattern<Int> = ObservablePattern(nil)
+   
    private let minTagCnt = 1
+   
    private let maxTagCnt = 3
    
-   /// 코스 지역 유효성 판별
+   // 코스 지역 유효성 판별
    let dateLocation: ObservablePattern<String> = ObservablePattern(nil)
+   
    let isDateLocationVaild: ObservablePattern<Bool> = ObservablePattern(nil)
    
-   var country = ""
-   var city = ""
-   
+   // 기타
    var isTimePicker: Bool?
+   
+   var country = ""
+   
+   var city = ""
    
    
    //MARK: - AddSecondView 전용 Viewmodel 변수
@@ -111,6 +122,7 @@ final class AddScheduleViewModel: Serviceable {
       initAmplitudeVar()
       fetchTagData()
    }
+   
 }
 
 extension AddScheduleViewModel {
@@ -248,7 +260,6 @@ extension AddScheduleViewModel {
       checkTagCount(min: minTagCnt, max: maxTagCnt)
    }
    
-   
    func checkTagCount(min: Int, max: Int) {
       let count = selectedTagData.count
       self.tagCount.value = count
@@ -378,9 +389,9 @@ extension AddScheduleViewModel {
                self.setLoading(isLoading: false)
                self.isSuccessPostData.value = true
             case .reIssueJWT:
-                self.patchReissue { isSuccess in
-                    self.onReissueSuccess.value = isSuccess
-                }
+               self.patchReissue { isSuccess in
+                  self.onReissueSuccess.value = isSuccess
+               }
             default:
                self.onFailNetwork.value = true
                print("Failed to another reason")

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/AddSchedule/ViewModels/AddScheduleViewModel.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/AddSchedule/ViewModels/AddScheduleViewModel.swift
@@ -58,7 +58,7 @@ final class AddScheduleViewModel: Serviceable {
    
    var isTimePicker: Bool?
    
-   // AddFirstCourse Amplitude 관련 변수
+   // AddFirstSchedule Amplitude 관련 변수
    
    var dateTitle: Bool
    
@@ -97,12 +97,27 @@ final class AddScheduleViewModel: Serviceable {
    
    let onFailNetwork: ObservablePattern<Bool> = ObservablePattern(false)
    
+   // AddScondSchedule Amplitude 관련 변수
+   
+   var dateDetailLocation: Bool
+   
+   var dateDetailTime: Bool
+   
+   var dateCourseNum: Int
+   
+   
+   // MARK: - Initializer
+   
    init() {
       dateTitle = false
       dateDate = false
       dateTime = false
       dateTagNum = 0
       dateArea = false
+      dateDetailLocation = false
+      dateDetailTime = false
+      dateCourseNum = 0
+      
       fetchTagData()
    }
 }

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/AddSchedule/ViewModels/AddScheduleViewModel.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/AddSchedule/ViewModels/AddScheduleViewModel.swift
@@ -146,6 +146,17 @@ extension AddScheduleViewModel {
       self.resetAddFirstScheduleAmplitude()
    }
    
+   func schedule2BackAmplitude() {
+      AmplitudeManager.shared.trackEventWithProperties(
+         StringLiterals.Amplitude.EventName.clickSchedule2Back,
+         properties: [
+            StringLiterals.Amplitude.Property.dateDetailLocation: self.dateDetailLocation,
+            StringLiterals.Amplitude.Property.dateDetailTime: self.dateDetailTime,
+            StringLiterals.Amplitude.Property.dateCourseNum: self.dateCourseNum
+         ]
+      )
+   }
+   
    func getTagIndices(from tags: [String]) -> [Int] {
       return tags.compactMap { tag in
          TendencyTag.allCases.firstIndex { $0.tag.english == tag }

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/AddSchedule/ViewModels/AddScheduleViewModel.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/AddSchedule/ViewModels/AddScheduleViewModel.swift
@@ -308,7 +308,7 @@ extension AddScheduleViewModel {
       if let doubleValue = Double(text) {
          let text = doubleValue.truncatingRemainder(dividingBy: 1) == 0 ? String(Int(doubleValue)) : String(doubleValue)
       }
-      timeRequire.value = "(text) 시간"
+      timeRequire.value = "\(text) 시간"
    }
    
    func isAbleAddBtn() -> Bool {

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/AddSchedule/ViewModels/AddScheduleViewModel.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/AddSchedule/ViewModels/AddScheduleViewModel.swift
@@ -74,8 +74,6 @@ final class AddScheduleViewModel: Serviceable {
    
    var addPlaceCollectionViewDataSource: [AddCoursePlaceModel] = []
    
-   let changeTableViewData: ObservablePattern<Int> = ObservablePattern(0)
-   
    let datePlace: ObservablePattern<String> = ObservablePattern(nil)
    
    let timeRequire: ObservablePattern<String> = ObservablePattern(nil)

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/AddSchedule/ViewModels/AddScheduleViewModel.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/AddSchedule/ViewModels/AddScheduleViewModel.swift
@@ -27,7 +27,7 @@ final class AddScheduleViewModel: Serviceable {
    //MARK: - AddFirstCourse 사용되는 ViewModel
    
    /// 데이트 이름 유효성 판별 (true는 통과)
-   let dateName: ObservablePattern<String> = ObservablePattern(nil)
+   let dateName: ObservablePattern<String> = ObservablePattern("")
    let isDateNameVaild: ObservablePattern<Bool> = ObservablePattern(nil)
    private let minimumDateNameLength = 5
    
@@ -45,30 +45,18 @@ final class AddScheduleViewModel: Serviceable {
    /// 선택된 태그
    let isOverCount: ObservablePattern<Bool> = ObservablePattern(false)
    let isValidTag: ObservablePattern<Bool> = ObservablePattern(nil)
-   let tagCount: ObservablePattern<Int> = ObservablePattern(nil)
+   let tagCount: ObservablePattern<Int> = ObservablePattern(0)
    private let minTagCnt = 1
    private let maxTagCnt = 3
    
    /// 코스 지역 유효성 판별
-   let dateLocation: ObservablePattern<String> = ObservablePattern(nil)
+   let dateLocation: ObservablePattern<String> = ObservablePattern("")
    let isDateLocationVaild: ObservablePattern<Bool> = ObservablePattern(nil)
    
    var country = ""
    var city = ""
    
    var isTimePicker: Bool?
-   
-   // AddFirstCourse Amplitude 관련 변수
-   
-   var dateTitle: Bool
-   
-   var dateDate: Bool
-   
-   var dateTime: Bool
-   
-   var dateTagNum: Int
-   
-   var dateArea: Bool
    
    
    //MARK: - AddSecondView 전용 Viewmodel 변수
@@ -77,9 +65,9 @@ final class AddScheduleViewModel: Serviceable {
    
    let changeTableViewData: ObservablePattern<Int> = ObservablePattern(0)
    
-   let datePlace: ObservablePattern<String> = ObservablePattern(nil)
+   let datePlace: ObservablePattern<String> = ObservablePattern("")
    
-   let timeRequire: ObservablePattern<String> = ObservablePattern(nil)
+   let timeRequire: ObservablePattern<String> = ObservablePattern("")
    
    let isValidOfSecondNextBtn: ObservablePattern<Bool> = ObservablePattern(false)
    
@@ -98,24 +86,11 @@ final class AddScheduleViewModel: Serviceable {
    let onFailNetwork: ObservablePattern<Bool> = ObservablePattern(false)
    
    init() {
-      dateTitle = false
-      dateDate = false
-      dateTime = false
-      dateTagNum = 0
-      dateArea = false
       fetchTagData()
    }
 }
 
 extension AddScheduleViewModel {
-   
-   func resetAddFirstScheduleAmplitude() {
-      dateTitle = false
-      dateDate = false
-      dateTime = false
-      dateTagNum = 0
-      dateArea = false
-   }
    
    func getTagIndices(from tags: [String]) -> [Int] {
       return tags.compactMap { tag in

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/AddSchedule/ViewModels/AddScheduleViewModel.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/AddSchedule/ViewModels/AddScheduleViewModel.swift
@@ -295,12 +295,9 @@ extension AddScheduleViewModel {
    
    func updateTimeRequireTextField(text: String) {
       if let doubleValue = Double(text) {
-         let text = doubleValue.truncatingRemainder(dividingBy: 1) == 0 ?
-         String(Int(doubleValue)) : String(doubleValue)
-         timeRequire.value = "\(text) 시간"
-      } else {
-         timeRequire.value = "\(text) 시간"
+         let text = doubleValue.truncatingRemainder(dividingBy: 1) == 0 ? String(Int(doubleValue)) : String(doubleValue)
       }
+      timeRequire.value = "(text) 시간"
    }
    
    func isAbleAddBtn() -> Bool {
@@ -380,15 +377,12 @@ extension AddScheduleViewModel {
             case .success(let response):
                self.setLoading(isLoading: false)
                self.isSuccessPostData.value = true
-            case .serverErr:
-               self.onFailNetwork.value = true
-            case . requestErr:
-               self.onFailNetwork.value = true
             case .reIssueJWT:
                 self.patchReissue { isSuccess in
                     self.onReissueSuccess.value = isSuccess
                 }
             default:
+               self.onFailNetwork.value = true
                print("Failed to another reason")
                return
             }

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/AddSchedule/ViewModels/AddScheduleViewModel.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/AddSchedule/ViewModels/AddScheduleViewModel.swift
@@ -318,7 +318,7 @@ extension AddScheduleViewModel {
    func isSourceMoreThanOne() {
       let cnt = addPlaceCollectionViewDataSource.count
       self.dateCourseNum = cnt
-      let flag = (cnt >= 2) ? true : false
+      let flag = (cnt >= 2)
       print("지금 데이터소스 개수 : \(addPlaceCollectionViewDataSource.count)\nflag: \(flag)")
       isValidOfSecondNextBtn.value = flag
    }

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/AddSchedule/ViewModels/AddScheduleViewModel.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/AddSchedule/ViewModels/AddScheduleViewModel.swift
@@ -27,7 +27,7 @@ final class AddScheduleViewModel: Serviceable {
    //MARK: - AddFirstCourse 사용되는 ViewModel
    
    /// 데이트 이름 유효성 판별 (true는 통과)
-   let dateName: ObservablePattern<String> = ObservablePattern("")
+   let dateName: ObservablePattern<String> = ObservablePattern(nil)
    let isDateNameVaild: ObservablePattern<Bool> = ObservablePattern(nil)
    private let minimumDateNameLength = 5
    
@@ -45,18 +45,30 @@ final class AddScheduleViewModel: Serviceable {
    /// 선택된 태그
    let isOverCount: ObservablePattern<Bool> = ObservablePattern(false)
    let isValidTag: ObservablePattern<Bool> = ObservablePattern(nil)
-   let tagCount: ObservablePattern<Int> = ObservablePattern(0)
+   let tagCount: ObservablePattern<Int> = ObservablePattern(nil)
    private let minTagCnt = 1
    private let maxTagCnt = 3
    
    /// 코스 지역 유효성 판별
-   let dateLocation: ObservablePattern<String> = ObservablePattern("")
+   let dateLocation: ObservablePattern<String> = ObservablePattern(nil)
    let isDateLocationVaild: ObservablePattern<Bool> = ObservablePattern(nil)
    
    var country = ""
    var city = ""
    
    var isTimePicker: Bool?
+   
+   // AddFirstCourse Amplitude 관련 변수
+   
+   var dateTitle: Bool
+   
+   var dateDate: Bool
+   
+   var dateTime: Bool
+   
+   var dateTagNum: Int
+   
+   var dateArea: Bool
    
    
    //MARK: - AddSecondView 전용 Viewmodel 변수
@@ -65,9 +77,9 @@ final class AddScheduleViewModel: Serviceable {
    
    let changeTableViewData: ObservablePattern<Int> = ObservablePattern(0)
    
-   let datePlace: ObservablePattern<String> = ObservablePattern("")
+   let datePlace: ObservablePattern<String> = ObservablePattern(nil)
    
-   let timeRequire: ObservablePattern<String> = ObservablePattern("")
+   let timeRequire: ObservablePattern<String> = ObservablePattern(nil)
    
    let isValidOfSecondNextBtn: ObservablePattern<Bool> = ObservablePattern(false)
    
@@ -86,11 +98,24 @@ final class AddScheduleViewModel: Serviceable {
    let onFailNetwork: ObservablePattern<Bool> = ObservablePattern(false)
    
    init() {
+      dateTitle = false
+      dateDate = false
+      dateTime = false
+      dateTagNum = 0
+      dateArea = false
       fetchTagData()
    }
 }
 
 extension AddScheduleViewModel {
+   
+   func resetAddFirstScheduleAmplitude() {
+      dateTitle = false
+      dateDate = false
+      dateTime = false
+      dateTagNum = 0
+      dateArea = false
+   }
    
    func getTagIndices(from tags: [String]) -> [Int] {
       return tags.compactMap { tag in

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/AddSchedule/ViewModels/AddScheduleViewModel.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/AddSchedule/ViewModels/AddScheduleViewModel.swift
@@ -58,18 +58,6 @@ final class AddScheduleViewModel: Serviceable {
    
    var isTimePicker: Bool?
    
-   // AddFirstSchedule Amplitude 관련 변수
-   
-   var dateTitle: Bool
-   
-   var dateDate: Bool
-   
-   var dateTime: Bool
-   
-   var dateTagNum: Int
-   
-   var dateArea: Bool
-   
    
    //MARK: - AddSecondView 전용 Viewmodel 변수
    
@@ -97,18 +85,37 @@ final class AddScheduleViewModel: Serviceable {
    
    let onFailNetwork: ObservablePattern<Bool> = ObservablePattern(false)
    
-   // AddScondSchedule Amplitude 관련 변수
    
-   var dateDetailLocation: Bool
+   //MARK: - AddSchedule Amplitude 관련 변수
    
-   var dateDetailTime: Bool
+   var dateTitle: Bool = false
    
-   var dateCourseNum: Int
+   var dateDate: Bool = false
+   
+   var dateTime: Bool = false
+   
+   var dateTagNum: Int = 0
+   
+   var dateArea: Bool = false
+   
+   var dateDetailLocation: Bool = false
+   
+   var dateDetailTime: Bool = false
+   
+   var dateCourseNum: Int = 0
    
    
    // MARK: - Initializer
    
    init() {
+      initAmplitudeVar()
+      fetchTagData()
+   }
+}
+
+extension AddScheduleViewModel {
+   
+   func initAmplitudeVar() {
       dateTitle = false
       dateDate = false
       dateTime = false
@@ -117,12 +124,7 @@ final class AddScheduleViewModel: Serviceable {
       dateDetailLocation = false
       dateDetailTime = false
       dateCourseNum = 0
-      
-      fetchTagData()
    }
-}
-
-extension AddScheduleViewModel {
    
    func resetAddFirstScheduleAmplitude() {
       dateTitle = false

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/AddSchedule/ViewModels/AddScheduleViewModel.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/AddSchedule/ViewModels/AddScheduleViewModel.swift
@@ -317,7 +317,9 @@ extension AddScheduleViewModel {
    
    /// dataSource 개수 >= 2 라면 (다음 2/3) 버튼 활성화
    func isSourceMoreThanOne() {
-      let flag = (addPlaceCollectionViewDataSource.count >= 2) ? true : false
+      let cnt = addPlaceCollectionViewDataSource.count
+      self.dateCourseNum = cnt
+      let flag = (cnt >= 2) ? true : false
       print("지금 데이터소스 개수 : \(addPlaceCollectionViewDataSource.count)\nflag: \(flag)")
       isValidOfSecondNextBtn.value = flag
    }

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/AddSchedule/ViewModels/AddScheduleViewModel.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/AddSchedule/ViewModels/AddScheduleViewModel.swift
@@ -254,7 +254,6 @@ extension AddScheduleViewModel {
             selectedTagData.remove(at: index)
          }
       }
-      
       checkTagCount(min: minTagCnt, max: maxTagCnt)
    }
    
@@ -303,10 +302,11 @@ extension AddScheduleViewModel {
    }
    
    func updateTimeRequireTextField(text: String) {
+      var formattedText = text
       if let doubleValue = Double(text) {
-         let text = doubleValue.truncatingRemainder(dividingBy: 1) == 0 ? String(Int(doubleValue)) : String(doubleValue)
+         formattedText = doubleValue.truncatingRemainder(dividingBy: 1) == 0 ? String(Int(doubleValue)) : String(doubleValue)
       }
-      timeRequire.value = "\(text) 시간"
+      timeRequire.value = "\(formattedText) 시간"
    }
    
    func isAbleAddBtn() -> Bool {
@@ -320,6 +320,7 @@ extension AddScheduleViewModel {
       //viewmodel 값 초기화
       self.datePlace.value = ""
       self.timeRequire.value = ""
+      
       self.dateDetailLocation = false
       self.dateDetailTime = false
       self.isChange?()
@@ -386,6 +387,7 @@ extension AddScheduleViewModel {
          places: places)) { result in
             switch result {
             case .success(let response):
+               print("Success: \(response)")
                self.setLoading(isLoading: false)
                self.isSuccessPostData.value = true
             case .reIssueJWT:

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/AddSchedule/Views/AddScheduleBottomSheetView.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/AddSchedule/Views/AddScheduleBottomSheetView.swift
@@ -37,7 +37,7 @@ final class AddScheduleBottomSheetView: BaseView {
    init(isCustomPicker: Bool) {
       self.isCustomPicker = isCustomPicker
       
-      super.init(frame: .zero) // 모든 Class의 초기화가 진행된 이후 super 클래스의 초기화가 이뤄져야 하기에 제일 하단에 위치
+      super.init(frame: .zero)
    }
    
    required init?(coder: NSCoder) {
@@ -49,14 +49,16 @@ final class AddScheduleBottomSheetView: BaseView {
    
    override func setHierarchy() {
       switch isCustomPicker {
+         
       case true:
          addSubviews(bottomSheetView)
          bottomSheetView.addSubviews(doneBtn, customPickerView)
          doneBtn.addSubview(doneBtnTitleLabel)
+         
       case false:
          self.addSubviews(datePicker)
+         
       }
-      
    }
    
    override func setLayout() {

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/AddSchedule/Views/AddScheduleBottomSheetView.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/AddSchedule/Views/AddScheduleBottomSheetView.swift
@@ -124,7 +124,7 @@ final class AddScheduleBottomSheetView: BaseView {
 }
 
 
-// MARK: - View Methods
+// MARK: - Extension Methods
 
 extension AddScheduleBottomSheetView {
    

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/AddSchedule/Views/AddScheduleBottomSheetViewController.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/AddSchedule/Views/AddScheduleBottomSheetViewController.swift
@@ -66,7 +66,7 @@ final class AddScheduleBottomSheetViewController: BaseViewController {
    
 }
 
-// MARK: - ViewController Methods
+// MARK: - Extension Methods
 
 private extension AddScheduleBottomSheetViewController {
    
@@ -77,9 +77,6 @@ private extension AddScheduleBottomSheetViewController {
       addSheetView.customPickerView.reloadAllComponents()
       addSheetView.doneBtn.addTarget(self, action: #selector(didTapDoneBtn), for: .touchUpInside)
    }
-   
-   
-   // MARK: - @objc Methods
    
    @objc
    func didTapDoneBtn() {
@@ -94,7 +91,16 @@ private extension AddScheduleBottomSheetViewController {
 
 // MARK: - UIPickerViewDataSource, UIPickerViewDelegate Methods
 
-extension AddScheduleBottomSheetViewController: UIPickerViewDataSource, UIPickerViewDelegate {
+
+extension AddScheduleBottomSheetViewController: UIPickerViewDelegate {
+   
+   func pickerView(_ pickerView: UIPickerView, titleForRow row: Int, forComponent component: Int) -> String? {
+      return String(customPickerValues[row])
+   }
+   
+}
+
+extension AddScheduleBottomSheetViewController: UIPickerViewDataSource {
    
    func numberOfComponents(in pickerView: UIPickerView) -> Int {
       return 1
@@ -102,10 +108,6 @@ extension AddScheduleBottomSheetViewController: UIPickerViewDataSource, UIPicker
    
    func pickerView(_ pickerView: UIPickerView, numberOfRowsInComponent component: Int) -> Int {
       return customPickerValues.count
-   }
-   
-   func pickerView(_ pickerView: UIPickerView, titleForRow row: Int, forComponent component: Int) -> String? {
-      return String(customPickerValues[row])
    }
    
 }

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/AddSchedule/Views/AddScheduleBottomSheetViewController.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/AddSchedule/Views/AddScheduleBottomSheetViewController.swift
@@ -28,6 +28,7 @@ final class AddScheduleBottomSheetViewController: BaseViewController {
    
    init(viewModel: AddScheduleViewModel) {
       self.viewModel = viewModel
+      
       super.init(nibName: nil, bundle: nil)
    }
    
@@ -69,7 +70,7 @@ final class AddScheduleBottomSheetViewController: BaseViewController {
 
 private extension AddScheduleBottomSheetViewController {
    
-   private func setCustomPicker() {
+   func setCustomPicker() {
       customPickerValues = Array(stride(from: 0.5, to: 6.5, by: 0.5))
       addSheetView.customPickerView.dataSource = self
       addSheetView.customPickerView.delegate = self
@@ -77,10 +78,11 @@ private extension AddScheduleBottomSheetViewController {
       addSheetView.doneBtn.addTarget(self, action: #selector(didTapDoneBtn), for: .touchUpInside)
    }
    
+   
    // MARK: - @objc Methods
    
    @objc
-   private func didTapDoneBtn() {
+   func didTapDoneBtn() {
       let selectedRow = addSheetView.customPickerView.selectedRow(inComponent: 0)
       let selectedValue = customPickerValues[selectedRow]
       viewModel?.updateTimeRequireTextField(text: String(selectedValue))

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/AddSchedule/Views/AddScheduleFirst/AddScheduleFirstView.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/AddSchedule/Views/AddScheduleFirst/AddScheduleFirstView.swift
@@ -64,9 +64,10 @@ final class AddScheduleFirstView: BaseView {
    
 }
 
+
+// MARK: - Extension Methods
+
 extension AddScheduleFirstView {
-   
-   // MARK: - Methods
    
    func updateDateNameTextField(isPassValid: Bool) {
       dateNameErrorLabel.isHidden = isPassValid

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/AddSchedule/Views/AddScheduleFirst/AddScheduleFirstViewController.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/AddSchedule/Views/AddScheduleFirst/AddScheduleFirstViewController.swift
@@ -226,6 +226,7 @@ private extension AddScheduleFirstViewController {
    @objc
    func didTapNavRightBtn() {
        let vc = NavViewedCourseViewController(viewedCourseViewModel: MyCourseListViewModel())
+      AmplitudeManager.shared.trackEvent(StringLiterals.Amplitude.EventName.clickBringCourse)
       self.navigationController?.pushViewController(vc, animated: false)
    }
    

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/AddSchedule/Views/AddScheduleFirst/AddScheduleFirstViewController.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/AddSchedule/Views/AddScheduleFirst/AddScheduleFirstViewController.swift
@@ -291,7 +291,7 @@ private extension AddScheduleFirstViewController {
    }
    
    @objc
-   func importingTagBtn(_ sender: UIButton) {
+   func broughtTagBtn(_ sender: UIButton) {
       self.addScheduleFirstView.inAddScheduleFirstView.updateTag(button: sender, buttonType: SelectedButton())
       self.viewModel.isValidTag.value = true
    }

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/AddSchedule/Views/AddScheduleFirst/AddScheduleFirstViewController.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/AddSchedule/Views/AddScheduleFirst/AddScheduleFirstViewController.swift
@@ -320,7 +320,7 @@ private extension AddScheduleFirstViewController {
 
 extension AddScheduleFirstViewController {
    func pastDateBindViewModel() {
-      if !viewModel.isImporting {
+      if !viewModel.isBroughtData {
          setRightBtnStyle()
          setRightButtonAction(target: self, action: #selector(didTapNavRightBtn))
       }

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/AddSchedule/Views/AddScheduleFirst/AddScheduleFirstViewController.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/AddSchedule/Views/AddScheduleFirst/AddScheduleFirstViewController.swift
@@ -267,8 +267,10 @@ private extension AddScheduleFirstViewController {
    
    @objc
    func textFieldDidChanacge(_ textField: UITextField) {
-      viewModel.dateName.value = textField.text ?? ""
-      viewModel.satisfyDateName(str: textField.text ?? "")
+      guard let text = textField.text else {return}
+      viewModel.dateName.value = text
+      viewModel.satisfyDateName(str: text)
+      self.viewModel.dateTitle = !text.isEmpty ? true : false
    }
    
    @objc

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/AddSchedule/Views/AddScheduleFirst/AddScheduleFirstViewController.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/AddSchedule/Views/AddScheduleFirst/AddScheduleFirstViewController.swift
@@ -26,11 +26,15 @@ final class AddScheduleFirstViewController: BaseNavBarViewController {
    
    let viewModel: AddScheduleViewModel
    
+   var viewPath: String
+   
    
    // MARK: - Initializer
    
-   init(viewModel: AddScheduleViewModel) {
+   init(viewModel: AddScheduleViewModel, viewPath: String) {
       self.viewModel = viewModel
+      self.viewPath = viewPath
+      
       super.init(nibName: nil, bundle: nil)
    }
    
@@ -53,6 +57,8 @@ final class AddScheduleFirstViewController: BaseNavBarViewController {
       
       setupKeyboardDismissRecognizer()
       pastDateBindViewModel()
+      
+      AmplitudeManager.shared.trackEventWithProperties(StringLiterals.Amplitude.EventName.viewAddSchedule, properties: [StringLiterals.Amplitude.Property.viewPath: viewPath])
    }
    
    
@@ -142,19 +148,18 @@ private extension AddScheduleFirstViewController {
       viewModel.ispastDateVaild.bind { [weak self] isValid in
          guard let self = self else { return }
          self.viewModel.fetchPastDate()
+         AmplitudeManager.shared.trackEventWithProperties(StringLiterals.Amplitude.EventName.viewAddBringcourse, properties: [StringLiterals.Amplitude.Property.viewPath: viewPath])
       }
       
       viewModel.isDateNameVaild.bind { date in
          guard let date else {return}
          self.addScheduleFirstView.updateDateNameTextField(isPassValid: date)
-         
          let flag = self.viewModel.isOkSixBtn()
          self.addScheduleFirstView.inAddScheduleFirstView.updateSixCheckButton(isValid: flag)
       }
       viewModel.isVisitDateVaild.bind { date in
          guard let date else {return}
          self.addScheduleFirstView.updateVisitDateTextField(isPassValid: date)
-         
          let flag = self.viewModel.isOkSixBtn()
          self.addScheduleFirstView.inAddScheduleFirstView.updateSixCheckButton(isValid: flag)
       }
@@ -174,21 +179,27 @@ private extension AddScheduleFirstViewController {
       viewModel.dateName.bind { date in
          guard let text = date else {return}
          self.addScheduleFirstView.inAddScheduleFirstView.updateDateName(text: text)
+         self.viewModel.dateTitle = true
       }
       viewModel.visitDate.bind { date in
          guard let text = date else {return}
          self.addScheduleFirstView.inAddScheduleFirstView.updateVisitDate(text: text)
+         self.viewModel.dateDate = true
       }
       viewModel.dateStartAt.bind { date in
          guard let text = date else {return}
          self.addScheduleFirstView.inAddScheduleFirstView.updatedateStartTime(text: text)
+         self.viewModel.dateTime = true
       }
       viewModel.tagCount.bind { count in
-         self.addScheduleFirstView.inAddScheduleFirstView.updateTagCount(count: count ?? 0)
+         guard let count else {return}
+         self.addScheduleFirstView.inAddScheduleFirstView.updateTagCount(count: count)
+         self.viewModel.dateTagNum = count
       }
       viewModel.dateLocation.bind { date in
          guard let date else {return}
          self.addScheduleFirstView.inAddScheduleFirstView.updateDateLocation(text: date)
+         self.viewModel.dateArea = true
       }
    }
    
@@ -312,6 +323,27 @@ extension AddScheduleFirstViewController {
          setRightButtonAction(target: self, action: #selector(didTapNavRightBtn))
       }
       viewModel.ispastDateVaild.value = true
+   }
+   
+   private func schedule1BackAmplitude() {
+      AmplitudeManager.shared.trackEventWithProperties(
+         StringLiterals.Amplitude.EventName.clickSchedule1Back,
+         properties: [
+            StringLiterals.Amplitude.Property.dateTitle: viewModel.dateTitle,
+            StringLiterals.Amplitude.Property.dateDate: viewModel.dateDate,
+            StringLiterals.Amplitude.Property.dateTime: viewModel.dateTime,
+            StringLiterals.Amplitude.Property.dateTagNum: viewModel.dateTagNum,
+            StringLiterals.Amplitude.Property.dateArea: viewModel.dateArea
+         ]
+      )
+      viewModel.resetAddFirstScheduleAmplitude()
+   }
+   
+   /// BaseNavBarViewController에서 backButtonTapped() 오버라이드
+   @objc
+   override func backButtonTapped() {
+      schedule1BackAmplitude()
+      super.backButtonTapped()
    }
 }
 

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/AddSchedule/Views/AddScheduleFirst/AddScheduleFirstViewController.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/AddSchedule/Views/AddScheduleFirst/AddScheduleFirstViewController.swift
@@ -26,15 +26,11 @@ final class AddScheduleFirstViewController: BaseNavBarViewController {
    
    let viewModel: AddScheduleViewModel
    
-   var viewPath: String
-   
    
    // MARK: - Initializer
    
-   init(viewModel: AddScheduleViewModel, viewPath: String) {
+   init(viewModel: AddScheduleViewModel) {
       self.viewModel = viewModel
-      self.viewPath = viewPath
-      
       super.init(nibName: nil, bundle: nil)
    }
    
@@ -57,8 +53,6 @@ final class AddScheduleFirstViewController: BaseNavBarViewController {
       
       setupKeyboardDismissRecognizer()
       pastDateBindViewModel()
-      
-      AmplitudeManager.shared.trackEventWithProperties(StringLiterals.Amplitude.EventName.viewAddSchedule, properties: [StringLiterals.Amplitude.Property.viewPath: viewPath])
    }
    
    
@@ -148,18 +142,19 @@ private extension AddScheduleFirstViewController {
       viewModel.ispastDateVaild.bind { [weak self] isValid in
          guard let self = self else { return }
          self.viewModel.fetchPastDate()
-         AmplitudeManager.shared.trackEventWithProperties(StringLiterals.Amplitude.EventName.viewAddBringcourse, properties: [StringLiterals.Amplitude.Property.viewPath: viewPath])
       }
       
       viewModel.isDateNameVaild.bind { date in
          guard let date else {return}
          self.addScheduleFirstView.updateDateNameTextField(isPassValid: date)
+         
          let flag = self.viewModel.isOkSixBtn()
          self.addScheduleFirstView.inAddScheduleFirstView.updateSixCheckButton(isValid: flag)
       }
       viewModel.isVisitDateVaild.bind { date in
          guard let date else {return}
          self.addScheduleFirstView.updateVisitDateTextField(isPassValid: date)
+         
          let flag = self.viewModel.isOkSixBtn()
          self.addScheduleFirstView.inAddScheduleFirstView.updateSixCheckButton(isValid: flag)
       }
@@ -179,27 +174,21 @@ private extension AddScheduleFirstViewController {
       viewModel.dateName.bind { date in
          guard let text = date else {return}
          self.addScheduleFirstView.inAddScheduleFirstView.updateDateName(text: text)
-         self.viewModel.dateTitle = true
       }
       viewModel.visitDate.bind { date in
          guard let text = date else {return}
          self.addScheduleFirstView.inAddScheduleFirstView.updateVisitDate(text: text)
-         self.viewModel.dateDate = true
       }
       viewModel.dateStartAt.bind { date in
          guard let text = date else {return}
          self.addScheduleFirstView.inAddScheduleFirstView.updatedateStartTime(text: text)
-         self.viewModel.dateTime = true
       }
       viewModel.tagCount.bind { count in
-         guard let count else {return}
-         self.addScheduleFirstView.inAddScheduleFirstView.updateTagCount(count: count)
-         self.viewModel.dateTagNum = count
+         self.addScheduleFirstView.inAddScheduleFirstView.updateTagCount(count: count ?? 0)
       }
       viewModel.dateLocation.bind { date in
          guard let date else {return}
          self.addScheduleFirstView.inAddScheduleFirstView.updateDateLocation(text: date)
-         self.viewModel.dateArea = true
       }
    }
    
@@ -323,27 +312,6 @@ extension AddScheduleFirstViewController {
          setRightButtonAction(target: self, action: #selector(didTapNavRightBtn))
       }
       viewModel.ispastDateVaild.value = true
-   }
-   
-   private func schedule1BackAmplitude() {
-      AmplitudeManager.shared.trackEventWithProperties(
-         StringLiterals.Amplitude.EventName.clickSchedule1Back,
-         properties: [
-            StringLiterals.Amplitude.Property.dateTitle: viewModel.dateTitle,
-            StringLiterals.Amplitude.Property.dateDate: viewModel.dateDate,
-            StringLiterals.Amplitude.Property.dateTime: viewModel.dateTime,
-            StringLiterals.Amplitude.Property.dateTagNum: viewModel.dateTagNum,
-            StringLiterals.Amplitude.Property.dateArea: viewModel.dateArea
-         ]
-      )
-      viewModel.resetAddFirstScheduleAmplitude()
-   }
-   
-   /// BaseNavBarViewController에서 backButtonTapped() 오버라이드
-   @objc
-   override func backButtonTapped() {
-      schedule1BackAmplitude()
-      super.backButtonTapped()
    }
 }
 

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/AddSchedule/Views/AddScheduleFirst/AddScheduleFirstViewController.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/AddSchedule/Views/AddScheduleFirst/AddScheduleFirstViewController.swift
@@ -157,20 +157,24 @@ private extension AddScheduleFirstViewController {
          let flag = self.viewModel.isOkSixBtn()
          self.addScheduleFirstView.inAddScheduleFirstView.updateSixCheckButton(isValid: flag)
       }
+      
       viewModel.isVisitDateVaild.bind { date in
          guard let date else {return}
          self.addScheduleFirstView.updateVisitDateTextField(isPassValid: date)
          let flag = self.viewModel.isOkSixBtn()
          self.addScheduleFirstView.inAddScheduleFirstView.updateSixCheckButton(isValid: flag)
       }
+      
       viewModel.isDateStartAtVaild.bind { date in
          let flag = self.viewModel.isOkSixBtn()
          self.addScheduleFirstView.inAddScheduleFirstView.updateSixCheckButton(isValid: flag)
       }
+      
       viewModel.isValidTag.bind { date in
          let flag = self.viewModel.isOkSixBtn()
          self.addScheduleFirstView.inAddScheduleFirstView.updateSixCheckButton(isValid: flag)
       }
+      
       viewModel.isDateLocationVaild.bind { date in
          let flag = self.viewModel.isOkSixBtn()
          self.addScheduleFirstView.inAddScheduleFirstView.updateSixCheckButton(isValid: flag)
@@ -181,21 +185,25 @@ private extension AddScheduleFirstViewController {
          self.addScheduleFirstView.inAddScheduleFirstView.updateDateName(text: text)
          self.viewModel.dateTitle = true
       }
+      
       viewModel.visitDate.bind { date in
          guard let text = date else {return}
          self.addScheduleFirstView.inAddScheduleFirstView.updateVisitDate(text: text)
          self.viewModel.dateDate = true
       }
+      
       viewModel.dateStartAt.bind { date in
          guard let text = date else {return}
          self.addScheduleFirstView.inAddScheduleFirstView.updatedateStartTime(text: text)
          self.viewModel.dateTime = true
       }
+      
       viewModel.tagCount.bind { count in
          guard let count else {return}
          self.addScheduleFirstView.inAddScheduleFirstView.updateTagCount(count: count)
          self.viewModel.dateTagNum = count
       }
+      
       viewModel.dateLocation.bind { date in
          guard let date else {return}
          self.addScheduleFirstView.inAddScheduleFirstView.updateDateLocation(text: date)
@@ -236,7 +244,7 @@ private extension AddScheduleFirstViewController {
    
    @objc
    func didTapNavRightBtn() {
-       let vc = NavViewedCourseViewController(viewedCourseViewModel: MyCourseListViewModel())
+      let vc = NavViewedCourseViewController(viewedCourseViewModel: MyCourseListViewModel())
       AmplitudeManager.shared.trackEvent(StringLiterals.Amplitude.EventName.clickBringCourse)
       self.navigationController?.pushViewController(vc, animated: false)
    }
@@ -319,6 +327,7 @@ private extension AddScheduleFirstViewController {
 }
 
 extension AddScheduleFirstViewController {
+   
    func pastDateBindViewModel() {
       if !viewModel.isBroughtData {
          setRightBtnStyle()
@@ -327,14 +336,13 @@ extension AddScheduleFirstViewController {
       viewModel.ispastDateVaild.value = true
    }
    
-   
-   
    /// BaseNavBarViewController에서 backButtonTapped() 오버라이드
    @objc
    override func backButtonTapped() {
       viewModel.schedule1BackAmplitude()
       super.backButtonTapped()
    }
+   
 }
 
 extension AddScheduleFirstViewController: UICollectionViewDelegateFlowLayout {

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/AddSchedule/Views/AddScheduleFirst/AddScheduleFirstViewController.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/AddSchedule/Views/AddScheduleFirst/AddScheduleFirstViewController.swift
@@ -325,24 +325,12 @@ extension AddScheduleFirstViewController {
       viewModel.ispastDateVaild.value = true
    }
    
-   private func schedule1BackAmplitude() {
-      AmplitudeManager.shared.trackEventWithProperties(
-         StringLiterals.Amplitude.EventName.clickSchedule1Back,
-         properties: [
-            StringLiterals.Amplitude.Property.dateTitle: viewModel.dateTitle,
-            StringLiterals.Amplitude.Property.dateDate: viewModel.dateDate,
-            StringLiterals.Amplitude.Property.dateTime: viewModel.dateTime,
-            StringLiterals.Amplitude.Property.dateTagNum: viewModel.dateTagNum,
-            StringLiterals.Amplitude.Property.dateArea: viewModel.dateArea
-         ]
-      )
-      viewModel.resetAddFirstScheduleAmplitude()
-   }
+   
    
    /// BaseNavBarViewController에서 backButtonTapped() 오버라이드
    @objc
    override func backButtonTapped() {
-      schedule1BackAmplitude()
+      viewModel.schedule1BackAmplitude()
       super.backButtonTapped()
    }
 }

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/AddSchedule/Views/AddScheduleFirst/AddScheduleFirstViewController.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/AddSchedule/Views/AddScheduleFirst/AddScheduleFirstViewController.swift
@@ -54,10 +54,8 @@ final class AddScheduleFirstViewController: BaseNavBarViewController {
       registerCell()
       setDelegate()
       bindViewModel()
-      
       setupKeyboardDismissRecognizer()
       pastDateBindViewModel()
-      
       AmplitudeManager.shared.trackEventWithProperties(StringLiterals.Amplitude.EventName.viewAddSchedule, properties: [StringLiterals.Amplitude.Property.viewPath: viewPath])
    }
    
@@ -314,7 +312,7 @@ private extension AddScheduleFirstViewController {
    }
    
    @objc
-   private func datePlaceContainerTapped() {
+   func datePlaceContainerTapped() {
       // datePlaceContainer가 탭되었을 때 수행할 동작을 여기에 구현합니다.
       print("datePlaceContainer tapped!")
       let locationFilterVC = LocationFilterViewController()
@@ -366,7 +364,11 @@ extension AddScheduleFirstViewController: UICollectionViewDelegateFlowLayout {
    
 }
 
-extension AddScheduleFirstViewController: UICollectionViewDataSource, UICollectionViewDelegate {
+extension AddScheduleFirstViewController: UICollectionViewDelegate {
+   
+}
+
+extension AddScheduleFirstViewController: UICollectionViewDataSource {
    
    func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
       return viewModel.tagData.count

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/AddSchedule/Views/AddScheduleFirst/InAddScheduleFirstView.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/AddSchedule/Views/AddScheduleFirst/InAddScheduleFirstView.swift
@@ -150,7 +150,6 @@ final class InAddScheduleFirstView: BaseView {
          $0.horizontalEdges.bottom.equalToSuperview()
          $0.height.equalTo(52)
       }
-      
    }
    
    override func setStyle() {
@@ -235,9 +234,10 @@ final class InAddScheduleFirstView: BaseView {
    
 }
 
+
+// MARK: - Extension Methods
+
 extension InAddScheduleFirstView {
-   
-   // MARK: - Methods
    
    func updateDateName(text: String) {
       dateNameTextField.text = text

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/AddSchedule/Views/AddScheduleSecond/AddScheduleSecondView.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/AddSchedule/Views/AddScheduleSecond/AddScheduleSecondView.swift
@@ -23,7 +23,7 @@ final class AddScheduleSecondView: BaseView {
    var addPlaceCollectionView = UICollectionView(frame: .zero, collectionViewLayout: UICollectionViewFlowLayout())
    
    let nextBtn: UIButton = UIButton()
-
+   
    
    // MARK: - Properties
    

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/AddSchedule/Views/AddScheduleSecond/AddScheduleSecondViewController.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/AddSchedule/Views/AddScheduleSecond/AddScheduleSecondViewController.swift
@@ -113,6 +113,9 @@ private extension AddScheduleSecondViewController {
          for i in viewModel.pastDatePlaces {
             viewModel.tapAddBtn(datePlace: i.title, timeRequire: String(i.duration))
          }
+         AmplitudeManager.shared.trackEvent(StringLiterals.Amplitude.EventName.viewAddBringcourse2)
+      } else {
+         AmplitudeManager.shared.trackEvent(StringLiterals.Amplitude.EventName.viewAddSchedule2)
       }
    }
    

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/AddSchedule/Views/AddScheduleSecond/AddScheduleSecondViewController.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/AddSchedule/Views/AddScheduleSecond/AddScheduleSecondViewController.swift
@@ -109,10 +109,11 @@ private extension AddScheduleSecondViewController {
    }
    
    func pastDateBindViewModel() {
-      if viewModel.pastDatePlaces.count > 0  {
+      if viewModel.isImporting  {
          for i in viewModel.pastDatePlaces {
             viewModel.tapAddBtn(datePlace: i.title, timeRequire: String(i.duration))
          }
+         viewModel.pastDatePlaces.removeAll()
          AmplitudeManager.shared.trackEvent(StringLiterals.Amplitude.EventName.viewAddBringcourse2)
       } else {
          AmplitudeManager.shared.trackEvent(StringLiterals.Amplitude.EventName.viewAddSchedule2)

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/AddSchedule/Views/AddScheduleSecond/AddScheduleSecondViewController.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/AddSchedule/Views/AddScheduleSecond/AddScheduleSecondViewController.swift
@@ -249,6 +249,20 @@ private extension AddScheduleSecondViewController {
    // MARK: - @objc Methods
    
    @objc
+   func textFieldTapped(_ textField: UITextField) {
+      let alertVC = AddScheduleBottomSheetViewController(viewModel: viewModel)
+      alertVC.addSheetView = AddScheduleBottomSheetView(isCustomPicker: true)
+      
+      self.alertVC = alertVC // alertVC를 인스턴스 변수에 저장
+      addScheduleSecondView.inAddScheduleSecondView.datePlaceTextField.resignFirstResponder()
+      
+      DispatchQueue.main.async {
+         alertVC.modalPresentationStyle = .overFullScreen
+         self.present(alertVC, animated: true, completion: nil)
+      }
+   }
+   
+   @objc
    func tapAddPlaceBtn() {
       viewModel.tapAddBtn(datePlace: viewModel.datePlace.value ?? "", timeRequire: viewModel.timeRequire.value ?? "")
    }
@@ -304,7 +318,7 @@ private extension AddScheduleSecondViewController {
       }
       addScheduleSecondView.updateEditBtnText(flag: flag)
       
-      Dispatch.DispatchQueue.main.async {
+      DispatchQueue.main.async {
          collectionView.reloadData()
       }
    }
@@ -345,26 +359,12 @@ extension AddScheduleSecondViewController: UITextFieldDelegate {
       print(textField.text ?? "")
    }
    
-   @objc
-   private func textFieldTapped(_ textField: UITextField) {
-      let alertVC = AddScheduleBottomSheetViewController(viewModel: viewModel)
-      alertVC.addSheetView = AddScheduleBottomSheetView(isCustomPicker: true)
-      
-      self.alertVC = alertVC // alertVC를 인스턴스 변수에 저장
-      addScheduleSecondView.inAddScheduleSecondView.datePlaceTextField.resignFirstResponder()
-      
-      DispatchQueue.main.async {
-         alertVC.modalPresentationStyle = .overFullScreen
-         self.present(alertVC, animated: true, completion: nil)
-      }
-   }
-   
 }
 
 
-// MARK: - UICollectionViewDataSource, UICollectionViewDelegate Methods
+// MARK: - UICollectionViewDelegate Methods
 
-extension AddScheduleSecondViewController: UICollectionViewDataSource, UICollectionViewDelegate {
+extension AddScheduleSecondViewController: UICollectionViewDelegate {
    
    func collectionView(_ collectionView: UICollectionView, canMoveItemAt indexPath: IndexPath) -> Bool {
       return true
@@ -372,6 +372,13 @@ extension AddScheduleSecondViewController: UICollectionViewDataSource, UICollect
    
    func collectionView(_ collectionView: UICollectionView, moveItemAt sourceIndexPath: IndexPath, to destinationIndexPath: IndexPath) {
    }
+   
+}
+
+
+// MARK: - UICollectionViewDataSource Methods
+
+extension AddScheduleSecondViewController: UICollectionViewDataSource {
    
    func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
       return viewModel.addPlaceCollectionViewDataSource.count
@@ -452,7 +459,7 @@ extension AddScheduleSecondViewController: UICollectionViewDropDelegate {
 }
 
 
-// MARK: - UICollectionViewDragDelegate Methods
+// MARK: - UICollectionViewDragDelegate Method
 
 extension AddScheduleSecondViewController: UICollectionViewDragDelegate {
    
@@ -461,6 +468,9 @@ extension AddScheduleSecondViewController: UICollectionViewDragDelegate {
    }
    
 }
+
+
+// MARK: - DRCustomAlertDelegate Method
 
 extension AddScheduleSecondViewController: DRCustomAlertDelegate {
    

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/AddSchedule/Views/AddScheduleSecond/AddScheduleSecondViewController.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/AddSchedule/Views/AddScheduleSecond/AddScheduleSecondViewController.swift
@@ -19,7 +19,7 @@ final class AddScheduleSecondViewController: BaseNavBarViewController {
    private let viewModel: AddScheduleViewModel
    
    private var alertVC: AddScheduleBottomSheetViewController?
-      
+   
    private let errorView: DRErrorViewController = DRErrorViewController()
    
    
@@ -27,6 +27,7 @@ final class AddScheduleSecondViewController: BaseNavBarViewController {
    
    init(viewModel: AddScheduleViewModel) {
       self.viewModel = viewModel
+      
       super.init(nibName: nil, bundle: nil)
    }
    
@@ -64,7 +65,7 @@ final class AddScheduleSecondViewController: BaseNavBarViewController {
    
    override func setLayout() {
       super.setLayout()
-
+      
       addScheduleSecondView.snp.makeConstraints {
          $0.top.equalToSuperview().offset(4)
          $0.horizontalEdges.equalToSuperview().inset(16)
@@ -151,7 +152,7 @@ private extension AddScheduleSecondViewController {
          guard let onLoading, let onFailNetwork = self?.viewModel.onFailNetwork.value else { return }
          
          if !onFailNetwork {
-             onLoading ? self?.showLoadingView() : self?.hideLoadingView()
+            onLoading ? self?.showLoadingView() : self?.hideLoadingView()
             self?.addScheduleSecondView.isHidden = onLoading
             self?.tabBarController?.tabBar.isHidden = onLoading
          }
@@ -211,7 +212,6 @@ private extension AddScheduleSecondViewController {
       self.viewModel.isValidOfSecondNextBtn.bind { [weak self] date in
          self?.addScheduleSecondView.changeNextBtnState(flag: date ?? false)
       }
-      
    }
    
    func setAddTarget() {
@@ -302,6 +302,7 @@ private extension AddScheduleSecondViewController {
          collectionView.reloadData()
       }
    }
+   
 }
 
 extension AddScheduleSecondViewController {

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/AddSchedule/Views/AddScheduleSecond/AddScheduleSecondViewController.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/AddSchedule/Views/AddScheduleSecond/AddScheduleSecondViewController.swift
@@ -190,8 +190,8 @@ private extension AddScheduleSecondViewController {
       }
       
       viewModel.timeRequire.bind { [weak self] date in
-         guard let text = date else {return}
-         self?.addScheduleSecondView.inAddScheduleSecondView.updatetimeRequire(text: text)
+         guard let date else {return}
+         self?.addScheduleSecondView.inAddScheduleSecondView.updatetimeRequire(text: date)
          self?.viewModel.dateDetailTime = true
          if let flag = self?.viewModel.isAbleAddBtn() {
             self?.addScheduleSecondView.inAddScheduleSecondView.changeAddPlaceButtonState(flag: flag)

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/AddSchedule/Views/AddScheduleSecond/AddScheduleSecondViewController.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/AddSchedule/Views/AddScheduleSecond/AddScheduleSecondViewController.swift
@@ -109,7 +109,7 @@ private extension AddScheduleSecondViewController {
    }
    
    func pastDateBindViewModel() {
-      if viewModel.isImporting  {
+      if viewModel.isBroughtData  {
          for i in viewModel.pastDatePlaces {
             viewModel.tapAddBtn(datePlace: i.title, timeRequire: String(i.duration))
          }

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/AddSchedule/Views/AddScheduleSecond/AddScheduleSecondViewController.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/AddSchedule/Views/AddScheduleSecond/AddScheduleSecondViewController.swift
@@ -175,6 +175,7 @@ private extension AddScheduleSecondViewController {
       viewModel.datePlace.bind { [weak self] date in
          guard let text = date else {return}
          self?.addScheduleSecondView.inAddScheduleSecondView.updateDatePlace(text: text)
+         self?.viewModel.dateDetailLocation = true
          if let flag = self?.viewModel.isAbleAddBtn() {
             self?.addScheduleSecondView.inAddScheduleSecondView.changeAddPlaceButtonState(flag: flag)
          }
@@ -183,13 +184,17 @@ private extension AddScheduleSecondViewController {
       viewModel.timeRequire.bind { [weak self] date in
          guard let text = date else {return}
          self?.addScheduleSecondView.inAddScheduleSecondView.updatetimeRequire(text: text)
+         self?.viewModel.dateDetailTime = true
          if let flag = self?.viewModel.isAbleAddBtn() {
             self?.addScheduleSecondView.inAddScheduleSecondView.changeAddPlaceButtonState(flag: flag)
          }
       }
       
       self.viewModel.isChange = { [weak self] in
-         print(self?.viewModel.addPlaceCollectionViewDataSource ?? "")
+         guard let cnt = self?.viewModel.addPlaceCollectionViewDataSource.count else {return}
+         print(cnt)
+         
+         self?.viewModel.dateCourseNum = cnt
          self?.viewModel.isDataSourceNotEmpty()
          
          let state = self?.viewModel.editBtnEnableState.value ?? false
@@ -297,6 +302,16 @@ private extension AddScheduleSecondViewController {
          collectionView.reloadData()
       }
    }
+}
+
+extension AddScheduleSecondViewController {
+   
+   @objc
+   override func backButtonTapped() {
+      viewModel.schedule2BackAmplitude()
+      super.backButtonTapped()
+   }
+   
 }
 
 

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/AddSchedule/Views/AddScheduleSecond/AddScheduleSecondViewController.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/AddSchedule/Views/AddScheduleSecond/AddScheduleSecondViewController.swift
@@ -195,7 +195,6 @@ private extension AddScheduleSecondViewController {
          guard let cnt = self?.viewModel.addPlaceCollectionViewDataSource.count else {return}
          print(cnt)
          
-         self?.viewModel.dateCourseNum = cnt
          self?.viewModel.isDataSourceNotEmpty()
          
          let state = self?.viewModel.editBtnEnableState.value ?? false

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/AddSchedule/Views/AddScheduleSecond/InAddScheduleSecondView.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/AddSchedule/Views/AddScheduleSecond/InAddScheduleSecondView.swift
@@ -162,7 +162,7 @@ final class InAddScheduleSecondView: BaseView {
 }
 
 
-// MARK: - View Methods
+// MARK: - Extension Methods
 
 extension InAddScheduleSecondView {
    

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/AddSchedule/Views/AddScheduleSecond/InAddScheduleSecondView.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/AddSchedule/Views/AddScheduleSecond/InAddScheduleSecondView.swift
@@ -13,7 +13,7 @@ import Then
 final class InAddScheduleSecondView: BaseView {
    
    // MARK: - UI Properties
-      
+   
    private let contentTitleLabel: UILabel = UILabel()
    
    private let contentSubTitleLabel: UILabel = UILabel()
@@ -27,7 +27,7 @@ final class InAddScheduleSecondView: BaseView {
    let addPlaceButton: UIButton = UIButton()
    
    let separatorLine: UIView = UIView()
-      
+   
    
    // MARK: - Properties
    

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/Course/Views/CourseViewController.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/Course/Views/CourseViewController.swift
@@ -235,7 +235,7 @@ extension CourseViewController: LocationFilterDelegate {
 extension CourseViewController: CourseNavigationBarViewDelegate {
     
     func didTapAddCourseButton() {
-        let addCourseFirstVC = AddCourseFirstViewController(viewModel: AddCourseViewModel())
+       let addCourseFirstVC = AddCourseFirstViewController(viewModel: AddCourseViewModel(), viewPath: StringLiterals.Amplitude.ViewPath.exploreCourse)
         self.navigationController?.pushViewController(addCourseFirstVC, animated: false)
     }
     

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/CourseDetail/Views/CourseDetailViewController.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/CourseDetail/Views/CourseDetailViewController.swift
@@ -391,7 +391,7 @@ private extension CourseDetailViewController {
         addScheduleViewModel.viewedDateCourseByMeData = courseDetailViewModel
         addScheduleViewModel.isImporting = true
         
-       let vc = AddScheduleFirstViewController(viewModel: addScheduleViewModel, viewPath: StringLiterals.Amplitude.ViewPath.courseDetail)
+        let vc = AddScheduleFirstViewController(viewModel: addScheduleViewModel)
        // 데이터를 바인딩합니다.
        vc.pastDateBindViewModel()
         self.navigationController?.pushViewController(vc, animated: false)

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/CourseDetail/Views/CourseDetailViewController.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/CourseDetail/Views/CourseDetailViewController.swift
@@ -332,9 +332,9 @@ extension CourseDetailViewController: ContentMaskViewDelegate {
     }
     
     
-    //코스 등록하기로 화면 전환
+    //포인트 부족 -> 코스 등록하기로 화면 전환
     func didTapAddCourseButton() {
-        let addCourseVC = AddCourseFirstViewController(viewModel: AddCourseViewModel())
+       let addCourseVC = AddCourseFirstViewController(viewModel: AddCourseViewModel(), viewPath: StringLiterals.Amplitude.ViewPath.exploreCourse)
         self.navigationController?.pushViewController(addCourseVC, animated: false)
     }
     

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/CourseDetail/Views/CourseDetailViewController.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/CourseDetail/Views/CourseDetailViewController.swift
@@ -391,7 +391,7 @@ private extension CourseDetailViewController {
         addScheduleViewModel.viewedDateCourseByMeData = courseDetailViewModel
         addScheduleViewModel.isImporting = true
         
-        let vc = AddScheduleFirstViewController(viewModel: addScheduleViewModel)
+       let vc = AddScheduleFirstViewController(viewModel: addScheduleViewModel, viewPath: StringLiterals.Amplitude.ViewPath.courseDetail)
        // 데이터를 바인딩합니다.
        vc.pastDateBindViewModel()
         self.navigationController?.pushViewController(vc, animated: false)

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/CourseDetail/Views/CourseDetailViewController.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/CourseDetail/Views/CourseDetailViewController.swift
@@ -389,7 +389,7 @@ private extension CourseDetailViewController {
         let addScheduleViewModel = AddScheduleViewModel()
         
         addScheduleViewModel.viewedDateCourseByMeData = courseDetailViewModel
-        addScheduleViewModel.isImporting = true
+        addScheduleViewModel.isBroughtData = true
         
        let vc = AddScheduleFirstViewController(viewModel: addScheduleViewModel, viewPath: StringLiterals.Amplitude.ViewPath.courseDetail)
        // 데이터를 바인딩합니다.

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/DateSchedule/View/PastDateDetailViewController.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/DateSchedule/View/PastDateDetailViewController.swift
@@ -178,7 +178,7 @@ extension PastDateDetailViewController {
     }
     
    //TODO: - 추후 데이트코스 공유 코스 등록 기능 살아날 시 수정해야함.
-   // isImporting 변수 생성하여 AddSchedule과 동일하게 수행하도록 수정
+   // isBroughtData 변수 생성하여 AddSchedule과 동일하게 수행하도록 수정
     @objc
     private func tapShareCourse() {
         print("코스 등록해서 공유하기 여기!!!!!!!!!!!!")

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/DateSchedule/View/PastDateDetailViewController.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/DateSchedule/View/PastDateDetailViewController.swift
@@ -184,7 +184,7 @@ extension PastDateDetailViewController {
         else { return }
            
            let addCourseViewModel = AddCourseViewModel(pastDateDetailData: data)
-           let vc = AddCourseFirstViewController(viewModel: addCourseViewModel)
+       let vc = AddCourseFirstViewController(viewModel: addCourseViewModel, viewPath: StringLiterals.Amplitude.ViewPath.dateSchedule)
            self.navigationController?.pushViewController(vc, animated: false)
     }
     

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/DateSchedule/View/PastDateDetailViewController.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/DateSchedule/View/PastDateDetailViewController.swift
@@ -177,6 +177,8 @@ extension PastDateDetailViewController {
         }
     }
     
+   //TODO: - 추후 데이트코스 공유 코스 등록 기능 살아날 시 수정해야함.
+   // isImporting 변수 생성하여 AddSchedule과 동일하게 수행하도록 수정
     @objc
     private func tapShareCourse() {
         print("코스 등록해서 공유하기 여기!!!!!!!!!!!!")

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/DateSchedule/View/UpcomingDateScheduleViewController.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/DateSchedule/View/UpcomingDateScheduleViewController.swift
@@ -166,7 +166,7 @@ extension UpcomingDateScheduleViewController: DRCustomAlertDelegate {
             self.present(customAlertVC, animated: false)
         } else {
             print("push to 일정등록하기")
-           let vc = AddScheduleFirstViewController(viewModel: AddScheduleViewModel())
+           let vc = AddScheduleFirstViewController(viewModel: AddScheduleViewModel(), viewPath: StringLiterals.Amplitude.ViewPath.dateSchedule)
            self.navigationController?.pushViewController(vc, animated: false)
         }
         

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/Main/Views/MainViewController.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/Main/Views/MainViewController.swift
@@ -184,7 +184,7 @@ extension MainViewController {
     
     @objc
     func pushToAddCourseVC() {
-        let addCourseVC = AddCourseFirstViewController(viewModel: AddCourseViewModel())
+       let addCourseVC = AddCourseFirstViewController(viewModel: AddCourseViewModel(), viewPath: StringLiterals.Amplitude.ViewPath.home)
         self.navigationController?.pushViewController(addCourseVC, animated: false)
     }
     

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/MyCourse/Views/NavViewedCourseViewController.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/MyCourse/Views/NavViewedCourseViewController.swift
@@ -175,7 +175,7 @@ extension NavViewedCourseViewController : UICollectionViewDataSource {
           addScheduleViewModel.viewedDateCourseByMeData = courseDetailViewModel
           addScheduleViewModel.isImporting = true
           
-          let vc = AddScheduleFirstViewController(viewModel: addScheduleViewModel, viewPath: StringLiterals.Amplitude.ViewPath.viewedCourse)
+          let vc = AddScheduleFirstViewController(viewModel: addScheduleViewModel)
           // 데이터를 바인딩합니다.
           vc.pastDateBindViewModel()
           self.navigationController?.pushViewController(vc, animated: false)

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/MyCourse/Views/NavViewedCourseViewController.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/MyCourse/Views/NavViewedCourseViewController.swift
@@ -175,7 +175,7 @@ extension NavViewedCourseViewController : UICollectionViewDataSource {
           addScheduleViewModel.viewedDateCourseByMeData = courseDetailViewModel
           addScheduleViewModel.isImporting = true
           
-          let vc = AddScheduleFirstViewController(viewModel: addScheduleViewModel)
+          let vc = AddScheduleFirstViewController(viewModel: addScheduleViewModel, viewPath: StringLiterals.Amplitude.ViewPath.viewedCourse)
           // 데이터를 바인딩합니다.
           vc.pastDateBindViewModel()
           self.navigationController?.pushViewController(vc, animated: false)

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/MyCourse/Views/NavViewedCourseViewController.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/MyCourse/Views/NavViewedCourseViewController.swift
@@ -173,7 +173,7 @@ extension NavViewedCourseViewController : UICollectionViewDataSource {
           let courseDetailViewModel = CourseDetailViewModel(courseId: courseId)
           let addScheduleViewModel = AddScheduleViewModel()
           addScheduleViewModel.viewedDateCourseByMeData = courseDetailViewModel
-          addScheduleViewModel.isImporting = true
+          addScheduleViewModel.isBroughtData = true
           
           let vc = AddScheduleFirstViewController(viewModel: addScheduleViewModel, viewPath: StringLiterals.Amplitude.ViewPath.viewedCourse)
           // 데이터를 바인딩합니다.

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/MyPage/ViewModels/MyPageViewModel.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/MyPage/ViewModels/MyPageViewModel.swift
@@ -119,7 +119,6 @@ extension MyPageViewModel {
                 self.onSuccessGetUserProfile.value = false
                 return
             }
-            self.setLoading()
         }
     }
     

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/MyPage/Views/MyPageViewController.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/MyPage/Views/MyPageViewController.swift
@@ -125,12 +125,20 @@ private extension MyPageViewController {
               self?.navigationController?.pushViewController(errorVC, animated: false)
            }
         }
+       
+       self.myPageViewModel.onSuccessGetUserProfile.bind { [weak self] onSuccess in
+          guard let onSuccess, let data = self?.myPageViewModel.userInfoData.value else { return }
+          if onSuccess {
+             DispatchQueue.main.async {
+                self?.myPageView.userInfoView.bindData(userInfo: data)
+                self?.myPageView.userInfoView.tagCollectionView.reloadData()
+             }
+          }
+          self?.myPageViewModel.setLoading()
+       }
         
         self.myPageViewModel.onLoading.bind { [weak self] onLoading in
-            guard let onLoading,
-                  let data = self?.myPageViewModel.userInfoData.value,
-                  let onFailNetwork = self?.myPageViewModel.onFailNetwork.value
-            else { return }
+            guard let onLoading, let onFailNetwork = self?.myPageViewModel.onFailNetwork.value else { return }
             if !onFailNetwork {
                 if onLoading {
                     self?.showLoadingView()
@@ -139,19 +147,13 @@ private extension MyPageViewController {
                     self?.navigationBarView.isHidden = onLoading
                     self?.tabBarController?.tabBar.isHidden = onLoading
                 } else {
-                    self?.myPageView.userInfoView.onLoading = {
-                        DispatchQueue.main.asyncAfter(deadline: .now() + 0.2) {
-                            self?.myPageView.isHidden = onLoading
-                            self?.topInsetView.isHidden = onLoading
-                            self?.navigationBarView.isHidden = onLoading
-                            self?.tabBarController?.tabBar.isHidden = onLoading
-                            self?.hideLoadingView()
-                        }
-                    }
-                    
-                    // `onDismiss` 설정 이후 `bindData` 호출
-                    self?.myPageView.userInfoView.bindData(userInfo: data)
-                    self?.myPageView.userInfoView.tagCollectionView.reloadData()
+                   DispatchQueue.main.asyncAfter(deadline: .now() + 0.2) {
+                      self?.myPageView.isHidden = onLoading
+                      self?.topInsetView.isHidden = onLoading
+                      self?.navigationBarView.isHidden = onLoading
+                      self?.tabBarController?.tabBar.isHidden = onLoading
+                      self?.hideLoadingView()
+                   }
                 }
             }
         }

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/MyPage/Views/UserInfoView.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/MyPage/Views/UserInfoView.swift
@@ -34,11 +34,6 @@ final class UserInfoView: BaseView {
     private let rightArrowButton: UIImageView = UIImageView()
     
     
-    // MARK: - UI Properties
-    
-    var onLoading: (() -> (Void))?
-    
-    
     // MARK: - Life Cycle
     
     override func setHierarchy() {
@@ -183,13 +178,6 @@ extension UserInfoView {
             return
         }
         let url = URL(string: imageURL)
-        self.profileImageView.kf.setImage(with: url) { result in
-            switch result {
-            case .success:
-                self.onLoading?()
-            case .failure(let error):
-                print(error)
-            }
-        }
+        self.profileImageView.kf.setImage(with: url)
     }
 }


### PR DESCRIPTION
# 🔥*Pull requests*

## ⛳ **작업한 브랜치**
- feature/#215

## 👷 **작업한 내용**
<!-- 작업한 내용을 적어주세요. -->
- `x` 의 경우 택소노미 상 `Event Property` 값이 존재하지 않는 경우 입니다.
### 일정 등록하기 1
- 일정 등록하기 1 진입 시
  - [x] 일정 등록하기 1 유입 경로
- 뒤로가기 버튼 클릭 시
  - [x] 데이트 이름 입력 여부
  - [x] 데이트 예정 일자 입력 여부
  - [x] 데이트 시작 시작 입력 여부
  - [x] 데이트 태그 등록 갯수
  - [x] 데이트 지역 등록 여부

### 일정 등록하기 2
- 일정 등록하기 2 진입 시
  - [x] x
- 뒤로가기 버튼 클릭 시
  - [x] 데이트 장소명 입력 여부
  - [x] 데이트 소요시간 입력 여부
  - [x] 데이트 코스 등록 갯수

### 일정 등록하기 1 (열람한 코스 불러오기)
- 일정 등록하기 1 진입 시
  - [x] 일정 등록하기 1 유입 경로
- 코스 불러오기 클릭 시
  - [x] x

### 열람한 코스 _ 불러온 일정 등록 1
- 일정 등록하기 1 정보 불러왔을 시
  - [x] 열람한 코스 불러온 유입 경로
- 뒤로가기 버튼 클릭 시
  - [x] 데이트 이름 입력 여부
  - [x] 데이트 예정 일자 입력 여부
  - [x] 데이트 시작 시작 입력 여부
  - [x] 데이트 태그 등록 갯수
  - [x] 데이트 지역 등록 여부

### 열람한 코스 _ 불러온 일정 등록 2
- 일정 등록하기 2 정보 불러왔을 시
  - [x] x
- 뒤로가기 버튼 클릭 시
  - [x] 데이트 장소명 입력 여부
  - [x] 데이트 소요시간 입력 여부
  - [x] 데이트 코스 등록 갯수

### 코스 등록하기 1
- 코스 등록하기1 진입 시
  - [x] 코스 등록하기1 유입 경로
- 뒤로가기 버튼 누를 시
  - [x] 이미지 등록 여부
  - [x] 데이트 제목 입력 여부
  - [x] 데이트 날짜 입력 여부
  - [x] 데이트 시작 시작 입력 여부
  - [x] 데이트 태그 선택 여부
  - [x] 데이트 코스 지역 선택 여부

### 코스 등록하기 2
- 뒤로가기 버튼 누를 시
  - [x] 데이트 장소명 입력 여부
  - [x] 데이트 소요 시간 입력 여부
  - [x] 데이트 장소 개수

### 코스 등록하기 3
- 뒤로가기 버튼 누를 시
  - [x] content 작성 여부
  - [x] content 글자 수
  - [x] 비용 입력 여부

### 📌 공유
- 옵저버 프로퍼티 유의
  ```swift
  /// 데이트 이름 유효성 판별 (true는 통과)
  let dateName: ObservablePattern<String> = ObservablePattern(””)
  let isDateNameVaild: ObservablePattern<Bool> = ObservablePattern(nil)
  private let minimumDateNameLength = 5
  
  /// 방문 일자 유효성 판별 (true는 통과)
  let visitDate: ObservablePattern<String> = ObservablePattern(””)
  let isVisitDateVaild: ObservablePattern<Bool> = ObservablePattern(nil)
  
  /// 데이트 시작시간 유효성 판별 (self.count > 0 인지)
  let dateStartAt: ObservablePattern<String> = ObservablePattern(””)
  let isDateStartAtVaild: ObservablePattern<Bool> = ObservablePattern(nil)
  ``` 
  - 위에 `dateName`, `visitDate`, `dateStartAt` 등 값들에 `“”` 를 부여하여 초반 bindViewModel 함수에서 해당 옵저버바인딩이 실행되어 난항을 겪어, 해당 값들을 전부 `nil`로 수정함으로써 해결하였습니다.


## 🚨 참고 사항
<!-- 참고할 사항이 있다면 적어주세요. -->
- `StringLiterals` enum ViewPath 추가
  ```swift
  enum ViewPath {
      static let home = "홈"
      static let exploreCourse = "코스 둘러보기"
      static let dateSchedule = "데이트 일정"
      static let viewedCourse = "내가 열람한 코스"
      static let courseDetail = "코스 상세"
   } 
  ```
  - 현재 택소노미에 적힌 viewPath 값들 중 StringLiterals에 없는 값들도 있어 위와 같이 ViewPath enum Case를 추가하여 사용하였습니다. 혹 더 나은 방법이 있다면 말씀해주세요!

- `일정등록`만 `resetAddFirstScheduleAmplitude()`과 같이 초기화 실행하는 이유
  - 이는 `불러오기` 버튼으로 일정을 불러온 이후 `뒤로가기`를 누르면 `NavViewedCourseVC`로 이동되고, 이 때 한번 더 뒤로간다면 다시 ‘불러오기’ 버튼이 활성화된 `일정등록 뷰`가 보여야 합니다.
  - 따라서 `불러오기` 버튼이 다시 활성화된 `일정등록 뷰` 에 초깃값을 적용하기 위하여 초기화를 실행하였습니다.
  - `코스등록`의 경우 추후 `지난 데이트 코스 공유` 기능이 추가되더라도 이는 기존 '코스 등록하기 1' 화면에서 진행되지 않기에 초기화 메서드를 추가하지 않았습니다.

## 📟 관련 이슈
- Resolved: #215 
