### PR TITLE
[UPDATE] 1.0.1 버전 업데이트 (#250)

### DIFF
--- a/DATEROAD-iOS/DATEROAD-iOS.xcodeproj/project.pbxproj
+++ b/DATEROAD-iOS/DATEROAD-iOS.xcodeproj/project.pbxproj
@@ -1831,10 +1831,10 @@
 			};
 			buildConfigurationList = CA3D0CD22C29A2F300735097 /* Build configuration list for PBXProject "DATEROAD-iOS" */;
 			compatibilityVersion = "Xcode 14.0";
-			developmentRegion = en;
+			developmentRegion = ko;
 			hasScannedForEncodings = 0;
 			knownRegions = (
-				en,
+				ko,
 				Base,
 			);
 			mainGroup = CA3D0CCE2C29A2F300735097;

--- a/DATEROAD-iOS/DATEROAD-iOS.xcodeproj/project.pbxproj
+++ b/DATEROAD-iOS/DATEROAD-iOS.xcodeproj/project.pbxproj
@@ -236,6 +236,7 @@
 		CABDCEB92C4A6C8800631FB3 /* AdTagType.swift in Sources */ = {isa = PBXBuildFile; fileRef = CABDCEB82C4A6C8800631FB3 /* AdTagType.swift */; };
 		CABDCEBB2C4A6CC100631FB3 /* AdModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = CABDCEBA2C4A6CC100631FB3 /* AdModel.swift */; };
 		CABDCEBD2C4A70AF00631FB3 /* BannerInfoHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CABDCEBC2C4A70AF00631FB3 /* BannerInfoHeaderView.swift */; };
+		CAC013D02CB7EA2200FF972F /* CellImageLoaded.swift in Sources */ = {isa = PBXBuildFile; fileRef = CAC013CF2CB7EA2200FF972F /* CellImageLoaded.swift */; };
 		CAC80FA02C3B10D100658EA6 /* MyPageView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CAC80F9F2C3B10D100658EA6 /* MyPageView.swift */; };
 		CAC80FA22C3B10EA00658EA6 /* MyPageViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = CAC80FA12C3B10EA00658EA6 /* MyPageViewController.swift */; };
 		CAC80FA42C3B34B400658EA6 /* UserInfoView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CAC80FA32C3B34B400658EA6 /* UserInfoView.swift */; };
@@ -498,6 +499,7 @@
 		CABDCEB82C4A6C8800631FB3 /* AdTagType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AdTagType.swift; sourceTree = "<group>"; };
 		CABDCEBA2C4A6CC100631FB3 /* AdModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AdModel.swift; sourceTree = "<group>"; };
 		CABDCEBC2C4A70AF00631FB3 /* BannerInfoHeaderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BannerInfoHeaderView.swift; sourceTree = "<group>"; };
+		CAC013CF2CB7EA2200FF972F /* CellImageLoaded.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CellImageLoaded.swift; sourceTree = "<group>"; };
 		CAC80F9F2C3B10D100658EA6 /* MyPageView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyPageView.swift; sourceTree = "<group>"; };
 		CAC80FA12C3B10EA00658EA6 /* MyPageViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyPageViewController.swift; sourceTree = "<group>"; };
 		CAC80FA32C3B34B400658EA6 /* UserInfoView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserInfoView.swift; sourceTree = "<group>"; };
@@ -1436,6 +1438,7 @@
 				CAC80FE22C3EC06200658EA6 /* MainSectionLayout.swift */,
 				CA80C0D62C4523A2002CAA9B /* DRBottomSheetAction.swift */,
 				CAA76AD62C6664B100821E3E /* Serviceable.swift */,
+				CAC013CF2CB7EA2200FF972F /* CellImageLoaded.swift */,
 			);
 			path = Protocols;
 			sourceTree = "<group>";
@@ -2012,6 +2015,7 @@
 				CA4EF3DA2C34791F003B02B6 /* OnboardingCollectionViewCell.swift in Sources */,
 				CABDCE6E2C47D6E600631FB3 /* AuthTargetType.swift in Sources */,
 				9E5098902C403C7500F72CD0 /* AddCourseThirdViewController.swift in Sources */,
+				CAC013D02CB7EA2200FF972F /* CellImageLoaded.swift in Sources */,
 				0DDC2B532C498F9300AC554D /* LikeCourseResponse.swift in Sources */,
 				0D98CBA92C410C7200E3618A /* CourseDetailViewModel.swift in Sources */,
 				CA4EF3E52C3538AA003B02B6 /* OnboardingViewModel.swift in Sources */,

--- a/DATEROAD-iOS/DATEROAD-iOS/Global/Literals/StringLiterals.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Global/Literals/StringLiterals.swift
@@ -419,6 +419,10 @@ enum StringLiterals {
         
         static let notFound = "대상을 찾을 수 없습니다."
         
+        static let networkFail = "네트워크 문제가 발생했습니다."
+
+        static let serverError = "서버에 문제가 발생했습니다."
+        
     }
     
     enum Course {

--- a/DATEROAD-iOS/DATEROAD-iOS/Global/Protocols/CellImageLoaded.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Global/Protocols/CellImageLoaded.swift
@@ -1,0 +1,14 @@
+//
+//  CellImageLoaded.swift
+//  DATEROAD-iOS
+//
+//  Created by 윤희슬 on 10/10/24.
+//
+
+import Foundation
+
+protocol CellImageLoadDelegate: AnyObject {
+    
+    func cellImageLoaded()
+    
+}

--- a/DATEROAD-iOS/DATEROAD-iOS/Global/Settings/Info.plist
+++ b/DATEROAD-iOS/DATEROAD-iOS/Global/Settings/Info.plist
@@ -26,6 +26,8 @@
 		<string>kakaokompassauth</string>
 		<string>kakaolink</string>
 	</array>
+	<key>Localization native development region</key>
+	<string>Korea</string>
 	<key>NSAppTransportSecurity</key>
 	<dict>
 		<key>NSAllowsArbitraryLoads</key>

--- a/DATEROAD-iOS/DATEROAD-iOS/Global/Utils/Enums/NetworkType.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Global/Utils/Enums/NetworkType.swift
@@ -13,4 +13,10 @@ enum NetworkType: String {
     
     case deleteDateSchedule
     
+    case postSignUp
+    
+    case getDoubleCheck
+    
+    case patchEditProfile
+    
 }

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/CourseDetail/Cells/ImageCarouselCell.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/CourseDetail/Cells/ImageCarouselCell.swift
@@ -44,6 +44,19 @@ final class ImageCarouselCell: BaseCollectionViewCell {
         fatalError("init(coder:) has not been implemented")
     }
     
+    override func prepareForReuse() {
+        
+        super.prepareForReuse()
+        
+        // 이미지 리소스 해제 및 다운로드 작업 취소
+        vcData.forEach { vc in
+            if let imageView = vc.view.subviews.first as? UIImageView {
+                imageView.image = nil
+                imageView.kf.cancelDownloadTask()
+            }
+        }
+    }
+    
     func setPageVC(thumbnailModel: [ThumbnailModel]) {
         vcData = thumbnailModel.map { thumbnail in
             let vc = UIViewController()

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/CourseDetail/Cells/ImageCarouselCell.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/CourseDetail/Cells/ImageCarouselCell.swift
@@ -33,6 +33,9 @@ final class ImageCarouselCell: BaseCollectionViewCell {
     
     weak var delegate: ImageCarouselDelegate?
     
+    
+    // MARK: - Life Cycles
+    
     override init(frame: CGRect) {
         
         super.init(frame: frame)

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/Main/ViewModels/MainViewModel.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/Main/ViewModels/MainViewModel.swift
@@ -27,6 +27,8 @@ final class MainViewModel: Serviceable {
     
     var onReissueSuccess: ObservablePattern<Bool> = ObservablePattern(nil)
     
+    var isAllLoaded: (() -> Void)?
+    
     var onLoading: ObservablePattern<Bool> = ObservablePattern(true)
     
     var onFailNetwork: ObservablePattern<Bool> = ObservablePattern(false)
@@ -193,7 +195,7 @@ extension MainViewModel {
     private func checkLoadingStatus() {
         // 모든 데이터 요청이 성공적으로 완료되었는지 확인
         if totalFetchCount % 5 == 0 {
-            setLoading(false)
+            self.isAllLoaded?()
         }
     }
     

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/Main/ViewModels/MainViewModel.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/Main/ViewModels/MainViewModel.swift
@@ -194,7 +194,7 @@ extension MainViewModel {
     
     private func checkLoadingStatus() {
         // 모든 데이터 요청이 성공적으로 완료되었는지 확인
-        if totalFetchCount % 5 == 0 {
+        if totalFetchCount != 0 && totalFetchCount % 5 == 0 {
             self.isAllLoaded?()
         }
     }

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/Main/Views/Cells/BannerCell.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/Main/Views/Cells/BannerCell.swift
@@ -14,6 +14,11 @@ final class BannerCell: BaseCollectionViewCell {
     private let bannerImage: UIImageView = UIImageView()
     
     
+    // MARK: - Properties
+    
+    weak var delegate: CellImageLoadDelegate?
+
+    
     // MARK: - Life Cycle
     
     override func setHierarchy() {
@@ -44,10 +49,14 @@ extension BannerCell {
     
     func bindData(bannerData: BannerModel?) {
         guard let bannerData else { return }
+
         if let url = URL(string: bannerData.imageUrl) {
-            self.bannerImage.kf.setImage(with: url)
+            self.bannerImage.kf.setImage(with: url) { result  in
+                self.delegate?.cellImageLoaded()
+            }
         } else {
             self.bannerImage.image = UIImage(resource: .imgBanner1)
+            self.delegate?.cellImageLoaded()
         }
     }
     

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/Main/Views/Cells/BannerCell.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/Main/Views/Cells/BannerCell.swift
@@ -21,6 +21,10 @@ final class BannerCell: BaseCollectionViewCell {
     
     // MARK: - Life Cycle
     
+    override func prepareForReuse() {
+        self.bannerImage.image = nil
+    }
+    
     override func setHierarchy() {
         self.addSubviews(bannerImage)
     }

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/Main/Views/Cells/BannerIndexFooterView.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/Main/Views/Cells/BannerIndexFooterView.swift
@@ -35,6 +35,10 @@ final class BannerIndexFooterView: UICollectionReusableView {
         fatalError("init(coder:) has not been implemented")
     }
     
+    override func prepareForReuse() {
+        self.indexLabel.text = nil
+    }
+    
     func setHierarchy() {
         self.addSubview(indexLabel)
     }

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/Main/Views/Cells/HotDateCourseCell.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/Main/Views/Cells/HotDateCourseCell.swift
@@ -40,6 +40,11 @@ final class HotDateCourseCell: BaseCollectionViewCell {
     private var timeLabel: DRPaddingLabel = DRPaddingLabel()
     
     
+    // MARK: - Properties
+    
+    weak var delegate: CellImageLoadDelegate?
+    
+    
     // MARK: - Life Cycle
     
     override func setHierarchy() {
@@ -228,9 +233,12 @@ extension HotDateCourseCell {
         guard let hotDateData else { return }
         self.countryLabel.text = hotDateData.city
         if let url = URL(string: hotDateData.thumbnail) {
-            self.courseImage.kf.setImage(with: url)
+            self.courseImage.kf.setImage(with: url) { result  in
+                self.delegate?.cellImageLoaded()
+            }
         } else {
             self.courseImage.image = UIImage(resource: .testImage2)
+            self.delegate?.cellImageLoaded()
         }
         
         self.likeLabel.text = "\(hotDateData.like)"

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/Main/Views/Cells/HotDateCourseCell.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/Main/Views/Cells/HotDateCourseCell.swift
@@ -47,6 +47,14 @@ final class HotDateCourseCell: BaseCollectionViewCell {
     
     // MARK: - Life Cycle
     
+    override func prepareForReuse() {
+        self.courseImage.image = nil
+        self.costLabel.text = nil
+        self.likeLabel.text = nil
+        self.countryLabel.text = nil
+        self.dateNameLabel.text = nil
+    }
+    
     override func setHierarchy() {
         self.addSubviews(countryLabel,
                          courseImage,

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/Main/Views/Cells/MainHeaderView.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/Main/Views/Cells/MainHeaderView.swift
@@ -44,6 +44,11 @@ final class MainHeaderView: UICollectionReusableView {
         fatalError("init(coder:) has not been implemented")
     }
     
+    override func prepareForReuse() {
+        self.titleLabel.text = nil
+        self.subLabel.text = nil
+    }
+    
     func setHierarchy() {
         self.addSubview(backgroundView)
         backgroundView.addSubviews(titleLabel, subLabel, viewMoreButton)

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/Main/Views/Cells/NewDateCourseCell.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/Main/Views/Cells/NewDateCourseCell.swift
@@ -45,6 +45,14 @@ final class NewDateCourseCell: BaseCollectionViewCell {
     
     // MARK: - Life Cycle
     
+    override func prepareForReuse() {
+        self.courseImage.image = nil
+        self.costLabel.text = nil
+        self.likeLabel.text = nil
+        self.countryLabel.text = nil
+        self.dateNameLabel.text = nil
+    }
+    
     override func setHierarchy() {
         self.addSubviews(courseImage,
                          likeView,

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/Main/Views/Cells/NewDateCourseCell.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/Main/Views/Cells/NewDateCourseCell.swift
@@ -38,6 +38,11 @@ final class NewDateCourseCell: BaseCollectionViewCell {
     private var timeLabel: DRPaddingLabel = DRPaddingLabel()
     
     
+    // MARK: - Properties
+    
+    weak var delegate: CellImageLoadDelegate?
+
+    
     // MARK: - Life Cycle
     
     override func setHierarchy() {
@@ -224,9 +229,12 @@ extension NewDateCourseCell {
         guard let newDateData else { return }
         self.countryLabel.text = newDateData.city
         if let url = URL(string: newDateData.thumbnail) {
-            self.courseImage.kf.setImage(with: url)
+            self.courseImage.kf.setImage(with: url) { result  in
+                self.delegate?.cellImageLoaded()
+            }
         } else {
             self.courseImage.image = UIImage(resource: .testImage2)
+            self.delegate?.cellImageLoaded()
         }
         self.likeLabel.text = "\(newDateData.like)"
         self.dateNameLabel.text = newDateData.title

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/Main/Views/Cells/UpcomingDateCell.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/Main/Views/Cells/UpcomingDateCell.swift
@@ -33,6 +33,11 @@ final class UpcomingDateCell: BaseCollectionViewCell {
     
     // MARK: - Life Cycle
     
+    override func prepareForReuse() {
+        self.profileImage.image = nil
+        self.pointLabel.text = nil
+    }
+    
     override func setHierarchy() {
         self.addSubviews(logoImage,
                          pointLabel,

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/Main/Views/Cells/UpcomingDateCell.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/Main/Views/Cells/UpcomingDateCell.swift
@@ -36,6 +36,9 @@ final class UpcomingDateCell: BaseCollectionViewCell {
     override func prepareForReuse() {
         self.profileImage.image = nil
         self.pointLabel.text = nil
+        self.profileImage.backgroundColor = .clear // 배경색 초기화
+        self.profileImage.layer.cornerRadius = self.profileImage.frame.size.width / 2  // cornerRadius 다시 적용
+        self.profileImage.clipsToBounds = true
     }
     
     override func setHierarchy() {

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/Main/Views/Cells/UpcomingDateCell.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/Main/Views/Cells/UpcomingDateCell.swift
@@ -124,6 +124,11 @@ extension UpcomingDateCell {
         guard let point = mainUserData?.point else { return }
         pointLabel.text = "\(point) P"
         
+        profileImage.do {
+            $0.clipsToBounds = true
+            $0.layer.cornerRadius = $0.frame.size.width / 2
+            $0.backgroundColor = .clear
+        }
         guard let imageUrl = mainUserData?.imageUrl else {
             self.profileImage.image = UIImage(resource: .emptyProfileImg)
             self.delegate?.cellImageLoaded()
@@ -132,11 +137,6 @@ extension UpcomingDateCell {
         let url = URL(string: imageUrl)
         self.profileImage.kf.setImage(with: url) { result  in
             self.delegate?.cellImageLoaded()
-        }
-        profileImage.do {
-            $0.clipsToBounds = true
-            $0.layer.cornerRadius = $0.frame.size.width / 2
-            $0.backgroundColor = .clear
         }
     }
     

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/Main/Views/Cells/UpcomingDateCell.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/Main/Views/Cells/UpcomingDateCell.swift
@@ -28,6 +28,8 @@ final class UpcomingDateCell: BaseCollectionViewCell {
     
     private var isEmpty: Bool = false
     
+    weak var delegate: CellImageLoadDelegate?
+
     
     // MARK: - Life Cycle
     
@@ -116,14 +118,17 @@ extension UpcomingDateCell {
         
         guard let imageUrl = mainUserData?.imageUrl else {
             self.profileImage.image = UIImage(resource: .emptyProfileImg)
+            self.delegate?.cellImageLoaded()
             return
         }
         let url = URL(string: imageUrl)
+        self.profileImage.kf.setImage(with: url) { result  in
+            self.delegate?.cellImageLoaded()
+        }
         profileImage.do {
             $0.clipsToBounds = true
             $0.layer.cornerRadius = $0.frame.size.width / 2
             $0.backgroundColor = .clear
-            $0.kf.setImage(with: url)
         }
     }
     

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/Main/Views/MainViewController.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/Main/Views/MainViewController.swift
@@ -26,6 +26,12 @@ final class MainViewController: BaseViewController {
     
     private lazy var point = mainViewModel.mainUserData.value?.point
     
+    private var totalCells: Int = 4 // 셀의 총 개수
+    
+    private var loadedCells: Int = 0 // 로딩이 완료된 셀 개수
+    
+    private var initial: Bool = false
+    
     
     // MARK: - Life Cycles
     
@@ -51,11 +57,13 @@ final class MainViewController: BaseViewController {
     
     override func viewIsAppearing(_ animated: Bool) {
         self.tabBarController?.tabBar.isHidden = false
+        self.loadedCells = 0
         self.mainViewModel.fetchSectionData()
     }
     
     override func viewWillDisappear(_ animated: Bool) {
         self.stopBannerAutoScroll()
+        self.initial = false
     }
     
     override func setHierarchy() {
@@ -105,6 +113,12 @@ extension MainViewController {
                         self?.hideLoadingView()
                     }
                 }
+            }
+        }
+        
+        self.mainViewModel.isAllLoaded = { [weak self] in
+            DispatchQueue.main.async {
+                self?.mainView.mainCollectionView.reloadData()
             }
         }
         
@@ -260,6 +274,7 @@ extension MainViewController: UICollectionViewDataSource {
             DispatchQueue.main.async {
                 cell.bindData(upcomingData: self.mainViewModel.upcomingData.value, mainUserData: self.mainViewModel.mainUserData.value)
             }
+            cell.delegate = self
             // Set button actions
             let pointLabelTapGesture = UITapGestureRecognizer(target: self, action: #selector(pushToPointDetailVC))
             cell.pointLabel.addGestureRecognizer(pointLabelTapGesture)
@@ -271,12 +286,14 @@ extension MainViewController: UICollectionViewDataSource {
         case .hotDateCourse:
             guard let cell = collectionView.dequeueReusableCell(withReuseIdentifier: HotDateCourseCell.cellIdentifier, for: indexPath) as? HotDateCourseCell
             else { return UICollectionViewCell() }
+            cell.delegate = self
             cell.bindData(hotDateData: mainViewModel.hotCourseData.value?[indexPath.row])
             return cell
             
         case .banner:
             guard let cell = collectionView.dequeueReusableCell(withReuseIdentifier: BannerCell.cellIdentifier, for: indexPath) as? BannerCell
             else { return UICollectionViewCell() }
+            cell.delegate = self
             cell.bindData(bannerData: mainViewModel.bannerData.value?[indexPath.row])
             let longPressGesture = UISwipeGestureRecognizer(target: self, action: #selector(handleLongPress(_:)))
             cell.addGestureRecognizer(longPressGesture)
@@ -348,6 +365,23 @@ extension MainViewController: BannerIndexDelegate {
     
     func bindIndex(currentIndex: Int) {
         self.mainViewModel.currentIndex.value?.row = currentIndex
+    }
+    
+}
+
+extension MainViewController: CellImageLoadDelegate {
+    
+    func cellImageLoaded() {
+        if !initial {
+            loadedCells += 1
+            print("Loaded cells: \(loadedCells)") // 디버깅 로그 추가
+
+            if loadedCells == totalCells {
+                self.mainViewModel.onLoading.value = false
+                loadedCells = 0
+                initial.toggle()
+            }
+        }
     }
     
 }

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/Main/Views/MainViewController.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/Main/Views/MainViewController.swift
@@ -271,10 +271,9 @@ extension MainViewController: UICollectionViewDataSource {
         case .upcomingDate:
             guard let cell = collectionView.dequeueReusableCell(withReuseIdentifier: UpcomingDateCell.cellIdentifier, for: indexPath) as? UpcomingDateCell
             else { return UICollectionViewCell() }
-            DispatchQueue.main.async {
-                cell.bindData(upcomingData: self.mainViewModel.upcomingData.value, mainUserData: self.mainViewModel.mainUserData.value)
-            }
             cell.delegate = self
+            cell.bindData(upcomingData: self.mainViewModel.upcomingData.value, mainUserData: self.mainViewModel.mainUserData.value)
+
             // Set button actions
             let pointLabelTapGesture = UITapGestureRecognizer(target: self, action: #selector(pushToPointDetailVC))
             cell.pointLabel.addGestureRecognizer(pointLabelTapGesture)

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/Main/Views/MainViewController.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/Main/Views/MainViewController.swift
@@ -302,6 +302,7 @@ extension MainViewController: UICollectionViewDataSource {
         case .newDateCourse:
             guard let cell = collectionView.dequeueReusableCell(withReuseIdentifier: NewDateCourseCell.cellIdentifier, for: indexPath) as? NewDateCourseCell
             else { return UICollectionViewCell() }
+            cell.delegate = self
             cell.bindData(newDateData: mainViewModel.newCourseData.value?[indexPath.row])
             return cell
         }

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/Profile/ViewModels/ProfileViewModel.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/Profile/ViewModels/ProfileViewModel.swift
@@ -51,6 +51,9 @@ final class ProfileViewModel: Serviceable {
     
     var onFailNetwork: ObservablePattern<Bool> = ObservablePattern(false)
     
+    var alertMessage: ObservablePattern<String> = ObservablePattern(nil)
+
+    
     
     init(profileData: ProfileModel) {
         self.profileData = ObservablePattern(profileData)
@@ -162,6 +165,10 @@ extension ProfileViewModel {
                 }
             case .requestErr:
                 self.isValidNickname.value = false
+            case .serverErr:
+                self.alertMessage.value = StringLiterals.Alert.serverError
+            case .networkFail:
+                self.alertMessage.value = StringLiterals.Alert.networkFail
             default:
                 print("Failed to fetch get double check")
                 self.isValidNickname.value = false

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/Profile/ViewModels/ProfileViewModel.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/Profile/ViewModels/ProfileViewModel.swift
@@ -9,6 +9,8 @@ import UIKit
 
 final class ProfileViewModel: Serviceable {
     
+    var type: ObservablePattern<NetworkType> = ObservablePattern(nil)
+    
     var tagData: [ProfileTagModel] = []
     
     var selectedTagData: [String]
@@ -135,6 +137,7 @@ extension ProfileViewModel {
                 self.onLoading.value = false
             case .reIssueJWT:
                 self.patchReissue { isSuccess in
+                    self.type.value = NetworkType.postSignUp
                     self.onReissueSuccess.value = isSuccess
                 }
             default:
@@ -154,6 +157,7 @@ extension ProfileViewModel {
                 self.isValidNickname.value = true
             case .reIssueJWT:
                 self.patchReissue { isSuccess in
+                    self.type.value = NetworkType.getDoubleCheck
                     self.onReissueSuccess.value = isSuccess
                 }
             case .requestErr:
@@ -189,6 +193,7 @@ extension ProfileViewModel {
                 self.onEditProfileLoading.value = false
             case .reIssueJWT:
                 self.patchReissue { isSuccess in
+                    self.type.value = NetworkType.patchEditProfile
                     self.onReissueSuccess.value = isSuccess
                 }
             default:

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/Profile/Views/EditProfileViewController.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/Profile/Views/EditProfileViewController.swift
@@ -24,6 +24,8 @@ final class EditProfileViewController: BaseNavBarViewController {
     
     private var initial: Bool = false
     
+    var networkType: NetworkType?
+
     
     // MARK: - Life Cycle
     
@@ -124,7 +126,14 @@ private extension EditProfileViewController {
         self.profileViewModel.onReissueSuccess.bind { [weak self] onSuccess in
             guard let onSuccess else { return }
             if onSuccess {
-                self?.profileViewModel.patchEditProfile()
+                switch self?.networkType {
+                case .getDoubleCheck:
+                    self?.profileViewModel.getDoubleCheck()
+                case .postSignUp:
+                    self?.profileViewModel.patchEditProfile()
+                default:
+                    self?.navigationController?.pushViewController(SplashViewController(splashViewModel: SplashViewModel()), animated: false)
+                }
             } else {
                 self?.navigationController?.pushViewController(SplashViewController(splashViewModel: SplashViewModel()), animated: false)
             }

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/Profile/Views/ProfileViewController.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/Profile/Views/ProfileViewController.swift
@@ -108,6 +108,11 @@ private extension ProfileViewController {
     }
     
     func bindViewModel() {
+        self.profileViewModel.alertMessage.bind { [weak self] message in
+            guard let message else { return }
+            self?.presentAlertVC(title: message)
+        }
+        
         self.profileViewModel.onReissueSuccess.bind { [weak self] onSuccess in
             guard let onSuccess else { return }
             if onSuccess {

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/Profile/Views/ProfileViewController.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/Profile/Views/ProfileViewController.swift
@@ -23,7 +23,9 @@ final class ProfileViewController: BaseNavBarViewController {
     private var profileViewModel: ProfileViewModel
     
     private var initial: Bool = false
-        
+    
+    var networkType: NetworkType?
+
     
     // MARK: - Life Cycle
     
@@ -109,8 +111,15 @@ private extension ProfileViewController {
         self.profileViewModel.onReissueSuccess.bind { [weak self] onSuccess in
             guard let onSuccess else { return }
             if onSuccess {
-                self?.profileViewModel.profileImage.value = self?.profileView.profileImageView.image
-                self?.profileViewModel.postSignUp()
+                switch self?.networkType {
+                case .getDoubleCheck:
+                    self?.profileViewModel.getDoubleCheck()
+                case .postSignUp:
+                    self?.profileViewModel.profileImage.value = self?.profileView.profileImageView.image
+                    self?.profileViewModel.postSignUp()
+                default:
+                    self?.navigationController?.pushViewController(SplashViewController(splashViewModel: SplashViewModel()), animated: false)
+                }
             } else {
                 self?.navigationController?.pushViewController(SplashViewController(splashViewModel: SplashViewModel()), animated: false)
             }


### PR DESCRIPTION
# 🔥*Pull requests*

## ⛳ **작업한 브랜치**
- feature/#250

## 👷 **작업한 내용**
<!-- 작업한 내용을 적어주세요. -->
- [x] 메인 이미지 로딩 속도 조정
- [x] 메인 프로필 이미지 배경색 설정
- [x] 메인 뷰 로딩 리팩

## 🚨 참고 사항
<!-- 참고할 사항이 있다면 적어주세요. -->
### 1️⃣ 메인뷰 로딩 시점 리팩
- 기존에는 모든 서버 통신이 성공 후 로딩뷰를 숨김처리 해주었는데요, 이때 이미지가 아직 로딩되지 않았는데 로딩뷰가 없어져서 이미지가 잠깐 보이지 않는 이슈가 있었습니다.
그래서 로딩뷰 숨김 시점을 모든 셀의 이미지가 로딩된 후로 변경해주었습니다.

``` Swift
// MainViewModel
private func checkLoadingStatus() {
    // 모든 데이터 요청이 성공적으로 완료되었는지 확인
    if totalFetchCount % 5 == 0 {
        // 모든 데이터 요청에 성공했다면 메인뷰컨에서 컬렉션뷰 리로드
        self.isAllLoaded?()
    }
}

// MainViewController
extension MainViewController: CellImageLoadDelegate {
    
    func cellImageLoaded() {
        // 뷰가 나타나고 한 번만 실행하도록
        if !initial {
            // 한 셀의 이미지가 모두 로드된 경우 1씩 증가
            loadedCells += 1
            print("Loaded cells: \(loadedCells)") // 디버깅 로그 추가

            // totalCells (총 4개의 셀)이 모두 로드되면 로딩뷰 숨겨주고, 변수 초기화
            if loadedCells == totalCells {
                self.mainViewModel.onLoading.value = false
                loadedCells = 0
                initial.toggle()
            }
        }
    }
    
}

// Cell
func bindData() {
    ...
    if let url = URL(string: hotDateData.thumbnail) {
        // 이미지가 로드되면 델리게이트 실행
        self.courseImage.kf.setImage(with: url) { result  in
            self.delegate?.cellImageLoaded()
        }
    } else {
        // 이미지가 로드되면 델리게이트 실행
        self.courseImage.image = UIImage(resource: .testImage2)
        self.delegate?.cellImageLoaded()
    }
}
```


## 📟 관련 이슈
- Resolved: #250 
