### PR TITLE
[HOTFIX] 1.0.0 버전 수정사항 적용 (#243)

### DIFF
--- a/DATEROAD-iOS/DATEROAD-iOS/Global/Literals/StringLiterals.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Global/Literals/StringLiterals.swift
@@ -231,6 +231,7 @@ enum StringLiterals {
       static let failToDeleteLike = "좋아요 해제 실패"
        static let failToDeleteSchedule = "데이트 일정 삭제 실패"
       static let delete = "삭제"
+      static let notFound = "대상을 찾을 수 없습니다."
    }
    
    enum Course {

--- a/DATEROAD-iOS/DATEROAD-iOS/Global/Literals/StringLiterals.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Global/Literals/StringLiterals.swift
@@ -229,6 +229,7 @@ enum StringLiterals {
       static let failToDeleteCourse = "코스 삭제 실패"
       static let failToAddLike = "좋아요 등록 실패"
       static let failToDeleteLike = "좋아요 해제 실패"
+       static let failToDeleteSchedule = "데이트 일정 삭제 실패"
       static let delete = "삭제"
    }
    

--- a/DATEROAD-iOS/DATEROAD-iOS/Network/Base/NetworkResult.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Network/Base/NetworkResult.swift
@@ -15,4 +15,5 @@ enum NetworkResult<T> {
     case serverErr                // 서버의 내부적 에러가 발생했을 때,
     case networkFail              // 네트워크 연결 실패했을 때
     case reIssueJWT             // 토큰 재발급 필요할 때
+    case notFoundErr           // 유저, 코스, 일정 정보가 없을 때
 }

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/Course/Views/Cells/CourseListCollectionViewCell.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/Course/Views/Cells/CourseListCollectionViewCell.swift
@@ -54,7 +54,19 @@ class CourseListCollectionViewCell: BaseCollectionViewCell {
     required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
-    
+
+    override func prepareForReuse() {
+        super.prepareForReuse()
+        // 셀이 재사용될 때 이미지나 데이터를 초기화합니다.
+        thumnailImgageView.image = nil
+        likeBoxView.removeFromSuperview()
+        likeButton.image = nil
+        likeNumLabel.text = nil
+        locationLabel.text = nil
+        titleLabel.text = nil
+        coastLabel.text = nil
+        timeLabel.text = nil
+    }
 
     @objc private func handleTapGesture(_ sender: UITapGestureRecognizer) {
         print("눌림?")

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/Course/Views/Cells/CourseListCollectionViewCell.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/Course/Views/Cells/CourseListCollectionViewCell.swift
@@ -15,7 +15,7 @@ protocol CourseListCollectionViewCellDelegate: AnyObject {
     func didTapCourseListCell()
 }
 
-class CourseListCollectionViewCell: BaseCollectionViewCell {
+final class CourseListCollectionViewCell: BaseCollectionViewCell {
     
     // MARK: - UI Properties
     
@@ -45,7 +45,7 @@ class CourseListCollectionViewCell: BaseCollectionViewCell {
     
     override init(frame: CGRect) {
         super.init(frame: frame)
- 
+        
         // 탭 제스처 추가
         let tapGesture = UITapGestureRecognizer(target: self, action: #selector(handleTapGesture(_:)))
         addGestureRecognizer(tapGesture)
@@ -54,27 +54,19 @@ class CourseListCollectionViewCell: BaseCollectionViewCell {
     required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
-
+    
     override func prepareForReuse() {
         super.prepareForReuse()
         // 셀이 재사용될 때 이미지나 데이터를 초기화합니다.
         thumnailImgageView.image = nil
-        likeBoxView.removeFromSuperview()
-        likeButton.image = nil
         likeNumLabel.text = nil
         locationLabel.text = nil
         titleLabel.text = nil
         coastLabel.text = nil
         timeLabel.text = nil
     }
-
-    @objc private func handleTapGesture(_ sender: UITapGestureRecognizer) {
-        print("눌림?")
-        delegate?.didTapCourseListCell()
-    }
     
     override func setHierarchy() {
-        
         self.addSubviews(
             thumnailImgageView,
             likeBoxView,
@@ -187,26 +179,31 @@ class CourseListCollectionViewCell: BaseCollectionViewCell {
 extension CourseListCollectionViewCell {
     
     func configure(with course: CourseListModel) {
-            thumnailImgageView.kfSetImage(with: course.thumbnail, placeholder: UIImage(named: "placeholder_image"))
-            
-            if let likeCount = course.like {
-                likeNumLabel.text = "\(likeCount)"
-            } else {
-                likeNumLabel.text = nil
-            }
-            
-            locationLabel.text = course.location
-            titleLabel.text = course.title
-            if let coast = course.cost {
-                coastLabel.text = "\(coast.priceRangeTag())"
-            } else {
-                coastLabel.text = nil
-            }
-            
-            if let time = course.time {
-                timeLabel.text = "\(time.formatFloatTime())시간"
-            } else {
-                timeLabel.text = nil
-            }
+        thumnailImgageView.kfSetImage(with: course.thumbnail, placeholder: UIImage(named: "placeholder_image"))
+        
+        if let likeCount = course.like {
+            likeNumLabel.text = "\(likeCount)"
+        } else {
+            likeNumLabel.text = nil
         }
+        
+        locationLabel.text = course.location
+        titleLabel.text = course.title
+        if let coast = course.cost {
+            coastLabel.text = "\(coast.priceRangeTag())"
+        } else {
+            coastLabel.text = nil
+        }
+        
+        if let time = course.time {
+            timeLabel.text = "\(time.formatFloatTime())시간"
+        } else {
+            timeLabel.text = nil
+        }
+    }
+    
+    @objc
+    private func handleTapGesture(_ sender: UITapGestureRecognizer) {
+        delegate?.didTapCourseListCell()
+    }
 }

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/CourseDetail/ViewModels/CourseDetailViewModel.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/CourseDetail/ViewModels/CourseDetailViewModel.swift
@@ -78,6 +78,8 @@ final class CourseDetailViewModel: Serviceable {
     
     var purchaseSuccess: Bool = false
     
+    var errMessage: ObservablePattern<String> = ObservablePattern(nil)
+    
     init(courseId: Int) {
         self.courseId = courseId
         getCourseDetail()
@@ -168,6 +170,8 @@ extension CourseDetailViewModel {
                 self.patchReissue { isSuccess in
                     self.onReissueSuccess.value = isSuccess
                 }
+            case .notFoundErr:
+                self.errMessage.value = StringLiterals.Alert.notFound
             default:
                 self.onFailNetwork.value = true
                 print("Failed to fetch course data")

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/CourseDetail/Views/CourseDetailViewController.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/CourseDetail/Views/CourseDetailViewController.swift
@@ -195,6 +195,10 @@ final class CourseDetailViewController: BaseViewController {
             self.updateLikeButtonColor(isLiked: isUserLiked ?? false)
         }
         
+        courseDetailViewModel.errMessage.bind { [weak self] message in
+            guard let message else { return }
+            self?.presentAlertVC(title: message)
+        }
     }
     
     func setAddTarget() {

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/DateSchedule/View/PastDateDetailViewController.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/DateSchedule/View/PastDateDetailViewController.swift
@@ -173,6 +173,8 @@ extension PastDateDetailViewController {
             guard let isSuccess else { return }
             if isSuccess {
                 self?.navigationController?.popViewController(animated: false)
+            } else {
+                self?.presentAlertVC(title: StringLiterals.Alert.failToDeleteSchedule)
             }
         }
         

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/DateSchedule/View/UpcomingDateDetailViewController.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/DateSchedule/View/UpcomingDateDetailViewController.swift
@@ -148,6 +148,8 @@ extension UpcomingDateDetailViewController {
             guard let isSuccess else { return }
             if isSuccess {
                 self?.navigationController?.popViewController(animated: false)
+            } else {
+                self?.presentAlertVC(title: StringLiterals.Alert.failToDeleteSchedule)
             }
         }
     }

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/DateSchedule/ViewModel/DateDetailViewModel.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/DateSchedule/ViewModel/DateDetailViewModel.swift
@@ -80,8 +80,6 @@ extension DateDetailViewModel {
                 self.isSuccessGetDateDetailData.value = true
                 self.dateCourseNum = self.dateDetailData.value?.places.count ?? 0
                 self.dateTotalDuration = datePlaceInfo.map { Float($0.duration) ?? 0 }.reduce(0, +)
-            case .serverErr:
-                self.onFailNetwork.value = true
             case .reIssueJWT:
                 self.patchReissue { isSuccess in
                     self.type.value = NetworkType.getDateDetail
@@ -100,6 +98,7 @@ extension DateDetailViewModel {
     
     func deleteDateSchdeuleData(dateID: Int) {
         self.onFailNetwork.value = false
+        self.setDateDetailLoading()
         
         NetworkService.shared.dateScheduleService.deleteDateSchedule(dateID: dateID) { response in
             switch response {

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/DateSchedule/ViewModel/DateScheduleViewModel.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/DateSchedule/ViewModel/DateScheduleViewModel.swift
@@ -95,14 +95,12 @@ final class DateScheduleViewModel: Serviceable {
                 AmplitudeManager.shared.trackEventWithProperties(StringLiterals.Amplitude.EventName.countDateSchedule, properties: [StringLiterals.Amplitude.Property.dateScheduleNum : dateScheduleNum])
                 self.upcomingDateScheduleData.value = dateScheduleInfo
                 self.isSuccessGetUpcomingDateScheduleData.value = true
-            case .serverErr:
-                self.onUpcomingScheduleFailNetwork.value = true
             case .reIssueJWT:
                 self.patchReissue { isSuccess in
                     self.onReissueSuccess.value = isSuccess
                 }
             default:
-                self.isSuccessGetUpcomingDateScheduleData.value = false
+                self.onUpcomingScheduleFailNetwork.value = true
             }
             self.setUpcomingScheduleLoading()
         }

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/Main/ViewModels/MainViewModel.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/Main/ViewModels/MainViewModel.swift
@@ -150,6 +150,7 @@ extension MainViewModel {
                                                             startAt: data.startAt)
                 self.totalFetchCount += 1
             case .requestErr:
+                self.upcomingData.value = nil
                 self.totalFetchCount += 1
             case .reIssueJWT:
                 self.patchReissue { isSuccess in

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/Main/Views/Cells/UpcomingDateCell.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/Main/Views/Cells/UpcomingDateCell.swift
@@ -118,8 +118,11 @@ extension UpcomingDateCell {
             return
         }
         let url = URL(string: imageUrl)
-        profileImage.kf.setImage(with: url)
-        profileImage.layer.cornerRadius = profileImage.frame.size.width / 2
-        profileImage.backgroundColor = .clear
+        profileImage.do {
+            $0.clipsToBounds = true
+            $0.layer.cornerRadius = $0.frame.size.width / 2
+            $0.backgroundColor = .clear
+            $0.kf.setImage(with: url)
+        }
     }
 }

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/Main/Views/MainViewController.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/Main/Views/MainViewController.swift
@@ -177,7 +177,6 @@ extension MainViewController {
         let targetIndexPath = IndexPath(item: currentIndex + 1, section: 2)
         if currentIndex >= 0 && currentIndex <= 5 {
             self.mainView.mainCollectionView.scrollToItem(at: targetIndexPath, at: .centeredHorizontally, animated: true)
-            self.mainViewModel.currentIndex.value?.row = currentIndex + 1
         }
     }
     

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/Main/Views/MainViewController.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/Main/Views/MainViewController.swift
@@ -206,9 +206,7 @@ extension MainViewController {
     
     @objc
     func pushToPointDetailVC() {
-        guard let userName = self.userName, 
-                let totalPoint = self.point
-        else { return }
+        guard let userName = self.userName, let totalPoint = self.point else { return }
         let pointDetailVC = PointDetailViewController(pointViewModel: PointViewModel(userName: userName, totalPoint: totalPoint))
         self.navigationController?.pushViewController(pointDetailVC, animated: false)
     }

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/Main/Views/MainViewController.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/Main/Views/MainViewController.swift
@@ -257,7 +257,9 @@ extension MainViewController: UICollectionViewDataSource {
         case .upcomingDate:
             guard let cell = collectionView.dequeueReusableCell(withReuseIdentifier: UpcomingDateCell.cellIdentifier, for: indexPath) as? UpcomingDateCell 
             else { return UICollectionViewCell() }
-            cell.bindData(upcomingData: mainViewModel.upcomingData.value, mainUserData: mainViewModel.mainUserData.value)
+            DispatchQueue.main.async {
+                cell.bindData(upcomingData: self.mainViewModel.upcomingData.value, mainUserData: self.mainViewModel.mainUserData.value)
+            }
             // Set button actions
             let pointLabelTapGesture = UITapGestureRecognizer(target: self, action: #selector(pushToPointDetailVC))
             cell.pointLabel.addGestureRecognizer(pointLabelTapGesture)

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/MyPage/Views/MyPageViewController.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/MyPage/Views/MyPageViewController.swift
@@ -388,6 +388,7 @@ extension MyPageViewController: ASAuthorizationControllerDelegate {
         guard let credential = authorization.credential as? ASAuthorizationAppleIDCredential
         else { return }
         
+        self.myPageViewModel.onAuthLoading.value = true
         self.loginViewModel.loginWithApple(userInfo: credential)
     }
     

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/PointDetail/ViewModels/PointViewModel.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/PointDetail/ViewModels/PointViewModel.swift
@@ -42,7 +42,6 @@ final class PointViewModel: Serviceable {
     }
     
     func updateData(nowEarnedPointHidden: Bool) {
-//        nowPointData.value = gainedPointData.value
         if nowEarnedPointHidden {
             nowPointData.value = usedPointData.value
         } else {
@@ -72,8 +71,6 @@ final class PointViewModel: Serviceable {
                 self.patchReissue { isSuccess in
                     self.onReissueSuccess.value = isSuccess
                 }
-            case .serverErr:
-                self.onFailNetwork.value = true
              default:
                 self.onFailNetwork.value = true //TODO: - 확인
                 return

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/Profile/ViewModels/ProfileViewModel.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/Profile/ViewModels/ProfileViewModel.swift
@@ -117,14 +117,14 @@ extension ProfileViewModel {
         self.isValidRegistration.value = (isValidNickname && isValidTag && is5CntVaild)
     }
     
-    func postSignUp(image: UIImage?) {
+    func postSignUp() {
         self.onLoading.value = true
         let socialType = UserDefaults.standard.bool(forKey: StringLiterals.Network.socialType)
         
         guard let name = self.nickname.value else { return }
-
+        self.checkDefaultImage()
         let requestBody = PostSignUpRequest(userSignUpReq: UserSignUpReq(name: name, platform: socialType ? SocialType.KAKAO.rawValue : SocialType.APPLE.rawValue),
-                                            image: image,
+                                            image: self.profileImage.value,
                                             tag: self.selectedTagData)
         
         NetworkService.shared.authService.postSignUp(requestBody: requestBody) { response in
@@ -209,7 +209,10 @@ extension ProfileViewModel {
     func checkDefaultImage() {
         if self.profileImage.value == UIImage(resource: .emptyProfileImg) {
             self.profileImage.value = nil
+            self.isDefaultImage = true
+        } else {
             self.isDefaultImage = false
         }
     }
 }
+

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/Profile/Views/EditProfileViewController.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/Profile/Views/EditProfileViewController.swift
@@ -179,7 +179,7 @@ private extension EditProfileViewController {
         }
         
         self.profileViewModel.isValidNicknameCount.bind { [weak self] isValidCount in
-            guard let isValidCount, 
+            guard let isValidCount,
                     let initial = self?.initial,
                   let isValidNickname = self?.profileViewModel.isValidNickname.value
             else { return }
@@ -274,7 +274,7 @@ private extension EditProfileViewController {
         // 3이 아닐 때
         if self.profileViewModel.selectedTagData.count != maxTags {
             sender.isSelected.toggle()
-            sender.isSelected 
+            sender.isSelected
             ? self.profileView.updateTag(button: sender, buttonType: SelectedButton())
             : self.profileView.updateTag(button: sender, buttonType: UnselectedButton())
             self.profileViewModel.countSelectedTag(isSelected: sender.isSelected, tag: tag)
@@ -300,8 +300,7 @@ private extension EditProfileViewController {
     func deletePhoto() {
         self.dismiss(animated: true)
         profileView.updateProfileImage(image: UIImage(resource: .emptyProfileImg))
-        profileViewModel.profileImage.value = nil
-        profileViewModel.isDefaultImage = true
+        profileViewModel.profileImage.value = UIImage(resource: .emptyProfileImg)
     }
     
     @objc
@@ -348,7 +347,7 @@ extension EditProfileViewController: UICollectionViewDataSource {
     }
     
     func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
-        guard let cell = collectionView.dequeueReusableCell(withReuseIdentifier: TendencyTagCollectionViewCell.cellIdentifier, for: indexPath) as? TendencyTagCollectionViewCell 
+        guard let cell = collectionView.dequeueReusableCell(withReuseIdentifier: TendencyTagCollectionViewCell.cellIdentifier, for: indexPath) as? TendencyTagCollectionViewCell
         else { return UICollectionViewCell() }
         cell.tendencyTagButton.tag = indexPath.item
         cell.tendencyTagButton.addTarget(self, action: #selector(didTapTagButton(_:)), for: .touchUpInside)
@@ -409,8 +408,8 @@ extension EditProfileViewController: ImagePickerDelegate {
     func didPickImages(_ images: [UIImage]) {
         let selectedImage = images[0]
         profileView.updateProfileImage(image: selectedImage)
-        self.profileViewModel.isDefaultImage = false
         self.profileViewModel.profileImage.value = selectedImage
     }
     
 }
+

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/Profile/Views/ProfileViewController.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/Profile/Views/ProfileViewController.swift
@@ -110,7 +110,8 @@ private extension ProfileViewController {
         self.profileViewModel.onReissueSuccess.bind { [weak self] onSuccess in
             guard let onSuccess else { return }
             if onSuccess {
-                self?.profileViewModel.postSignUp(image: self?.profileView.profileImageView.image)
+                self?.profileViewModel.profileImage.value = self?.profileView.profileImageView.image
+                self?.profileViewModel.postSignUp()
             } else {
                 self?.navigationController?.pushViewController(SplashViewController(splashViewModel: SplashViewModel()), animated: false)
             }
@@ -125,7 +126,7 @@ private extension ProfileViewController {
         
         // 중복 확인 결과 변수
         self.profileViewModel.isValidNickname.bind { [weak self] isValid in
-            guard let isValid, 
+            guard let isValid,
                     let initial = self?.initial,
                     let nicknameCount = self?.profileViewModel.nickname.value?.count
             else { return }
@@ -185,8 +186,8 @@ private extension ProfileViewController {
                 let mainVC = TabBarController()
                 self?.navigationController?.pushViewController(mainVC, animated: false)
             } else {
-                let loginVC = LoginViewController()
-                self?.navigationController?.pushViewController(loginVC, animated: false)
+                let errorVC = DRErrorViewController(type: StringLiterals.Common.main)
+                self?.navigationController?.pushViewController(errorVC, animated: false)
             }
         }
         
@@ -222,7 +223,7 @@ private extension ProfileViewController {
         // 3이 아닐 때
         if self.profileViewModel.selectedTagData.count != maxTags {
             sender.isSelected.toggle()
-            sender.isSelected 
+            sender.isSelected
             ? self.profileView.updateTag(button: sender, buttonType: SelectedButton())
             : self.profileView.updateTag(button: sender, buttonType: UnselectedButton())
             self.profileViewModel.countSelectedTag(isSelected: sender.isSelected, tag: tag)
@@ -248,7 +249,7 @@ private extension ProfileViewController {
     func deletePhoto() {
         self.dismiss(animated: true)
         profileView.updateProfileImage(image: UIImage(resource: .emptyProfileImg))
-        profileViewModel.profileImage.value = nil
+        profileViewModel.profileImage.value = UIImage(resource: .emptyProfileImg)
     }
     
     @objc
@@ -260,7 +261,7 @@ private extension ProfileViewController {
     @objc
     func registerProfile() {
         self.profileView.registerButton.isEnabled = false
-        self.profileViewModel.postSignUp(image: self.profileView.profileImageView.image)
+        self.profileViewModel.postSignUp()
     }
     
 }
@@ -348,3 +349,4 @@ extension ProfileViewController: ImagePickerDelegate {
     }
     
 }
+


### PR DESCRIPTION
# 🔥*Pull requests*

## ⛳ **작업한 브랜치**
- hotfix/#243

## 👷 **작업한 내용**
<!-- 작업한 내용을 적어주세요. -->
- [x] 프로필 관련 로직 수정
- [x] 탈퇴 시 로딩뷰 시점 수정
- [x] 배너 인덱스 버벅임 수정
- [x] 메인 프로필 클립 수정
- [x] 코스 둘러보기 메모리 최적화
- [x] 코스 상세 에러 핸들링

## 🚨 참고 사항
<!-- 참고할 사항이 있다면 적어주세요. -->
### 1️⃣ 코스 둘러보기 메모리 최적화
여러번 스크롤하면 메모리 과부하로 앱이 터지는 이슈가 있었습니다.
셀이 재사용되기 전에 `prepareForReuse` 메소드를 호출하여, 셀이 재사용 될 때 이전 데이터나 상태를 초기화함으로써 불필요한 메모리 사용을 방지할 수 있도록 했습니다



## 📟 관련 이슈
- Resolved: #243 
