### PR TITLE
[Fix] QA 적용 및 데이터 로딩 방식 변경 (#266)

### DIFF
--- a/DATEROAD-iOS/DATEROAD-iOS/Global/Extensions/UIImageView+.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Global/Extensions/UIImageView+.swift
@@ -21,7 +21,7 @@ extension UIImageView {
             placeholder: placeholder,
             options: [.transition(.none),
                       .cacheOriginalImage,
-                      .keepCurrentImageWhileLoading]
+                      ]
         )
     }
     

--- a/DATEROAD-iOS/DATEROAD-iOS/Global/Extensions/UIImageView+.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Global/Extensions/UIImageView+.swift
@@ -16,13 +16,9 @@ extension UIImageView {
             self.image = placeholder
             return
         }
-        self.kf.setImage(
-            with: url,
-            placeholder: placeholder,
-            options: [.transition(.none),
-                      .cacheOriginalImage,
-                      ]
-        )
+        self.kf.setImage(with: url,
+                         placeholder: placeholder,
+                         options: [.transition(.none), .cacheOriginalImage,])
     }
     
 }

--- a/DATEROAD-iOS/DATEROAD-iOS/Global/UIComponents/DRBottomSheetViewController.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Global/UIComponents/DRBottomSheetViewController.swift
@@ -11,6 +11,8 @@ final class DRBottomSheetViewController: BaseViewController {
     
     // MARK: - UI Properties
     
+    private let backgroundView: UIView = UIView()
+    
     private let bottomSheetView: UIView = UIView()
     
     var contentView: UIView
@@ -51,11 +53,16 @@ final class DRBottomSheetViewController: BaseViewController {
     }
     
     override func setHierarchy() {
+        self.view.addSubview(backgroundView)
         self.view.addSubview(bottomSheetView)
         bottomSheetView.addSubviews(contentView, bottomButton)
     }
     
     override func setLayout() {
+        backgroundView.snp.makeConstraints {
+            $0.edges.equalToSuperview()
+        }
+        
         bottomSheetView.snp.makeConstraints {
             $0.height.equalTo(self.height)
             $0.horizontalEdges.bottom.equalToSuperview()
@@ -74,8 +81,9 @@ final class DRBottomSheetViewController: BaseViewController {
     }
     
     override func setStyle() {
-        self.view.do {
+        self.backgroundView.do {
             $0.backgroundColor = UIColor(resource: .drBlack).withAlphaComponent(0.4)
+            $0.alpha = 0
         }
         
         self.bottomSheetView.do {
@@ -121,6 +129,47 @@ final class DRBottomSheetViewController: BaseViewController {
     @objc
     func didTapBottomLabel() {
         self.delegate?.didTapSecondLabel()
+    }
+    
+}
+
+extension DRBottomSheetViewController {
+    
+    func presentBottomSheet(in viewController: UIViewController, animated: Bool = true, completion: (() -> Void)? = nil) {
+        self.modalPresentationStyle = .overFullScreen
+        viewController.present(self, animated: false) {
+            self.animateBottomSheetPresentation(animated: animated, completion: completion)
+        }
+    }
+    
+    func dismissBottomSheet(animated: Bool = true, completion: (() -> Void)? = nil) {
+        if animated {
+            UIView.animate(withDuration: 0.3, delay: 0, options: .curveEaseIn, animations: {
+                self.bottomSheetView.transform = CGAffineTransform(translationX: 0, y: self.height)
+            }, completion: { _ in
+                self.backgroundView.alpha = 0
+                self.dismiss(animated: false, completion: completion)
+            })
+        } else {
+            self.backgroundView.alpha = 0
+            self.dismiss(animated: false, completion: completion)
+        }
+    }
+    
+    private func animateBottomSheetPresentation(animated: Bool, completion: (() -> Void)? = nil) {
+        if animated {
+            self.bottomSheetView.transform = CGAffineTransform(translationX: 0, y: self.height)
+            
+            UIView.animate(withDuration: 0.3, delay: 0, options: .curveEaseOut, animations: {
+                self.backgroundView.alpha = 1
+                self.bottomSheetView.transform = .identity
+            }, completion: { _ in
+                completion?()
+            })
+        } else {
+            self.backgroundView.alpha = 1
+            completion?()
+        }
     }
     
 }

--- a/DATEROAD-iOS/DATEROAD-iOS/Global/UIComponents/DRBottomSheetViewController.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Global/UIComponents/DRBottomSheetViewController.swift
@@ -53,8 +53,8 @@ final class DRBottomSheetViewController: BaseViewController {
     }
     
     override func setHierarchy() {
-        self.view.addSubview(backgroundView)
-        self.view.addSubview(bottomSheetView)
+        self.view.addSubviews(backgroundView, bottomSheetView)
+        
         bottomSheetView.addSubviews(contentView, bottomButton)
     }
     
@@ -146,8 +146,8 @@ extension DRBottomSheetViewController {
         if animated {
             UIView.animate(withDuration: 0.3, delay: 0, options: .curveEaseIn, animations: {
                 self.bottomSheetView.transform = CGAffineTransform(translationX: 0, y: self.height)
-            }, completion: { _ in
                 self.backgroundView.alpha = 0
+            }, completion: { _ in
                 self.dismiss(animated: false, completion: completion)
             })
         } else {
@@ -159,6 +159,7 @@ extension DRBottomSheetViewController {
     private func animateBottomSheetPresentation(animated: Bool, completion: (() -> Void)? = nil) {
         if animated {
             self.bottomSheetView.transform = CGAffineTransform(translationX: 0, y: self.height)
+            self.backgroundView.alpha = 0
             
             UIView.animate(withDuration: 0.3, delay: 0, options: .curveEaseOut, animations: {
                 self.backgroundView.alpha = 1

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/AddCourse/Cells/AddSecondViewTableViewCell.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/AddCourse/Cells/AddSecondViewTableViewCell.swift
@@ -33,11 +33,9 @@ final class AddSecondViewCollectionViewCell: BaseCollectionViewCell {
     override func setHierarchy() {
         self.addSubview(contentView)
         
-        contentView.addSubviews(
-            placeTitleLabel,
-            timeRequireContainer,
-            moveAbleButton
-        )
+        contentView.addSubviews(placeTitleLabel,
+                                timeRequireContainer,
+                                moveAbleButton)
         
         timeRequireContainer.addSubview(timeRequireLabel)
     }

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/AddCourse/Cells/AddSecondViewTableViewCell.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/AddCourse/Cells/AddSecondViewTableViewCell.swift
@@ -46,7 +46,9 @@ final class AddSecondViewCollectionViewCell: BaseCollectionViewCell {
         placeTitleLabel.snp.makeConstraints {
             $0.centerY.equalToSuperview()
             $0.leading.equalToSuperview().offset(17)
+            $0.trailing.equalTo(timeRequireContainer.snp.leading).offset(-20)
             $0.width.equalTo(198)
+            $0.height.equalToSuperview()
         }
         
         timeRequireContainer.snp.makeConstraints {

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/AddCourse/Views/AddCourseFirst/AddCourseFirstViewController.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/AddCourse/Views/AddCourseFirst/AddCourseFirstViewController.swift
@@ -260,6 +260,7 @@ private extension AddCourseFirstViewController {
         viewModel.pickedImageArr.remove(at: indexPath.item)
         
         let dataSourceCnt = viewModel.pickedImageArr.count
+        
         if dataSourceCnt < 1 {
             cell.updateImageCellUI(isImageEmpty: true, vcCnt: 1)
             viewModel.isPickedImageVaild.value = false

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/AddCourse/Views/AddCourseFirst/AddCourseFirstViewController.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/AddCourse/Views/AddCourseFirst/AddCourseFirstViewController.swift
@@ -20,6 +20,8 @@ final class AddCourseFirstViewController: BaseNavBarViewController {
     
     lazy var alertVC = DRBottomSheetViewController(contentView: addSheetView, height: 304, buttonType: EnabledButton(), buttonTitle: StringLiterals.AddCourseOrSchedule.AddBottomSheetView.datePickerBtnTitle)
     
+    let locationFilterVC = LocationFilterViewController()
+    
     private let imagePickerViewController = CustomImagePicker(isProfilePicker: false)
     
     
@@ -227,8 +229,7 @@ private extension AddCourseFirstViewController {
         alertVC.delegate = self
         addCourseFirstView.addFirstView.dateNameTextField.resignFirstResponder()
         DispatchQueue.main.async {
-            self.alertVC.modalPresentationStyle = .overFullScreen
-            self.present(self.alertVC, animated: true, completion: nil)
+            self.alertVC.presentBottomSheet(in: self)
         }
     }
     
@@ -239,8 +240,7 @@ private extension AddCourseFirstViewController {
         alertVC.delegate = self
         addCourseFirstView.addFirstView.dateNameTextField.resignFirstResponder()
         DispatchQueue.main.async {
-            self.alertVC.modalPresentationStyle = .overFullScreen
-            self.present(self.alertVC, animated: true, completion: nil)
+            self.alertVC.presentBottomSheet(in: self)
         }
     }
     
@@ -313,13 +313,11 @@ private extension AddCourseFirstViewController {
     
     @objc
     func datePlaceContainerTapped() {
-        // datePlaceContainer가 탭되었을 때 수행할 동작을 여기에 구현합니다.
-        print("datePlaceContainer tapped!")
-        let locationFilterVC = LocationFilterViewController()
-        locationFilterVC.modalPresentationStyle = .overFullScreen
         locationFilterVC.isAddType = true
         locationFilterVC.delegate = self
-        self.present(locationFilterVC, animated: true)
+        DispatchQueue.main.async {
+            self.locationFilterVC.presentBottomSheet(in: self)
+        }
     }
     
 }
@@ -473,8 +471,7 @@ extension AddCourseFirstViewController: ImagePickerDelegate {
 extension AddCourseFirstViewController: DRBottomSheetDelegate {
     
     func didTapBottomButton() {
-        print("")
-        self.dismiss(animated: true)
+        alertVC.dismissBottomSheet()
         updateTextField()
     }
     
@@ -484,7 +481,6 @@ extension AddCourseFirstViewController: DRBottomSheetDelegate {
         if !isTimePickerFlag {
             let selectedDate = addSheetView.datePicker.date
             viewModel.isFutureDate(date: selectedDate, dateType: "date")
-            dismiss(animated: true)
         } else {
             let formattedDate = addSheetView.datePicker.date
             viewModel.isFutureDate(date: formattedDate, dateType: "time")

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/AddCourse/Views/AddCourseSecond/AddCourseSecondViewController.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/AddCourse/Views/AddCourseSecond/AddCourseSecondViewController.swift
@@ -190,8 +190,7 @@ private extension AddCourseSecondViewController {
         addCourseSecondView.addSecondView.datePlaceTextField.resignFirstResponder()
         
         DispatchQueue.main.async {
-            alertVC.modalPresentationStyle = .overFullScreen
-            self.present(alertVC, animated: true, completion: nil)
+            alertVC.presentBottomSheet(in: self)
         }
     }
     

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/AddCourse/Views/AddCourseSecond/AddCourseSecondViewController.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/AddCourse/Views/AddCourseSecond/AddCourseSecondViewController.swift
@@ -292,8 +292,15 @@ extension AddCourseSecondViewController: UITextFieldDelegate {
     }
     
     func textFieldDidEndEditing(_ textField: UITextField) {
-        viewModel.datePlace.value = textField.text
-        print(textField.text ?? "")
+        let trimmedText = textField.text?.trimmingCharacters(in: .whitespacesAndNewlines)
+        
+        if let text = trimmedText, !text.isEmpty {
+            viewModel.datePlace.value = text
+            print(text)
+        } else {
+            viewModel.datePlace.value = ""
+            print("공란")
+        }
     }
     
 }

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/AddCourse/Views/AddCourseSecond/AddSecondView.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/AddCourse/Views/AddCourseSecond/AddSecondView.swift
@@ -140,6 +140,11 @@ final class AddSecondView: BaseView {
             $0.layer.cornerRadius = 14
             $0.autocorrectionType = .no
             $0.spellCheckingType = .no
+            let attributes: [NSAttributedString.Key: Any] = [
+                .font: UIFont.suit(.body_semi_13),
+                .foregroundColor: UIColor(resource: .drBlack)
+            ]
+            $0.defaultTextAttributes = attributes
         }
         
         timeRequireTextField.do {

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/AddCourse/Views/AddSheetViewController.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/AddCourse/Views/AddSheetViewController.swift
@@ -15,6 +15,8 @@ final class AddSheetViewController: BaseViewController {
     
     // MARK: - UI Properties
     
+    private let backgroundView: UIView = UIView()
+    
     var addSheetView = AddSheetView(isCustomPicker: true)
     
     
@@ -50,24 +52,78 @@ final class AddSheetViewController: BaseViewController {
     // MARK: - Methods
     
     override func setHierarchy() {
-        view.addSubview(addSheetView)
+        view.addSubviews(backgroundView, addSheetView)
     }
     
     override func setLayout() {
-        addSheetView.snp.makeConstraints {
+        backgroundView.snp.makeConstraints {
             $0.edges.equalToSuperview()
+        }
+        
+        addSheetView.snp.makeConstraints {
+            $0.left.right.bottom.equalToSuperview()
+            $0.height.equalTo(304)
         }
     }
     
     override func setStyle() {
-        view.do {
-            $0.backgroundColor = UIColor.drBlack.withAlphaComponent(0.65)
+        backgroundView.do {
+            $0.backgroundColor = UIColor.drBlack.withAlphaComponent(0.4)
+            $0.alpha = 0
+        }
+        
+        addSheetView.do {
+            $0.backgroundColor = .white
+            $0.layer.cornerRadius = 20
+            $0.layer.maskedCorners = [.layerMinXMinYCorner, .layerMaxXMinYCorner]
         }
     }
     
 }
 
+
 // MARK: - ViewController Methods
+
+extension AddSheetViewController {
+    
+    func presentBottomSheet(in viewController: UIViewController, animated: Bool = true, completion: (() -> Void)? = nil) {
+        self.modalPresentationStyle = .overFullScreen
+        viewController.present(self, animated: false) {
+            self.animateBottomSheetPresentation(animated: animated, completion: completion)
+        }
+    }
+    
+    func dismissBottomSheet(animated: Bool = true, completion: (() -> Void)? = nil) {
+        if animated {
+            UIView.animate(withDuration: 0.3, delay: 0, options: .curveEaseIn, animations: {
+                self.addSheetView.transform = CGAffineTransform(translationX: 0, y: self.addSheetView.frame.height)
+                self.backgroundView.alpha = 0
+            }, completion: { _ in
+                self.dismiss(animated: false, completion: completion)
+            })
+        } else {
+            self.backgroundView.alpha = 0
+            self.dismiss(animated: false, completion: completion)
+        }
+    }
+    
+    private func animateBottomSheetPresentation(animated: Bool, completion: (() -> Void)? = nil) {
+        if animated {
+            self.addSheetView.transform = CGAffineTransform(translationX: 0, y: self.addSheetView.frame.height)
+            
+            UIView.animate(withDuration: 0.3, delay: 0, options: .curveEaseOut, animations: {
+                self.backgroundView.alpha = 1
+                self.addSheetView.transform = .identity
+            }, completion: { _ in
+                completion?()
+            })
+        } else {
+            self.backgroundView.alpha = 1
+            completion?()
+        }
+    }
+    
+}
 
 private extension AddSheetViewController {
     
@@ -87,7 +143,7 @@ private extension AddSheetViewController {
         let selectedRow = addSheetView.customPickerView.selectedRow(inComponent: 0)
         let selectedValue = customPickerValues[selectedRow]
         viewModel?.updateTimeRequireTextField(text: String(selectedValue))
-        dismiss(animated: true)
+        self.dismissBottomSheet()
     }
     
 }

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/AddSchedule/Views/AddScheduleBottomSheetViewController.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/AddSchedule/Views/AddScheduleBottomSheetViewController.swift
@@ -14,6 +14,8 @@ final class AddScheduleBottomSheetViewController: BaseViewController {
     
     // MARK: - UI Properties
     
+    private let backgroundView: UIView = UIView()
+    
     var addSheetView = AddScheduleBottomSheetView(isCustomPicker: true)
     
     
@@ -49,24 +51,77 @@ final class AddScheduleBottomSheetViewController: BaseViewController {
     // MARK: - Methods
     
     override func setHierarchy() {
-        view.addSubview(addSheetView)
+        view.addSubviews(backgroundView, addSheetView)
     }
     
     override func setLayout() {
-        addSheetView.snp.makeConstraints {
+        backgroundView.snp.makeConstraints {
             $0.edges.equalToSuperview()
+        }
+        
+        addSheetView.snp.makeConstraints {
+            $0.left.right.bottom.equalToSuperview()
+            $0.height.equalTo(304)
         }
     }
     
     override func setStyle() {
-        view.do {
-            $0.backgroundColor = UIColor.drBlack.withAlphaComponent(0.65)
+        backgroundView.do {
+            $0.backgroundColor = UIColor.drBlack.withAlphaComponent(0.4)
+            $0.alpha = 0
+        }
+        
+        addSheetView.do {
+            $0.backgroundColor = .white
+            $0.layer.cornerRadius = 20
+            $0.layer.maskedCorners = [.layerMinXMinYCorner, .layerMaxXMinYCorner]
         }
     }
     
 }
 
 // MARK: - Extension Methods
+
+extension AddScheduleBottomSheetViewController {
+    
+    func presentBottomSheet(in viewController: UIViewController, animated: Bool = true, completion: (() -> Void)? = nil) {
+        self.modalPresentationStyle = .overFullScreen
+        viewController.present(self, animated: false) {
+            self.animateBottomSheetPresentation(animated: animated, completion: completion)
+        }
+    }
+    
+    func dismissBottomSheet(animated: Bool = true, completion: (() -> Void)? = nil) {
+        if animated {
+            UIView.animate(withDuration: 0.3, delay: 0, options: .curveEaseIn, animations: {
+                self.addSheetView.transform = CGAffineTransform(translationX: 0, y: self.addSheetView.frame.height)
+                self.backgroundView.alpha = 0
+            }, completion: { _ in
+                self.dismiss(animated: false, completion: completion)
+            })
+        } else {
+            self.backgroundView.alpha = 0
+            self.dismiss(animated: false, completion: completion)
+        }
+    }
+    
+    private func animateBottomSheetPresentation(animated: Bool, completion: (() -> Void)? = nil) {
+        if animated {
+            self.addSheetView.transform = CGAffineTransform(translationX: 0, y: self.addSheetView.frame.height)
+            
+            UIView.animate(withDuration: 0.3, delay: 0, options: .curveEaseOut, animations: {
+                self.backgroundView.alpha = 1
+                self.addSheetView.transform = .identity
+            }, completion: { _ in
+                completion?()
+            })
+        } else {
+            self.backgroundView.alpha = 1
+            completion?()
+        }
+    }
+    
+}
 
 private extension AddScheduleBottomSheetViewController {
     
@@ -83,7 +138,7 @@ private extension AddScheduleBottomSheetViewController {
         let selectedRow = addSheetView.customPickerView.selectedRow(inComponent: 0)
         let selectedValue = customPickerValues[selectedRow]
         viewModel?.updateTimeRequireTextField(text: String(selectedValue))
-        dismiss(animated: true)
+        self.dismissBottomSheet()
     }
     
 }

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/AddSchedule/Views/AddScheduleFirst/AddScheduleFirstViewController.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/AddSchedule/Views/AddScheduleFirst/AddScheduleFirstViewController.swift
@@ -15,12 +15,10 @@ final class AddScheduleFirstViewController: BaseNavBarViewController {
     
     let addSheetView = AddSheetView(isCustomPicker: false)
     
-    lazy var alertVC = DRBottomSheetViewController(
-        contentView: addSheetView,
-        height: 304,
-        buttonType: EnabledButton(),
-        buttonTitle: StringLiterals.AddCourseOrSchedule.AddBottomSheetView.datePickerBtnTitle
-    )
+    lazy var alertVC = DRBottomSheetViewController(contentView: addSheetView,
+                                                   height: 304,
+                                                   buttonType: EnabledButton(),
+                                                   buttonTitle: StringLiterals.AddCourseOrSchedule.AddBottomSheetView.datePickerBtnTitle)
     
     let locationFilterVC = LocationFilterViewController()
     

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/AddSchedule/Views/AddScheduleFirst/AddScheduleFirstViewController.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/AddSchedule/Views/AddScheduleFirst/AddScheduleFirstViewController.swift
@@ -15,7 +15,12 @@ final class AddScheduleFirstViewController: BaseNavBarViewController {
     
     let addSheetView = AddSheetView(isCustomPicker: false)
     
-    lazy var alertVC = DRBottomSheetViewController(contentView: addSheetView, height: 304, buttonType: EnabledButton(), buttonTitle: StringLiterals.AddCourseOrSchedule.AddBottomSheetView.datePickerBtnTitle)
+    lazy var alertVC = DRBottomSheetViewController(
+        contentView: addSheetView,
+        height: 304,
+        buttonType: EnabledButton(),
+        buttonTitle: StringLiterals.AddCourseOrSchedule.AddBottomSheetView.datePickerBtnTitle
+    )
     
     let locationFilterVC = LocationFilterViewController()
     

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/AddSchedule/Views/AddScheduleFirst/AddScheduleFirstViewController.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/AddSchedule/Views/AddScheduleFirst/AddScheduleFirstViewController.swift
@@ -17,6 +17,8 @@ final class AddScheduleFirstViewController: BaseNavBarViewController {
     
     lazy var alertVC = DRBottomSheetViewController(contentView: addSheetView, height: 304, buttonType: EnabledButton(), buttonTitle: StringLiterals.AddCourseOrSchedule.AddBottomSheetView.datePickerBtnTitle)
     
+    let locationFilterVC = LocationFilterViewController()
+    
     private let loadingView: DRLoadingView = DRLoadingView()
     
     private let errorView: DRErrorViewController = DRErrorViewController()
@@ -245,8 +247,7 @@ private extension AddScheduleFirstViewController {
         alertVC.delegate = self
         addScheduleFirstView.inAddScheduleFirstView.dateNameTextField.resignFirstResponder()
         DispatchQueue.main.async {
-            self.alertVC.modalPresentationStyle = .overFullScreen
-            self.present(self.alertVC, animated: true, completion: nil)
+            self.alertVC.presentBottomSheet(in: self)
         }
     }
     
@@ -257,8 +258,7 @@ private extension AddScheduleFirstViewController {
         alertVC.delegate = self
         addScheduleFirstView.inAddScheduleFirstView.dateNameTextField.resignFirstResponder()
         DispatchQueue.main.async {
-            self.alertVC.modalPresentationStyle = .overFullScreen
-            self.present(self.alertVC, animated: true, completion: nil)
+            self.alertVC.presentBottomSheet(in: self)
         }
     }
     
@@ -304,13 +304,11 @@ private extension AddScheduleFirstViewController {
     
     @objc
     func datePlaceContainerTapped() {
-        // datePlaceContainer가 탭되었을 때 수행할 동작을 여기에 구현합니다.
-        print("datePlaceContainer tapped!")
-        let locationFilterVC = LocationFilterViewController()
-        locationFilterVC.modalPresentationStyle = .overFullScreen
         locationFilterVC.isAddType = true
         locationFilterVC.delegate = self
-        self.present(locationFilterVC, animated: false)
+        DispatchQueue.main.async {
+            self.locationFilterVC.presentBottomSheet(in: self)
+        }
     }
     
 }
@@ -407,7 +405,7 @@ extension AddScheduleFirstViewController: UITextFieldDelegate {
 extension AddScheduleFirstViewController: DRBottomSheetDelegate {
     
     func didTapBottomButton() {
-        self.dismiss(animated: true)
+        alertVC.dismissBottomSheet()
         updateTextField()
     }
     
@@ -417,7 +415,6 @@ extension AddScheduleFirstViewController: DRBottomSheetDelegate {
         if !isTimePickerFlag {
             let selectedDate = addSheetView.datePicker.date
             viewModel.isFutureDate(date: selectedDate, dateType: "date")
-            dismiss(animated: true)
         } else {
             let formattedDate = addSheetView.datePicker.date
             viewModel.isFutureDate(date: formattedDate, dateType: "time")

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/AddSchedule/Views/AddScheduleSecond/AddScheduleSecondViewController.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/AddSchedule/Views/AddScheduleSecond/AddScheduleSecondViewController.swift
@@ -355,8 +355,15 @@ extension AddScheduleSecondViewController: UITextFieldDelegate {
     }
     
     func textFieldDidEndEditing(_ textField: UITextField) {
-        viewModel.datePlace.value = textField.text
-        print(textField.text ?? "")
+        let trimmedText = textField.text?.trimmingCharacters(in: .whitespacesAndNewlines)
+        
+        if let text = trimmedText, !text.isEmpty {
+            viewModel.datePlace.value = text
+            print(text)
+        } else {
+            viewModel.datePlace.value = ""
+            print("공란")
+        }
     }
     
 }

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/AddSchedule/Views/AddScheduleSecond/AddScheduleSecondViewController.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/AddSchedule/Views/AddScheduleSecond/AddScheduleSecondViewController.swift
@@ -226,6 +226,7 @@ private extension AddScheduleSecondViewController {
         addScheduleSecondView.nextBtn.addTarget(self, action: #selector(didTapNextBtn), for: .touchUpInside)
     }
     
+    // 등록 완료 alertVC도 blurView 페이드인 적용 미정
     func successDone() {
         let customAlertVC = DRCustomAlertViewController(
             rightActionType: .none,
@@ -257,8 +258,7 @@ private extension AddScheduleSecondViewController {
         addScheduleSecondView.inAddScheduleSecondView.datePlaceTextField.resignFirstResponder()
         
         DispatchQueue.main.async {
-            alertVC.modalPresentationStyle = .overFullScreen
-            self.present(alertVC, animated: true, completion: nil)
+            alertVC.presentBottomSheet(in: self)
         }
     }
     

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/AddSchedule/Views/AddScheduleSecond/InAddScheduleSecondView.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/AddSchedule/Views/AddScheduleSecond/InAddScheduleSecondView.swift
@@ -129,6 +129,11 @@ final class InAddScheduleSecondView: BaseView {
             $0.layer.cornerRadius = 14
             $0.autocorrectionType = .no
             $0.spellCheckingType = .no
+            let attributes: [NSAttributedString.Key: Any] = [
+                .font: UIFont.suit(.body_semi_13),
+                .foregroundColor: UIColor(resource: .drBlack)
+            ]
+            $0.defaultTextAttributes = attributes
         }
         
         timeRequireTextField.do {

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/Banner/Models/BannerDetailModel.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/Banner/Models/BannerDetailModel.swift
@@ -7,11 +7,29 @@
 
 import Foundation
 
-struct BannerDetailModel: Codable {
+struct BannerDetailModel: Equatable {
     
-    let images: [Image]
+    var images: [ThumbnailModel]
     
-    let title, createAt, description, adTagType: String
+    let headerData: BannerHeaderModel
+    
+    let title: String
+    
+    let mainContents: MainContentsModel
+    
+    init(data: GetBannerDetailResponse) {
+        self.images = data.images.map { ThumbnailModel(imageUrl: $0.imageURL, sequence: $0.sequence) }
+        self.headerData = BannerHeaderModel(tag: AdTagType.getAdTag(byEnglish: data.adTagType)?.tag.title ?? "", createAt: data.createAt)
+        self.title = data.title
+        self.mainContents = MainContentsModel(description: data.description)
+    }
+    
+    static func == (lhs: BannerDetailModel, rhs: BannerDetailModel) -> Bool {
+        return lhs.images == rhs.images &&
+               lhs.headerData == rhs.headerData &&
+               lhs.title == rhs.title &&
+               lhs.mainContents == rhs.mainContents
+    }
     
 }
 

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/Banner/ViewModels/BannerViewModel.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/Banner/ViewModels/BannerViewModel.swift
@@ -10,21 +10,21 @@ import UIKit
 final class BannerViewModel: Serviceable {
     
     let updateBannerDetailData: ObservablePattern<Bool> = ObservablePattern(false)
-        
+    
     var currentPage: ObservablePattern<Int> = ObservablePattern(0)
     
     var bannerDetailData: ObservablePattern<BannerDetailModel?> = ObservablePattern(nil)
     
     var isUpdate: ObservablePattern<Bool> = ObservablePattern(nil)
-        
+    
     var imageData: ObservablePattern<[ThumbnailModel]> = ObservablePattern(nil)
-                    
+    
     var mainContentsData: ObservablePattern<MainContentsModel> = ObservablePattern(nil)
-        
+    
     let bannerSectionData: [BannerDetailSection] = BannerDetailSection.dataSource
     
     var isSuccessGetBannerData: ObservablePattern<Bool> = ObservablePattern(nil)
-        
+    
     var bannerHeaderData: ObservablePattern<BannerHeaderModel> = ObservablePattern(nil)
     
     var onReissueSuccess: ObservablePattern<Bool> = ObservablePattern(nil)
@@ -36,12 +36,12 @@ final class BannerViewModel: Serviceable {
     var advertisementId: Int = 0
     
     var bannerDetailTitle: String = ""
-                
+    
     
     init(advertisementId: Int) {
         self.advertisementId = advertisementId
     }
-
+    
     func didSwipeImage(to index: Int) {
         currentPage.value = index
     }
@@ -49,7 +49,7 @@ final class BannerViewModel: Serviceable {
 }
 
 extension BannerViewModel {
-
+    
     func getBannerDetail() {
         self.isSuccessGetBannerData.value = false
         self.setBannerDetailLoading()

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/Banner/ViewModels/BannerViewModel.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/Banner/ViewModels/BannerViewModel.swift
@@ -8,8 +8,14 @@
 import UIKit
 
 final class BannerViewModel: Serviceable {
+    
+    let updateBannerDetailData: ObservablePattern<Bool> = ObservablePattern(false)
         
     var currentPage: ObservablePattern<Int> = ObservablePattern(0)
+    
+    var bannerDetailData: ObservablePattern<BannerDetailModel?> = ObservablePattern(nil)
+    
+    var isUpdate: ObservablePattern<Bool> = ObservablePattern(nil)
         
     var imageData: ObservablePattern<[ThumbnailModel]> = ObservablePattern(nil)
                     
@@ -52,10 +58,18 @@ extension BannerViewModel {
         NetworkService.shared.courseDetailService.getBannerDetailInfo(advertismentId: self.advertisementId){ response in
             switch response {
             case .success(let data):
-                self.imageData.value = data.images.map { ThumbnailModel(imageUrl: $0.imageURL, sequence: $0.sequence) }
-                self.bannerHeaderData.value = BannerHeaderModel(tag: AdTagType.getAdTag(byEnglish: data.adTagType)?.tag.title ?? "", createAt: data.createAt)
-                self.bannerDetailTitle = data.title
-                self.mainContentsData.value = MainContentsModel(description: data.description)
+                let newBannerDetailModel = BannerDetailModel(data: data)
+                
+                if self.bannerDetailData.value != newBannerDetailModel {
+                    self.bannerDetailData.value = newBannerDetailModel
+                    
+                    self.imageData.value = newBannerDetailModel.images
+                    self.bannerHeaderData.value = newBannerDetailModel.headerData
+                    self.bannerDetailTitle = newBannerDetailModel.title
+                    self.mainContentsData.value = newBannerDetailModel.mainContents
+                    self.updateBannerDetailData.value = true
+                }
+                
                 self.isSuccessGetBannerData.value = true
             case .reIssueJWT:
                 self.patchReissue { isSuccess in

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/Banner/Views/BannerDetailViewController.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/Banner/Views/BannerDetailViewController.swift
@@ -86,6 +86,18 @@ final class BannerDetailViewController: BaseViewController {
     }
     
     func bindViewModel() {
+        self.bannerViewModel.updateBannerDetailData.bind { [weak self] flag in
+            guard let flag else { return }
+            if flag {
+                DispatchQueue.main.async {
+                    self?.bannerDetailView.mainCollectionView.performBatchUpdates({
+                        self?.bannerDetailView.mainCollectionView.reloadData()
+                    })
+                }
+                self?.bannerViewModel.updateBannerDetailData.value = false
+            }
+        }
+        
         self.bannerViewModel.isSuccessGetBannerData.bind { [weak self] onSuccess in
             guard let onSuccess  else { return }
             self?.bannerViewModel.onLoading.value = !onSuccess

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/Commons/LocationFilter/Views/LocationFilterView.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/Commons/LocationFilter/Views/LocationFilterView.swift
@@ -12,7 +12,7 @@ import Then
 
 protocol LocationFilterViewDelegate: AnyObject {
     
-    func closeLocationFilterView()
+    func closeLocationFilterViewToDelegate()
     
     func didTapApplyButton()
     
@@ -21,8 +21,6 @@ protocol LocationFilterViewDelegate: AnyObject {
 final class LocationFilterView: BaseView {
     
     // MARK: - UI Properties
-    
-    private let dimmedView = UIView()
     
     private let bottomSheetView = UIView()
     
@@ -55,7 +53,7 @@ final class LocationFilterView: BaseView {
     }
     
     override func setHierarchy() {
-        self.addSubviews(dimmedView, bottomSheetView)
+        self.addSubview(bottomSheetView)
         
         bottomSheetView.addSubviews(
             titleLabel,
@@ -68,14 +66,9 @@ final class LocationFilterView: BaseView {
     }
     
     override func setLayout() {
-        dimmedView.snp.makeConstraints {
-            $0.top.horizontalEdges.equalToSuperview()
-            $0.bottom.equalTo(bottomSheetView)
-        }
-        
         bottomSheetView.snp.makeConstraints {
+            $0.horizontalEdges.bottom.equalToSuperview()
             $0.height.equalTo(469)
-            $0.leading.trailing.bottom.equalToSuperview()
         }
         
         titleLabel.snp.makeConstraints {
@@ -119,14 +112,6 @@ final class LocationFilterView: BaseView {
             $0.showsVerticalScrollIndicator = false
         }
         
-        dimmedView.do {
-            $0.alpha = 0.7
-            $0.layer.backgroundColor = UIColor(resource: .drBlack).cgColor
-            let gesture = UITapGestureRecognizer(target: self, action: #selector(closeLocationFilterView))
-            $0.isUserInteractionEnabled = true
-            $0.addGestureRecognizer(gesture)
-        }
-        
         bottomSheetView.do {
             $0.backgroundColor = UIColor(resource: .drWhite)
             $0.roundCorners(cornerRadius: 16, maskedCorners: [.layerMinXMinYCorner, .layerMaxXMinYCorner])
@@ -157,7 +142,7 @@ final class LocationFilterView: BaseView {
     
     @objc
     func closeLocationFilterView() {
-        delegate?.closeLocationFilterView()
+        delegate?.closeLocationFilterViewToDelegate()
     }
     
     @objc

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/Commons/LocationFilter/Views/LocationFilterViewController.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/Commons/LocationFilter/Views/LocationFilterViewController.swift
@@ -22,6 +22,8 @@ final class LocationFilterViewController: BaseViewController {
     
     // MARK: - UI Properties
     
+    private let backgroundView = UIView() // 배경 뷰 추가
+    
     private let locationFilterView = LocationFilterView()
     
     
@@ -48,17 +50,33 @@ final class LocationFilterViewController: BaseViewController {
     }
     
     override func setHierarchy() {
-        self.view.addSubview(locationFilterView)
+        self.view.addSubviews(backgroundView, locationFilterView)
     }
     
     override func setLayout() {
-        locationFilterView.snp.makeConstraints {
+        backgroundView.snp.makeConstraints {
             $0.edges.equalToSuperview()
+        }
+        
+        locationFilterView.snp.makeConstraints {
+            $0.height.equalTo(469)
+            $0.horizontalEdges.bottom.equalToSuperview()
         }
     }
     
     override func setStyle() {
-        self.view.backgroundColor = .clear
+        self.backgroundView.do {
+            $0.backgroundColor = UIColor(resource: .drBlack).withAlphaComponent(0.4)
+            $0.alpha = 0
+            let gesture = UITapGestureRecognizer(target: self, action: #selector(closeLocationFilterView))
+            $0.isUserInteractionEnabled = true
+            $0.addGestureRecognizer(gesture)
+        }
+        
+        self.locationFilterView.do {
+            $0.backgroundColor = UIColor(resource: .drWhite)
+            $0.roundCorners(cornerRadius: 16, maskedCorners: [.layerMinXMinYCorner, .layerMaxXMinYCorner])
+        }
     }
     
     func registerCell() {
@@ -114,7 +132,55 @@ final class LocationFilterViewController: BaseViewController {
         }
     }
     
+    @objc
+    func closeLocationFilterView() {
+        self.dismissBottomSheet()
+    }
+    
 }
+
+extension LocationFilterViewController {
+    
+    func presentBottomSheet(in viewController: UIViewController, animated: Bool = true, completion: (() -> Void)? = nil) {
+        self.modalPresentationStyle = .overFullScreen
+        viewController.present(self, animated: false) {
+            self.animateBottomSheetPresentation(animated: animated, completion: completion)
+        }
+    }
+    
+    func dismissBottomSheet(animated: Bool = true, completion: (() -> Void)? = nil) {
+        if animated {
+            UIView.animate(withDuration: 0.3, delay: 0, options: .curveEaseIn, animations: {
+                self.locationFilterView.transform = CGAffineTransform(translationX: 0, y: 469)
+                self.backgroundView.alpha = 0  // 배경을 페이드아웃
+            }, completion: { _ in
+                self.dismiss(animated: false, completion: completion)
+            })
+        } else {
+            self.backgroundView.alpha = 0
+            self.dismiss(animated: false, completion: completion)
+        }
+    }
+    
+    private func animateBottomSheetPresentation(animated: Bool, completion: (() -> Void)? = nil) {
+        if animated {
+            self.locationFilterView.transform = CGAffineTransform(translationX: 0, y: 469)
+            self.backgroundView.alpha = 0
+            
+            UIView.animate(withDuration: 0.3, delay: 0, options: .curveEaseOut, animations: {
+                self.backgroundView.alpha = 1
+                self.locationFilterView.transform = .identity
+            }, completion: { _ in
+                completion?()
+            })
+        } else {
+            self.backgroundView.alpha = 1
+            completion?()
+        }
+    }
+    
+}
+
 
 // MARK: - Private Methods
 
@@ -132,12 +198,8 @@ private extension LocationFilterViewController {
 
 extension LocationFilterViewController: LocationFilterViewDelegate {
     
-    func closeLocationFilterView() {
-        if self.navigationController == nil {
-            self.dismiss(animated: false)
-        } else {
-            self.navigationController?.popViewController(animated: false)
-        }
+    func closeLocationFilterViewToDelegate() {
+        self.dismissBottomSheet()
     }
     
     func didTapApplyButton() {

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/Course/Models/CourseListModel.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/Course/Models/CourseListModel.swift
@@ -7,7 +7,7 @@
 
 import UIKit
 
-struct CourseListModel {
+struct CourseListModel: Equatable {
     
     let courseId: Int?
     
@@ -31,6 +31,16 @@ struct CourseListModel {
         self.cost = cost
         self.time = time
         self.like = like
+    }
+    
+    static func == (lhs: CourseListModel, rhs: CourseListModel) -> Bool {
+        return lhs.courseId == rhs.courseId &&
+               lhs.thumbnail == rhs.thumbnail &&
+               lhs.location == rhs.location &&
+               lhs.title == rhs.title &&
+               lhs.cost == rhs.cost &&
+               lhs.time == rhs.time &&
+               lhs.like == rhs.like
     }
     
 }

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/Course/Models/CourseListModel.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/Course/Models/CourseListModel.swift
@@ -35,12 +35,12 @@ struct CourseListModel: Equatable {
     
     static func == (lhs: CourseListModel, rhs: CourseListModel) -> Bool {
         return lhs.courseId == rhs.courseId &&
-               lhs.thumbnail == rhs.thumbnail &&
-               lhs.location == rhs.location &&
-               lhs.title == rhs.title &&
-               lhs.cost == rhs.cost &&
-               lhs.time == rhs.time &&
-               lhs.like == rhs.like
+        lhs.thumbnail == rhs.thumbnail &&
+        lhs.location == rhs.location &&
+        lhs.title == rhs.title &&
+        lhs.cost == rhs.cost &&
+        lhs.time == rhs.time &&
+        lhs.like == rhs.like
     }
     
 }

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/Course/ViewModels/CourseViewModel.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/Course/ViewModels/CourseViewModel.swift
@@ -105,7 +105,6 @@ extension CourseViewModel {
                 }
                 
                 self.isSuccessGetData.value = true
-                
             case .reIssueJWT:
                 self.patchReissue { isSuccess in
                     self.onReissueSuccess.value = isSuccess

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/Course/ViewModels/CourseViewModel.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/Course/ViewModels/CourseViewModel.swift
@@ -99,8 +99,11 @@ extension CourseViewModel {
                     )
                 }
                 
-                self.courseListModel = courseModels
-                self.didUpdateCourseList?()
+                if self.courseListModel != courseModels {
+                    self.courseListModel = courseModels
+                    self.didUpdateCourseList?()
+                }
+                
                 self.isSuccessGetData.value = true
                 
             case .reIssueJWT:

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/Course/Views/CourseViewController.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/Course/Views/CourseViewController.swift
@@ -29,6 +29,8 @@ final class CourseViewController: BaseViewController {
     
     private var selectedButton: UIButton?
     
+    private var loaded: Bool = false
+    
     
     // MARK: - Life Cycle
     
@@ -102,7 +104,9 @@ final class CourseViewController: BaseViewController {
         }
         
         self.courseViewModel.onLoading.bind { [weak self] onLoading in
-            guard let onLoading, let onFailNetwork = self?.courseViewModel.onFailNetwork.value else { return }
+            guard let onLoading,
+                  let loaded = self?.loaded,
+                  let onFailNetwork = self?.courseViewModel.onFailNetwork.value else { return }
             if !onFailNetwork {
                 if !onFailNetwork {
                     if onLoading {
@@ -111,9 +115,14 @@ final class CourseViewController: BaseViewController {
                         self?.showLoadingView(type: StringLiterals.Course.course)
                     } else {
                         self?.courseView.courseListView.courseListCollectionView.reloadData()
+                        if !loaded {
+                            let initialIndexPath = IndexPath(item: 0, section: 0)
+                            self?.courseView.courseListView.courseListCollectionView.scrollToItem(at: initialIndexPath, at: .centeredHorizontally, animated: false)
+                        }
                         self?.courseView.courseListView.isHidden = false
                         self?.courseView.courseSkeletonView.isHidden = true
                         self?.hideLoadingView()
+                        self?.loaded = true
                     }
                 }
             }
@@ -143,8 +152,12 @@ final class CourseViewController: BaseViewController {
         self.courseViewModel.didUpdateCourseList = { [weak self] in
             self?.courseListModel = self?.courseViewModel.courseListModel ?? []
             
+            // 새로운 데이터 추가됐을 때 스크롤 최상단으로 올리고자 한다면
+            // 아래에 scrollToItem 코드 추가
             DispatchQueue.main.async {
-                self?.courseView.courseListView.courseListCollectionView.reloadData()
+                self?.courseView.courseListView.courseListCollectionView.performBatchUpdates({
+                    self?.courseView.courseListView.courseListCollectionView.reloadSections(IndexSet(integer: 0))
+                })
             }
         }
     }

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/Course/Views/CourseViewController.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/Course/Views/CourseViewController.swift
@@ -29,8 +29,6 @@ final class CourseViewController: BaseViewController {
     
     private var selectedButton: UIButton?
     
-    private var loaded: Bool = false
-    
     
     // MARK: - Life Cycle
     
@@ -104,8 +102,7 @@ final class CourseViewController: BaseViewController {
         }
         
         self.courseViewModel.onLoading.bind { [weak self] onLoading in
-            guard let onLoading, let loaded = self?.loaded,
-                  let onFailNetwork = self?.courseViewModel.onFailNetwork.value else { return }
+            guard let onLoading, let onFailNetwork = self?.courseViewModel.onFailNetwork.value else { return }
             
             if !onFailNetwork {
                 if !onFailNetwork {
@@ -115,14 +112,9 @@ final class CourseViewController: BaseViewController {
                         self?.showLoadingView(type: StringLiterals.Course.course)
                     } else {
                         self?.courseView.courseListView.courseListCollectionView.reloadData()
-                        if !loaded {
-                            let initialIndexPath = IndexPath(item: 0, section: 0)
-                            self?.courseView.courseListView.courseListCollectionView.scrollToItem(at: initialIndexPath, at: .centeredHorizontally, animated: false)
-                        }
                         self?.courseView.courseListView.isHidden = false
                         self?.courseView.courseSkeletonView.isHidden = true
                         self?.hideLoadingView()
-                        self?.loaded = true
                     }
                 }
             }

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/Course/Views/CourseViewController.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/Course/Views/CourseViewController.swift
@@ -104,9 +104,9 @@ final class CourseViewController: BaseViewController {
         }
         
         self.courseViewModel.onLoading.bind { [weak self] onLoading in
-            guard let onLoading,
-                  let loaded = self?.loaded,
+            guard let onLoading, let loaded = self?.loaded,
                   let onFailNetwork = self?.courseViewModel.onFailNetwork.value else { return }
+            
             if !onFailNetwork {
                 if !onFailNetwork {
                     if onLoading {

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/Course/Views/CourseViewController.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/Course/Views/CourseViewController.swift
@@ -18,6 +18,8 @@ final class CourseViewController: BaseViewController {
     
     private let courseView = CourseView()
     
+    let locationFilterVC = LocationFilterViewController()
+    
     
     // MARK: - Properties
     
@@ -165,10 +167,10 @@ extension CourseViewController {
 extension CourseViewController: CourseFilterViewDelegate {
     
     func didTapLocationFilter() {
-        let locationFilterVC = LocationFilterViewController()
-        locationFilterVC.modalPresentationStyle = .overFullScreen
         locationFilterVC.delegate = self
-        self.present(locationFilterVC, animated: true)
+        DispatchQueue.main.async {
+            self.locationFilterVC.presentBottomSheet(in: self)
+        }
     }
     
     @objc

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/CourseDetail/Models/CourseDetailModel.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/CourseDetail/Models/CourseDetailModel.swift
@@ -30,11 +30,11 @@ struct ConditionalModel: Equatable {
     
     static func == (lhs: ConditionalModel, rhs: ConditionalModel) -> Bool {
         return lhs.courseId == rhs.courseId &&
-               lhs.isCourseMine == rhs.isCourseMine &&
-               lhs.isAccess == rhs.isAccess &&
-               lhs.free == rhs.free &&
-               lhs.totalPoint == rhs.totalPoint &&
-               lhs.isUserLiked == rhs.isUserLiked
+        lhs.isCourseMine == rhs.isCourseMine &&
+        lhs.isAccess == rhs.isAccess &&
+        lhs.free == rhs.free &&
+        lhs.totalPoint == rhs.totalPoint &&
+        lhs.isUserLiked == rhs.isUserLiked
     }
     
 }

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/CourseDetail/Models/CourseDetailModel.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/CourseDetail/Models/CourseDetailModel.swift
@@ -28,6 +28,15 @@ struct ConditionalModel: Equatable {
         self.isUserLiked = isUserLiked
     }
     
+    static func == (lhs: ConditionalModel, rhs: ConditionalModel) -> Bool {
+        return lhs.courseId == rhs.courseId &&
+               lhs.isCourseMine == rhs.isCourseMine &&
+               lhs.isAccess == rhs.isAccess &&
+               lhs.free == rhs.free &&
+               lhs.totalPoint == rhs.totalPoint &&
+               lhs.isUserLiked == rhs.isUserLiked
+    }
+    
 }
 
 struct ThumbnailModel: Equatable {

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/CourseDetail/ViewModels/CourseDetailViewModel.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/CourseDetail/ViewModels/CourseDetailViewModel.swift
@@ -64,7 +64,7 @@ final class CourseDetailViewModel: Serviceable {
     var onLoading: ObservablePattern<Bool> = ObservablePattern(true)
     
     var onFailNetwork: ObservablePattern<Bool> = ObservablePattern(false)
-            
+    
     var numberOfSections: Int = 6
     
     var isChange: (() -> Void)?
@@ -130,15 +130,12 @@ extension CourseDetailViewModel {
             case .success(let data):
                 dump(data)
                 
-                let newConditionalData = ConditionalModel(
-                    courseId: self.courseId,
-                    isCourseMine: data.isCourseMine,
-                    isAccess: data.isAccess,
-                    free: data.free,
-                    totalPoint: data.totalPoint,
-                    isUserLiked: data.isUserLiked
-                )
-                
+                let newConditionalData = ConditionalModel(courseId: self.courseId,
+                                                          isCourseMine: data.isCourseMine,
+                                                          isAccess: data.isAccess,
+                                                          free: data.free,
+                                                          totalPoint: data.totalPoint,
+                                                          isUserLiked: data.isUserLiked)
                 if self.currentConditionalData != newConditionalData {
                     self.currentConditionalData = newConditionalData
                     self.conditionalData.value = newConditionalData
@@ -166,13 +163,11 @@ extension CourseDetailViewModel {
                     self.updateConditionalData.value = true
                 }
                 
-                let newTitleHeaderData = TitleHeaderModel(
-                    date: data.date,
-                    title: data.title,
-                    cost: data.totalCost,
-                    totalTime: data.totalTime,
-                    city: data.city
-                )
+                let newTitleHeaderData = TitleHeaderModel(date: data.date,
+                                                          title: data.title,
+                                                          cost: data.totalCost,
+                                                          totalTime: data.totalTime,
+                                                          city: data.city)
                 if self.currentTitleHeaderData != newTitleHeaderData {
                     self.currentTitleHeaderData = newTitleHeaderData
                     self.titleHeaderData.value = newTitleHeaderData
@@ -187,12 +182,9 @@ extension CourseDetailViewModel {
                 }
                 
                 let newTimelineData = data.places.map { place in
-                    TimelineModel(
-                        sequence: place.sequence,
-                        title: place.title,
-                        duration: Float(place.duration)
-                    )
-                }
+                    TimelineModel(sequence: place.sequence,
+                                  title: place.title,
+                                  duration: Float(place.duration)) }
                 if self.currentTimelineData != newTimelineData {
                     self.currentTimelineData = newTimelineData
                     self.timelineData.value = newTimelineData
@@ -224,7 +216,6 @@ extension CourseDetailViewModel {
                         StringLiterals.Amplitude.Property.courseListTitle: self.courseListTitle
                     ]
                 )
-                
             case .reIssueJWT:
                 self.patchReissue { isSuccess in
                     self.onReissueSuccess.value = isSuccess
@@ -273,7 +264,7 @@ extension CourseDetailViewModel {
             completion(success)
         }
     }
-
+    
     func setLoading() {
         guard let isSuccessGetData = self.isSuccessGetData.value else { return }
         self.onLoading.value = !isSuccessGetData

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/CourseDetail/ViewModels/CourseDetailViewModel.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/CourseDetail/ViewModels/CourseDetailViewModel.swift
@@ -166,7 +166,13 @@ extension CourseDetailViewModel {
                     self.updateConditionalData.value = true
                 }
                 
-                let newTitleHeaderData = TitleHeaderModel(date: data.date, title: data.title, cost: data.totalCost, totalTime: data.totalTime, city: data.city)
+                let newTitleHeaderData = TitleHeaderModel(
+                    date: data.date,
+                    title: data.title,
+                    cost: data.totalCost,
+                    totalTime: data.totalTime,
+                    city: data.city
+                )
                 if self.currentTitleHeaderData != newTitleHeaderData {
                     self.currentTitleHeaderData = newTitleHeaderData
                     self.titleHeaderData.value = newTitleHeaderData
@@ -181,7 +187,11 @@ extension CourseDetailViewModel {
                 }
                 
                 let newTimelineData = data.places.map { place in
-                    TimelineModel(sequence: place.sequence, title: place.title, duration: Float(place.duration))
+                    TimelineModel(
+                        sequence: place.sequence,
+                        title: place.title,
+                        duration: Float(place.duration)
+                    )
                 }
                 if self.currentTimelineData != newTimelineData {
                     self.currentTimelineData = newTimelineData

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/CourseDetail/Views/CourseDetailViewController.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/CourseDetail/Views/CourseDetailViewController.swift
@@ -144,6 +144,18 @@ final class CourseDetailViewController: BaseViewController {
     }
     
     func bindViewModel() {
+        self.courseDetailViewModel.updateConditionalData.bind { [weak self] flag in
+            guard let flag else { return }
+            if flag {
+                DispatchQueue.main.async {
+                    self?.courseDetailView.mainCollectionView.performBatchUpdates({
+                        self?.courseDetailView.mainCollectionView.reloadData()
+                    })
+                }
+                self?.courseDetailViewModel.updateConditionalData.value = false
+            }
+        }
+        
         self.courseDetailViewModel.onFailNetwork.bind { [weak self] onFailure in
             guard let onFailure else { return }
             if onFailure {

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/CourseDetail/Views/CourseDetailViewController.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/CourseDetail/Views/CourseDetailViewController.swift
@@ -24,12 +24,10 @@ final class CourseDetailViewController: BaseViewController {
     
     private let skeletonView: CourseDetailSkeletonView = CourseDetailSkeletonView()
     
-    lazy var bottomSheetVC = DRBottomSheetViewController(
-        contentView: deleteCourseSettingView,
-        height: 210,
-        buttonType: DisabledButton(),
-        buttonTitle: StringLiterals.Common.close
-    )
+    lazy var bottomSheetVC = DRBottomSheetViewController(contentView: deleteCourseSettingView,
+                                                         height: 210,
+                                                         buttonType: DisabledButton(),
+                                                         buttonTitle: StringLiterals.Common.close)
     
     
     // MARK: - Properties
@@ -84,7 +82,9 @@ final class CourseDetailViewController: BaseViewController {
     override func setHierarchy() {
         super.setHierarchy()
         
-        self.view.addSubviews(courseDetailView, courseInfoTabBarView, skeletonView)
+        self.view.addSubviews(courseDetailView,
+                              courseInfoTabBarView,
+                              skeletonView)
     }
     
     override func setLayout() {

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/CourseDetail/Views/CourseDetailViewController.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/CourseDetail/Views/CourseDetailViewController.swift
@@ -396,7 +396,7 @@ extension CourseDetailViewController: StickyHeaderNavBarViewDelegate, DRBottomSh
         deleteCourseSettingView.deleteLabel.text = courseDetailViewModel.isCourseMine.value == true ? StringLiterals.CourseDetail.deleteCourse : StringLiterals.CourseDetail.delclareCourse
         
         DispatchQueue.main.async {
-        self.bottomSheetVC.presentBottomSheet(in: self)
+            self.bottomSheetVC.presentBottomSheet(in: self)
         }
     }
     

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/CourseDetail/Views/CourseDetailViewController.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/CourseDetail/Views/CourseDetailViewController.swift
@@ -24,6 +24,13 @@ final class CourseDetailViewController: BaseViewController {
     
     private let skeletonView: CourseDetailSkeletonView = CourseDetailSkeletonView()
     
+    lazy var bottomSheetVC = DRBottomSheetViewController(
+        contentView: deleteCourseSettingView,
+        height: 210,
+        buttonType: DisabledButton(),
+        buttonTitle: StringLiterals.Common.close
+    )
+    
     
     // MARK: - Properties
     
@@ -373,20 +380,16 @@ extension CourseDetailViewController: StickyHeaderNavBarViewDelegate, DRBottomSh
     }
     
     func didTapMoreButton() {
-        let bottomSheetVC = DRBottomSheetViewController(
-            contentView: deleteCourseSettingView,
-            height: 210,
-            buttonType: DisabledButton(),
-            buttonTitle: StringLiterals.Common.close
-        )
         bottomSheetVC.delegate = self
         deleteCourseSettingView.deleteLabel.text = courseDetailViewModel.isCourseMine.value == true ? StringLiterals.CourseDetail.deleteCourse : StringLiterals.CourseDetail.delclareCourse
-        bottomSheetVC.modalPresentationStyle = .overFullScreen
-        present(bottomSheetVC, animated: true)
+        
+        DispatchQueue.main.async {
+        self.bottomSheetVC.presentBottomSheet(in: self)
+        }
     }
     
     func didTapBottomButton() {
-        self.dismiss(animated: true)
+        self.bottomSheetVC.dismissBottomSheet()
     }
     
 }

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/DateSchedule/View/PastDateDetailViewController.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/DateSchedule/View/PastDateDetailViewController.swift
@@ -18,12 +18,10 @@ final class PastDateDetailViewController: BaseNavBarViewController {
     
     private let errorView: DRErrorViewController = DRErrorViewController()
     
-    lazy var bottomSheetVC = DRBottomSheetViewController(
-        contentView: dateScheduleDeleteView,
-        height: 222,
-        buttonType: DisabledButton(),
-        buttonTitle: StringLiterals.DateSchedule.quit
-    )
+    lazy var bottomSheetVC = DRBottomSheetViewController(contentView: dateScheduleDeleteView,
+                                                         height: 222,
+                                                         buttonType: DisabledButton(),
+                                                         buttonTitle: StringLiterals.DateSchedule.quit)
     
     
     // MARK: - Properties
@@ -31,7 +29,7 @@ final class PastDateDetailViewController: BaseNavBarViewController {
     var index: Int
     
     var dateID: Int
-        
+    
     var pastDateDetailViewModel: DateDetailViewModel
     
     private let dateScheduleDeleteView = DateScheduleDeleteView()
@@ -74,7 +72,7 @@ final class PastDateDetailViewController: BaseNavBarViewController {
     override func setHierarchy() {
         super.setHierarchy()
         
-        contentView.addSubviews(pastDateDetailContentView)
+        contentView.addSubview(pastDateDetailContentView)
     }
     
     override func setLayout() {
@@ -174,9 +172,9 @@ extension PastDateDetailViewController {
         }
         
         self.pastDateDetailViewModel.onReissueSuccess.bind { [weak self] onSuccess in
-            guard let onSuccess, 
+            guard let onSuccess,
                     let dateID = self?.dateID,
-                    let type = self?.pastDateDetailViewModel.type.value
+                  let type = self?.pastDateDetailViewModel.type.value
             else { return }
             if onSuccess {
                 switch type {

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/DateSchedule/View/PastDateDetailViewController.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/DateSchedule/View/PastDateDetailViewController.swift
@@ -18,7 +18,12 @@ final class PastDateDetailViewController: BaseNavBarViewController {
     
     private let errorView: DRErrorViewController = DRErrorViewController()
     
-    lazy var bottomSheetVC = DRBottomSheetViewController(contentView: dateScheduleDeleteView, height: 222, buttonType: DisabledButton(), buttonTitle: StringLiterals.DateSchedule.quit)
+    lazy var bottomSheetVC = DRBottomSheetViewController(
+        contentView: dateScheduleDeleteView,
+        height: 222,
+        buttonType: DisabledButton(),
+        buttonTitle: StringLiterals.DateSchedule.quit
+    )
     
     
     // MARK: - Properties

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/DateSchedule/View/PastDateDetailViewController.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/DateSchedule/View/PastDateDetailViewController.swift
@@ -149,9 +149,6 @@ extension PastDateDetailViewController {
             if flag {
                 guard let data = self?.pastDateDetailViewModel.dateDetailData.value else { return }
                 DispatchQueue.main.async {
-                    self?.pastDateDetailContentView.dataBind(data)
-                    self?.pastDateDetailViewModel.setDateDetailLoading()
-                    
                     self?.pastDateDetailContentView.dateTimeLineCollectionView.reloadData()
                 }
                 self?.pastDateDetailViewModel.updateDateDetailData.value = false

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/DateSchedule/View/PastDateDetailViewController.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/DateSchedule/View/PastDateDetailViewController.swift
@@ -139,6 +139,20 @@ extension PastDateDetailViewController: DRBottomSheetDelegate {
 extension PastDateDetailViewController {
     
     func bindViewModel() {
+        self.pastDateDetailViewModel.updateDateDetailData.bind { [weak self] flag in
+            guard let flag else { return }
+            if flag {
+                guard let data = self?.pastDateDetailViewModel.dateDetailData.value else { return }
+                DispatchQueue.main.async {
+                    self?.pastDateDetailContentView.dataBind(data)
+                    self?.pastDateDetailViewModel.setDateDetailLoading()
+                    
+                    self?.pastDateDetailContentView.dateTimeLineCollectionView.reloadData()
+                }
+                self?.pastDateDetailViewModel.updateDateDetailData.value = false
+            }
+        }
+        
         self.pastDateDetailViewModel.onDateDetailLoading.bind { [weak self] onLoading in
             guard let onLoading,
                   let onFailNetwork = self?.pastDateDetailViewModel.onFailNetwork.value,

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/DateSchedule/View/PastDateDetailViewController.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/DateSchedule/View/PastDateDetailViewController.swift
@@ -18,6 +18,8 @@ final class PastDateDetailViewController: BaseNavBarViewController {
     
     private let errorView: DRErrorViewController = DRErrorViewController()
     
+    lazy var bottomSheetVC = DRBottomSheetViewController(contentView: dateScheduleDeleteView, height: 222, buttonType: DisabledButton(), buttonTitle: StringLiterals.DateSchedule.quit)
+    
     
     // MARK: - Properties
     
@@ -109,17 +111,18 @@ extension PastDateDetailViewController: DRCustomAlertDelegate {
 extension PastDateDetailViewController: DRBottomSheetDelegate {
     
     func didTapBottomButton() {
-        self.dismiss(animated: false)
+        self.bottomSheetVC.dismissBottomSheet()
     }
     
     @objc
     private func deleteDateCourse() {
         let labelTap = UITapGestureRecognizer(target: self, action: #selector(didTapFirstLabel))
         dateScheduleDeleteView.deleteLabel.addGestureRecognizer(labelTap)
-        let bottomSheetVC = DRBottomSheetViewController(contentView: dateScheduleDeleteView, height: 222, buttonType: DisabledButton(), buttonTitle: StringLiterals.DateSchedule.quit)
-        bottomSheetVC.modalPresentationStyle = .overFullScreen
         bottomSheetVC.delegate = self
-        self.present(bottomSheetVC, animated: false)
+        
+        DispatchQueue.main.async {
+            self.bottomSheetVC.presentBottomSheet(in: self)
+        }
     }
     
     @objc

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/DateSchedule/View/PastDateViewController.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/DateSchedule/View/PastDateViewController.swift
@@ -83,6 +83,18 @@ private extension PastDateViewController {
     }
     
     func bindViewModel() {
+        self.pastDateScheduleViewModel.updatePastDateScheduleData.bind { [weak self] flag in
+            guard let flag else { return }
+            if flag {
+                DispatchQueue.main.async {
+                    self?.pastDateContentView.pastDateCollectionView.performBatchUpdates({
+                        self?.pastDateContentView.pastDateCollectionView.reloadData()
+                    })
+                }
+                self?.pastDateScheduleViewModel.updatePastDateScheduleData.value = false
+            }
+        }
+        
         self.pastDateScheduleViewModel.onPastScheduleFailNetwork.bind { [weak self] onFailure in
             guard let onFailure else { return }
             if onFailure {

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/DateSchedule/View/UpcomingDateDetailViewController.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/DateSchedule/View/UpcomingDateDetailViewController.swift
@@ -18,7 +18,12 @@ final class UpcomingDateDetailViewController: BaseNavBarViewController {
     
     private let errorView: DRErrorViewController = DRErrorViewController()
     
-    lazy var bottomSheetVC = DRBottomSheetViewController(contentView: dateScheduleDeleteView, height: 222, buttonType: DisabledButton(), buttonTitle: StringLiterals.DateSchedule.quit)
+    lazy var bottomSheetVC = DRBottomSheetViewController(
+        contentView: dateScheduleDeleteView,
+        height: 222,
+        buttonType: DisabledButton(),
+        buttonTitle: StringLiterals.DateSchedule.quit
+    )
     
     
     // MARK: - Properties

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/DateSchedule/View/UpcomingDateDetailViewController.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/DateSchedule/View/UpcomingDateDetailViewController.swift
@@ -102,9 +102,6 @@ extension UpcomingDateDetailViewController {
             if flag {
                 guard let data = self?.upcomingDateDetailViewModel.dateDetailData.value else { return }
                 DispatchQueue.main.async {
-                    self?.upcomingDateDetailContentView.dataBind(data)
-                    self?.upcomingDateDetailViewModel.setDateDetailLoading()
-                    
                     self?.upcomingDateDetailContentView.dateTimeLineCollectionView.reloadData()
                 }
                 self?.upcomingDateDetailViewModel.updateDateDetailData.value = false

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/DateSchedule/View/UpcomingDateDetailViewController.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/DateSchedule/View/UpcomingDateDetailViewController.swift
@@ -92,6 +92,20 @@ final class UpcomingDateDetailViewController: BaseNavBarViewController {
 extension UpcomingDateDetailViewController {
     
     func bindViewModel() {
+        self.upcomingDateDetailViewModel.updateDateDetailData.bind { [weak self] flag in
+            guard let flag else { return }
+            if flag {
+                guard let data = self?.upcomingDateDetailViewModel.dateDetailData.value else { return }
+                DispatchQueue.main.async {
+                    self?.upcomingDateDetailContentView.dataBind(data)
+                    self?.upcomingDateDetailViewModel.setDateDetailLoading()
+                    
+                    self?.upcomingDateDetailContentView.dateTimeLineCollectionView.reloadData()
+                }
+                self?.upcomingDateDetailViewModel.updateDateDetailData.value = false
+            }
+        }
+        
         self.upcomingDateDetailViewModel.onDateDetailLoading.bind { [weak self] onLoading in
             guard let onLoading,
                   let onFailNetwork = self?.upcomingDateDetailViewModel.onFailNetwork.value,

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/DateSchedule/View/UpcomingDateDetailViewController.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/DateSchedule/View/UpcomingDateDetailViewController.swift
@@ -18,6 +18,8 @@ final class UpcomingDateDetailViewController: BaseNavBarViewController {
     
     private let errorView: DRErrorViewController = DRErrorViewController()
     
+    lazy var bottomSheetVC = DRBottomSheetViewController(contentView: dateScheduleDeleteView, height: 222, buttonType: DisabledButton(), buttonTitle: StringLiterals.DateSchedule.quit)
+    
     
     // MARK: - Properties
     
@@ -225,17 +227,18 @@ extension UpcomingDateDetailViewController: DRCustomAlertDelegate {
 extension UpcomingDateDetailViewController: DRBottomSheetDelegate {
     
     func didTapBottomButton() {
-        self.dismiss(animated: false)
+        self.bottomSheetVC.dismissBottomSheet()
     }
     
     @objc
     private func deleteDateCourse() {
         let labelTap = UITapGestureRecognizer(target: self, action: #selector(didTapFirstLabel))
         dateScheduleDeleteView.deleteLabel.addGestureRecognizer(labelTap)
-        let bottomSheetVC = DRBottomSheetViewController(contentView: dateScheduleDeleteView, height: 222, buttonType: DisabledButton(), buttonTitle: StringLiterals.DateSchedule.quit)
-        bottomSheetVC.modalPresentationStyle = .overFullScreen
         bottomSheetVC.delegate = self
-        self.present(bottomSheetVC, animated: false)
+        
+        DispatchQueue.main.async {
+            self.bottomSheetVC.presentBottomSheet(in: self)
+        }
     }
     
     @objc

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/DateSchedule/View/UpcomingDateDetailViewController.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/DateSchedule/View/UpcomingDateDetailViewController.swift
@@ -18,12 +18,10 @@ final class UpcomingDateDetailViewController: BaseNavBarViewController {
     
     private let errorView: DRErrorViewController = DRErrorViewController()
     
-    lazy var bottomSheetVC = DRBottomSheetViewController(
-        contentView: dateScheduleDeleteView,
-        height: 222,
-        buttonType: DisabledButton(),
-        buttonTitle: StringLiterals.DateSchedule.quit
-    )
+    lazy var bottomSheetVC = DRBottomSheetViewController(contentView: dateScheduleDeleteView,
+                                                         height: 222,
+                                                         buttonType: DisabledButton(),
+                                                         buttonTitle: StringLiterals.DateSchedule.quit)
     
     
     // MARK: - Properties
@@ -111,7 +109,7 @@ extension UpcomingDateDetailViewController {
         self.upcomingDateDetailViewModel.onDateDetailLoading.bind { [weak self] onLoading in
             guard let onLoading,
                   let onFailNetwork = self?.upcomingDateDetailViewModel.onFailNetwork.value,
-                  let index = self?.index 
+                  let index = self?.index
             else { return }
             if !onFailNetwork {
                 if onLoading {

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/DateSchedule/View/UpcomingDateScheduleViewController.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/DateSchedule/View/UpcomingDateScheduleViewController.swift
@@ -90,6 +90,18 @@ private extension UpcomingDateScheduleViewController {
     }
     
     func bindViewModel() {
+        self.upcomingDateScheduleViewModel.updateUpcomingDateScheduleData.bind { [weak self] flag in
+            guard let flag else { return }
+            if flag {
+                DispatchQueue.main.async {
+                    self?.upcomingDateScheduleView.cardCollectionView.performBatchUpdates({
+                        self?.upcomingDateScheduleView.cardCollectionView.reloadSections(IndexSet(integer: 0))
+                    })
+                }
+                self?.upcomingDateScheduleViewModel.updateUpcomingDateScheduleData.value = false
+            }
+        }
+        
         self.upcomingDateScheduleViewModel.onUpcomingScheduleLoading.bind { [weak self] onLoading in
             guard let onLoading, let onFailNetwork = self?.upcomingDateScheduleViewModel.onUpcomingScheduleFailNetwork.value else { return }
             if !onFailNetwork {

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/DateSchedule/View/UpcomingDateScheduleViewController.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/DateSchedule/View/UpcomingDateScheduleViewController.swift
@@ -17,7 +17,7 @@ final class UpcomingDateScheduleViewController: BaseViewController {
     private var upcomingDateScheduleView = UpcomingDateScheduleView()
     
     private let errorView: DRErrorViewController = DRErrorViewController()
-        
+    
     
     // MARK: - Properties
     

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/DateSchedule/ViewModel/DateDetailViewModel.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/DateSchedule/ViewModel/DateDetailViewModel.swift
@@ -71,22 +71,19 @@ extension DateDetailViewModel {
                 let tagsInfo: [TagsModel] = data.tags.map { tag in
                     TagsModel(tag: tag.tag)
                 }
+                
                 let datePlaceInfo: [DatePlaceModel] = data.places.map { place in
                     DatePlaceModel(name: place.title, duration: (place.duration).formatFloatTime(), sequence: place.sequence)
                 }
-                let newDateDetailData = DateDetailModel(
-                    dateID: data.dateID,
-                    title: data.title,
-                    startAt: data.startAt,
-                    city: data.city,
-                    tags: tagsInfo,
-                    date: data.date.formatDateFromString(
-                        inputFormat: "yyyy.MM.dd",
-                        outputFormat: "yyyy년 M월 d일"
-                    ) ?? "",
-                    places: datePlaceInfo,
-                    dDay: data.dDay
-                )
+                
+                let newDateDetailData = DateDetailModel(dateID: data.dateID,
+                                                        title: data.title,
+                                                        startAt: data.startAt,
+                                                        city: data.city,
+                                                        tags: tagsInfo,
+                                                        date: data.date.formatDateFromString(inputFormat: "yyyy.MM.dd", outputFormat: "yyyy년 M월 d일") ?? "",
+                                                        places: datePlaceInfo,
+                                                        dDay: data.dDay)
                 
                 // 기존 데이터와 비교 이후 동작
                 if self.currentDateDetailData != newDateDetailData {

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/DateSchedule/ViewModel/DateDetailViewModel.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/DateSchedule/ViewModel/DateDetailViewModel.swift
@@ -103,8 +103,6 @@ extension DateDetailViewModel {
             default:
                 self.onFailNetwork.value = true
             }
-            
-            self.setDateDetailLoading()
         }
     }
     

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/DateSchedule/ViewModel/DateDetailViewModel.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/DateSchedule/ViewModel/DateDetailViewModel.swift
@@ -89,12 +89,12 @@ extension DateDetailViewModel {
                 if self.currentDateDetailData != newDateDetailData {
                     self.currentDateDetailData = newDateDetailData
                     self.dateDetailData.value = newDateDetailData
-                    self.isSuccessGetDateDetailData.value = true
                     self.dateCourseNum = newDateDetailData.places.count
                     self.dateTotalDuration = datePlaceInfo.map { Float($0.duration) ?? 0 }.reduce(0, +)
                     self.updateDateDetailData.value = true
                 }
                 
+                self.isSuccessGetDateDetailData.value = true
             case .reIssueJWT:
                 self.patchReissue { isSuccess in
                     self.type.value = NetworkType.getDateDetail

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/DateSchedule/ViewModel/DateDetailViewModel.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/DateSchedule/ViewModel/DateDetailViewModel.swift
@@ -15,6 +15,10 @@ import KakaoSDKUser
 
 final class DateDetailViewModel: Serviceable {
     
+    private var currentDateDetailData: DateDetailModel?
+    
+    let updateDateDetailData: ObservablePattern<Bool> = ObservablePattern(false)
+    
     var type: ObservablePattern<NetworkType> = ObservablePattern(nil)
     
     var onReissueSuccess: ObservablePattern<Bool> = ObservablePattern(nil)
@@ -55,6 +59,7 @@ final class DateDetailViewModel: Serviceable {
 
 extension DateDetailViewModel {
     
+    // '지난 데이트 상세보기' or '다가올 데이트 상세보기' 데이터 .get
     func getDateDetailData(dateID: Int) {
         self.isSuccessGetDateDetailData.value = false
         self.setDateDetailLoading()
@@ -69,18 +74,30 @@ extension DateDetailViewModel {
                 let datePlaceInfo: [DatePlaceModel] = data.places.map { place in
                     DatePlaceModel(name: place.title, duration: (place.duration).formatFloatTime(), sequence: place.sequence)
                 }
-                self.dateDetailData.value = DateDetailModel(dateID: data.dateID,
-                                                            title: data.title,
-                                                            startAt: data.startAt,
-                                                            city: data.city,
-                                                            tags: tagsInfo,
-                                                            date: data.date.formatDateFromString(inputFormat: "yyyy.MM.dd",
-                                                                                                 outputFormat: "yyyy년 M월 d일") ?? "",
-                                                            places: datePlaceInfo,
-                                                            dDay: data.dDay)
-                self.isSuccessGetDateDetailData.value = true
-                self.dateCourseNum = self.dateDetailData.value?.places.count ?? 0
-                self.dateTotalDuration = datePlaceInfo.map { Float($0.duration) ?? 0 }.reduce(0, +)
+                let newDateDetailData = DateDetailModel(
+                    dateID: data.dateID,
+                    title: data.title,
+                    startAt: data.startAt,
+                    city: data.city,
+                    tags: tagsInfo,
+                    date: data.date.formatDateFromString(
+                        inputFormat: "yyyy.MM.dd",
+                        outputFormat: "yyyy년 M월 d일"
+                    ) ?? "",
+                    places: datePlaceInfo,
+                    dDay: data.dDay
+                )
+                
+                // 기존 데이터와 비교 이후 동작
+                if self.currentDateDetailData != newDateDetailData {
+                    self.currentDateDetailData = newDateDetailData
+                    self.dateDetailData.value = newDateDetailData
+                    self.isSuccessGetDateDetailData.value = true
+                    self.dateCourseNum = newDateDetailData.places.count
+                    self.dateTotalDuration = datePlaceInfo.map { Float($0.duration) ?? 0 }.reduce(0, +)
+                    self.updateDateDetailData.value = true
+                }
+                
             case .reIssueJWT:
                 self.patchReissue { isSuccess in
                     self.type.value = NetworkType.getDateDetail
@@ -89,6 +106,8 @@ extension DateDetailViewModel {
             default:
                 self.onFailNetwork.value = true
             }
+            
+            self.setDateDetailLoading()
         }
     }
     

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/DateSchedule/ViewModel/DateScheduleViewModel.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/DateSchedule/ViewModel/DateScheduleViewModel.swift
@@ -9,6 +9,10 @@ import Foundation
 
 final class DateScheduleViewModel: Serviceable {
     
+    let updatePastDateScheduleData: ObservablePattern<Bool> = ObservablePattern(false)
+    
+    let updateUpcomingDateScheduleData: ObservablePattern<Bool> = ObservablePattern(false)
+    
     var onReissueSuccess: ObservablePattern<Bool> = ObservablePattern(nil)
     
     var upcomingDateScheduleData: ObservablePattern<[DateCardModel]> = ObservablePattern(nil)
@@ -37,6 +41,7 @@ final class DateScheduleViewModel: Serviceable {
         getUpcomingDateScheduleData()
     }
     
+    // 지난 데이트 일정 (상세보기X)
     func getPastDateScheduleData() {
         self.isSuccessGetPastDateScheduleData.value = false
         self.setPastScheduleLoading()
@@ -49,15 +54,21 @@ final class DateScheduleViewModel: Serviceable {
                     let tagsModel: [TagsModel] = date.tags.map { tag in
                         TagsModel(tag: tag.tag)
                     }
-                    return DateCardModel(dateID: date.dateID,
-                                         title: date.title,
-                                         date: date.date.formatDateFromString(inputFormat: "yyyy.MM.dd", outputFormat: "yyyy년 M월 d일") ?? "",
-                                         city: date.city,
-                                         tags: tagsModel,
-                                         dDay: date.dDay)
+                    return DateCardModel(
+                        dateID: date.dateID,
+                        title: date.title,
+                        date: date.date.formatDateFromString(inputFormat: "yyyy.MM.dd", outputFormat: "yyyy년 M월 d일") ?? "",
+                        city: date.city,
+                        tags: tagsModel,
+                        dDay: date.dDay
+                    )
                 }
                 
-                self.pastDateScheduleData.value = dateScheduleInfo
+                if self.pastDateScheduleData.value != dateScheduleInfo {
+                    self.pastDateScheduleData.value = dateScheduleInfo
+                    self.updatePastDateScheduleData.value = true
+                }
+                
                 self.isSuccessGetPastDateScheduleData.value = true
             case .reIssueJWT:
                 self.patchReissue { isSuccess in
@@ -74,6 +85,7 @@ final class DateScheduleViewModel: Serviceable {
         self.onPastScheduleLoading.value = !isSuccessGetPastDateScheduleData
     }
     
+    // 다가올 데이트 일정 (상세보기X)
     func getUpcomingDateScheduleData() {
         self.isSuccessGetUpcomingDateScheduleData.value = false
         self.setUpcomingScheduleLoading()
@@ -97,7 +109,12 @@ final class DateScheduleViewModel: Serviceable {
                 AmplitudeManager.shared.setUserProperty(userProperties: [StringLiterals.Amplitude.UserProperty.dateScheduleNum : dateScheduleInfo.count])
                 AmplitudeManager.shared.trackEvent(StringLiterals.Amplitude.EventName.viewDateSchedule)
                 AmplitudeManager.shared.trackEventWithProperties(StringLiterals.Amplitude.EventName.countDateSchedule, properties: [StringLiterals.Amplitude.Property.dateScheduleNum : dateScheduleNum])
-                self.upcomingDateScheduleData.value = dateScheduleInfo
+                
+                if self.upcomingDateScheduleData.value != dateScheduleInfo {
+                    self.upcomingDateScheduleData.value = dateScheduleInfo
+                    self.updateUpcomingDateScheduleData.value = true
+                }
+                
                 self.isSuccessGetUpcomingDateScheduleData.value = true
             case .reIssueJWT:
                 self.patchReissue { isSuccess in

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/DateSchedule/ViewModel/DateScheduleViewModel.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/DateSchedule/ViewModel/DateScheduleViewModel.swift
@@ -54,14 +54,12 @@ final class DateScheduleViewModel: Serviceable {
                     let tagsModel: [TagsModel] = date.tags.map { tag in
                         TagsModel(tag: tag.tag)
                     }
-                    return DateCardModel(
-                        dateID: date.dateID,
-                        title: date.title,
-                        date: date.date.formatDateFromString(inputFormat: "yyyy.MM.dd", outputFormat: "yyyy년 M월 d일") ?? "",
-                        city: date.city,
-                        tags: tagsModel,
-                        dDay: date.dDay
-                    )
+                    return DateCardModel(dateID: date.dateID,
+                                         title: date.title,
+                                         date: date.date.formatDateFromString(inputFormat: "yyyy.MM.dd", outputFormat: "yyyy년 M월 d일") ?? "",
+                                         city: date.city,
+                                         tags: tagsModel,
+                                         dDay: date.dDay)
                 }
                 
                 if self.pastDateScheduleData.value != dateScheduleInfo {

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/DateSchedule/ViewModel/DateScheduleViewModel.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/DateSchedule/ViewModel/DateScheduleViewModel.swift
@@ -96,7 +96,7 @@ final class DateScheduleViewModel: Serviceable {
                     let tagsModel: [TagsModel] = date.tags.map { tag in
                         TagsModel(tag: tag.tag)
                     }
-                    return DateCardModel(dateID: date.dateID, 
+                    return DateCardModel(dateID: date.dateID,
                                          title: date.title,
                                          date: (date.date).toReadableDate() ?? "",
                                          city: date.city ,

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/MyCourse/Models/MyCourseListModel.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/MyCourse/Models/MyCourseListModel.swift
@@ -44,3 +44,27 @@ struct MyCourseModel: Equatable  {
     }
     
 }
+
+// ViewedCoursesModel 싱글톤
+class ViewedCoursesManager {
+    static let shared = ViewedCoursesManager()
+    var viewedCoursesModel: [MyCourseModel] = []
+    
+    private init() {}
+}
+
+// BroughtViewedCoursesModel 싱글톤
+class BroughtViewedCoursesManager {
+    static let shared = BroughtViewedCoursesManager()
+    var broughtViewedCoursesModel: [MyCourseModel] = []
+    
+    private init() {}
+}
+
+// MyRegisterCoursesManager 싱글톤
+class MyRegisterCoursesManager {
+    static let shared = MyRegisterCoursesManager()
+    var myRegisterCoursesModel: [MyCourseModel] = []
+    
+    private init() {}
+}

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/MyCourse/Models/MyCourseListModel.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/MyCourse/Models/MyCourseListModel.swift
@@ -47,24 +47,33 @@ struct MyCourseModel: Equatable  {
 
 // ViewedCoursesModel 싱글톤
 class ViewedCoursesManager {
+    
     static let shared = ViewedCoursesManager()
+    
     var viewedCoursesModel: [MyCourseModel] = []
     
     private init() {}
+    
 }
 
 // BroughtViewedCoursesModel 싱글톤
 class BroughtViewedCoursesManager {
+    
     static let shared = BroughtViewedCoursesManager()
+    
     var broughtViewedCoursesModel: [MyCourseModel] = []
     
     private init() {}
+    
 }
 
 // MyRegisterCoursesManager 싱글톤
 class MyRegisterCoursesManager {
+    
     static let shared = MyRegisterCoursesManager()
+    
     var myRegisterCoursesModel: [MyCourseModel] = []
     
     private init() {}
+    
 }

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/MyCourse/ViewModels/MyCourseListViewModel.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/MyCourse/ViewModels/MyCourseListViewModel.swift
@@ -15,9 +15,9 @@ final class MyCourseListViewModel: Serviceable {
     
     var myRegisterCoursesModel = MyRegisterCoursesManager.shared.myRegisterCoursesModel
     
-    var broughtViewedCoursesModelIsUpdate: ObservablePattern<Bool> = ObservablePattern(nil)
-    
     var viewedCoursesModelIsUpdate: ObservablePattern<Bool> = ObservablePattern(nil)
+    
+    var broughtViewedCoursesModelIsUpdate: ObservablePattern<Bool> = ObservablePattern(nil)
     
     var myRegisterCoursesModelIsUpdate: ObservablePattern<Bool> = ObservablePattern(nil)
     
@@ -70,9 +70,9 @@ final class MyCourseListViewModel: Serviceable {
                 AmplitudeManager.shared.setUserProperty(userProperties: [StringLiterals.Amplitude.UserProperty.userPurchaseCount: viewedCourseInfo.count])
                 
                 if self.viewedCoursesModel != viewedCourseInfo {
-                    self.viewedCoursesModelIsUpdate.value = true
                     self.viewedCourseData.value = viewedCourseInfo
                     self.viewedCoursesModel = viewedCourseInfo
+                    self.viewedCoursesModelIsUpdate.value = true
                 }
                 
                 self.isSuccessGetViewedCourseInfo.value = true
@@ -111,9 +111,9 @@ final class MyCourseListViewModel: Serviceable {
                 ) }
                 
                 if self.broughtViewedCoursesModel != viewedCourseInfo {
-                    self.broughtViewedCoursesModelIsUpdate.value = true
                     self.viewedCourseData.value = viewedCourseInfo
                     self.broughtViewedCoursesModel = viewedCourseInfo
+                    self.broughtViewedCoursesModelIsUpdate.value = true
                 }
                 
                 self.isSuccessGetNavViewedCourseInfo.value = true
@@ -153,10 +153,11 @@ final class MyCourseListViewModel: Serviceable {
                 AmplitudeManager.shared.setUserProperty(userProperties: [StringLiterals.Amplitude.UserProperty.userCourseCount: myRegisterCourseInfo.count])
                 
                 if self.myRegisterCoursesModel != myRegisterCourseInfo {
-                    self.myRegisterCoursesModelIsUpdate.value = true
                     self.myRegisterCourseData.value = myRegisterCourseInfo
                     self.myRegisterCoursesModel = myRegisterCourseInfo
+                    self.myRegisterCoursesModelIsUpdate.value = true
                 }
+                
                 self.isSuccessGetMyRegisterCourseInfo.value = true
             case .reIssueJWT:
                 self.patchReissue { isSuccess in

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/MyCourse/ViewModels/MyCourseListViewModel.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/MyCourse/ViewModels/MyCourseListViewModel.swift
@@ -10,7 +10,7 @@ import Foundation
 final class MyCourseListViewModel: Serviceable {
     
     var viewedCoursesModel = ViewedCoursesManager.shared.viewedCoursesModel
-
+    
     var broughtViewedCoursesModel = BroughtViewedCoursesManager.shared.broughtViewedCoursesModel
     
     var myRegisterCoursesModel = MyRegisterCoursesManager.shared.myRegisterCoursesModel

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/MyCourse/ViewModels/MyCourseListViewModel.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/MyCourse/ViewModels/MyCourseListViewModel.swift
@@ -58,15 +58,13 @@ final class MyCourseListViewModel: Serviceable {
         NetworkService.shared.myCourseService.getViewedCourse() { response in
             switch response {
             case .success(let data):
-                let viewedCourseInfo = data.courses.map { MyCourseModel(
-                    courseId: $0.courseID,
-                    thumbnail: $0.thumbnail,
-                    title: $0.title,
-                    city: $0.city,
-                    cost: $0.cost.priceRangeTag(),
-                    duration: ($0.duration).formatFloatTime(),
-                    like: $0.like
-                ) }
+                let viewedCourseInfo = data.courses.map { MyCourseModel(courseId: $0.courseID,
+                                                                        thumbnail: $0.thumbnail,
+                                                                        title: $0.title,
+                                                                        city: $0.city,
+                                                                        cost: $0.cost.priceRangeTag(),
+                                                                        duration: ($0.duration).formatFloatTime(),
+                                                                        like: $0.like) }
                 AmplitudeManager.shared.setUserProperty(userProperties: [StringLiterals.Amplitude.UserProperty.userPurchaseCount: viewedCourseInfo.count])
                 
                 if self.viewedCoursesModel != viewedCourseInfo {
@@ -100,15 +98,13 @@ final class MyCourseListViewModel: Serviceable {
         NetworkService.shared.myCourseService.getViewedCourse() { response in
             switch response {
             case .success(let data):
-                let viewedCourseInfo = data.courses.map { MyCourseModel(
-                    courseId: $0.courseID,
-                    thumbnail: $0.thumbnail,
-                    title: $0.title,
-                    city: $0.city,
-                    cost: $0.cost.priceRangeTag(),
-                    duration: ($0.duration).formatFloatTime(),
-                    like: $0.like
-                ) }
+                let viewedCourseInfo = data.courses.map { MyCourseModel(courseId: $0.courseID,
+                                                                        thumbnail: $0.thumbnail,
+                                                                        title: $0.title,
+                                                                        city: $0.city,
+                                                                        cost: $0.cost.priceRangeTag(),
+                                                                        duration: ($0.duration).formatFloatTime(),
+                                                                        like: $0.like) }
                 
                 if self.broughtViewedCoursesModel != viewedCourseInfo {
                     self.viewedCourseData.value = viewedCourseInfo
@@ -141,15 +137,13 @@ final class MyCourseListViewModel: Serviceable {
         NetworkService.shared.myCourseService.getMyRegisterCourse() { response in
             switch response {
             case .success(let data):
-                let myRegisterCourseInfo = data.courses.map { MyCourseModel(
-                    courseId: $0.courseID,
-                    thumbnail: $0.thumbnail,
-                    title: $0.title,
-                    city: $0.city,
-                    cost: ($0.cost).priceRangeTag(),
-                    duration: ($0.duration).formatFloatTime(),
-                    like: $0.like
-                ) }
+                let myRegisterCourseInfo = data.courses.map { MyCourseModel(courseId: $0.courseID,
+                                                                            thumbnail: $0.thumbnail,
+                                                                            title: $0.title,
+                                                                            city: $0.city,
+                                                                            cost: ($0.cost).priceRangeTag(),
+                                                                            duration: ($0.duration).formatFloatTime(),
+                                                                            like: $0.like) }
                 AmplitudeManager.shared.setUserProperty(userProperties: [StringLiterals.Amplitude.UserProperty.userCourseCount: myRegisterCourseInfo.count])
                 
                 if self.myRegisterCoursesModel != myRegisterCourseInfo {

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/MyCourse/ViewModels/MyCourseListViewModel.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/MyCourse/ViewModels/MyCourseListViewModel.swift
@@ -9,6 +9,18 @@ import Foundation
 
 final class MyCourseListViewModel: Serviceable {
     
+    var viewedCoursesModel = ViewedCoursesManager.shared.viewedCoursesModel
+
+    var broughtViewedCoursesModel = BroughtViewedCoursesManager.shared.broughtViewedCoursesModel
+    
+    var myRegisterCoursesModel = MyRegisterCoursesManager.shared.myRegisterCoursesModel
+    
+    var broughtViewedCoursesModelIsUpdate: ObservablePattern<Bool> = ObservablePattern(nil)
+    
+    var viewedCoursesModelIsUpdate: ObservablePattern<Bool> = ObservablePattern(nil)
+    
+    var myRegisterCoursesModelIsUpdate: ObservablePattern<Bool> = ObservablePattern(nil)
+    
     var viewedCourseData: ObservablePattern<[MyCourseModel]> = ObservablePattern([])
     
     var myRegisterCourseData: ObservablePattern<[MyCourseModel]> = ObservablePattern([])
@@ -38,6 +50,7 @@ final class MyCourseListViewModel: Serviceable {
         setMyRegisterCourseData()
     }
     
+    // '열람한 코스'(탭바) _ viewedCoursesModel
     func setViewedCourseData() {
         self.isSuccessGetViewedCourseInfo.value = false
         self.onViewedCourseFailNetwork.value = false
@@ -45,15 +58,23 @@ final class MyCourseListViewModel: Serviceable {
         NetworkService.shared.myCourseService.getViewedCourse() { response in
             switch response {
             case .success(let data):
-                let viewedCourseInfo = data.courses.map { MyCourseModel(courseId: $0.courseID,
-                                                                        thumbnail: $0.thumbnail,
-                                                                        title: $0.title,
-                                                                        city: $0.city,
-                                                                        cost: $0.cost.priceRangeTag(),
-                                                                        duration: ($0.duration).formatFloatTime(),
-                                                                        like: $0.like) }
+                let viewedCourseInfo = data.courses.map { MyCourseModel(
+                    courseId: $0.courseID,
+                    thumbnail: $0.thumbnail,
+                    title: $0.title,
+                    city: $0.city,
+                    cost: $0.cost.priceRangeTag(),
+                    duration: ($0.duration).formatFloatTime(),
+                    like: $0.like
+                ) }
                 AmplitudeManager.shared.setUserProperty(userProperties: [StringLiterals.Amplitude.UserProperty.userPurchaseCount: viewedCourseInfo.count])
-                self.viewedCourseData.value = viewedCourseInfo
+                
+                if self.viewedCoursesModel != viewedCourseInfo {
+                    self.viewedCoursesModelIsUpdate.value = true
+                    self.viewedCourseData.value = viewedCourseInfo
+                    self.viewedCoursesModel = viewedCourseInfo
+                }
+                
                 self.isSuccessGetViewedCourseInfo.value = true
             case .reIssueJWT:
                 self.patchReissue { isSuccess in
@@ -71,6 +92,7 @@ final class MyCourseListViewModel: Serviceable {
         self.onViewedCourseLoading.value = !isSuccessGetViewedCourseInfo
     }
     
+    // 일정등록(불러오기 '내가 열람한 코스') _ broughtViewedCoursesModel
     func setNavViewedCourseData() {
         self.isSuccessGetNavViewedCourseInfo.value = false
         self.onNavViewedCourseFailNetwork.value = false
@@ -78,14 +100,22 @@ final class MyCourseListViewModel: Serviceable {
         NetworkService.shared.myCourseService.getViewedCourse() { response in
             switch response {
             case .success(let data):
-                let viewedCourseInfo = data.courses.map { MyCourseModel(courseId: $0.courseID,
-                                                                        thumbnail: $0.thumbnail,
-                                                                        title: $0.title,
-                                                                        city: $0.city,
-                                                                        cost: $0.cost.priceRangeTag(),
-                                                                        duration: ($0.duration).formatFloatTime(),
-                                                                        like: $0.like) }
-                self.viewedCourseData.value = viewedCourseInfo
+                let viewedCourseInfo = data.courses.map { MyCourseModel(
+                    courseId: $0.courseID,
+                    thumbnail: $0.thumbnail,
+                    title: $0.title,
+                    city: $0.city,
+                    cost: $0.cost.priceRangeTag(),
+                    duration: ($0.duration).formatFloatTime(),
+                    like: $0.like
+                ) }
+                
+                if self.broughtViewedCoursesModel != viewedCourseInfo {
+                    self.broughtViewedCoursesModelIsUpdate.value = true
+                    self.viewedCourseData.value = viewedCourseInfo
+                    self.broughtViewedCoursesModel = viewedCourseInfo
+                }
+                
                 self.isSuccessGetNavViewedCourseInfo.value = true
             case .reIssueJWT:
                 self.patchReissue { isSuccess in
@@ -103,6 +133,7 @@ final class MyCourseListViewModel: Serviceable {
         self.onNavViewedCourseLoading.value = !isSuccessGetNavViewedCourseInfo
     }
     
+    // 내가 등록한 코스
     func setMyRegisterCourseData() {
         self.isSuccessGetMyRegisterCourseInfo.value = false
         self.onMyRegisterCourseFailNetwork.value = false
@@ -110,15 +141,22 @@ final class MyCourseListViewModel: Serviceable {
         NetworkService.shared.myCourseService.getMyRegisterCourse() { response in
             switch response {
             case .success(let data):
-                let myRegisterCourseInfo = data.courses.map { MyCourseModel(courseId: $0.courseID,
-                                                                            thumbnail: $0.thumbnail,
-                                                                            title: $0.title,
-                                                                            city: $0.city,
-                                                                            cost: ($0.cost).priceRangeTag(),
-                                                                            duration: ($0.duration).formatFloatTime(),
-                                                                            like: $0.like) }
+                let myRegisterCourseInfo = data.courses.map { MyCourseModel(
+                    courseId: $0.courseID,
+                    thumbnail: $0.thumbnail,
+                    title: $0.title,
+                    city: $0.city,
+                    cost: ($0.cost).priceRangeTag(),
+                    duration: ($0.duration).formatFloatTime(),
+                    like: $0.like
+                ) }
                 AmplitudeManager.shared.setUserProperty(userProperties: [StringLiterals.Amplitude.UserProperty.userCourseCount: myRegisterCourseInfo.count])
-                self.myRegisterCourseData.value = myRegisterCourseInfo
+                
+                if self.myRegisterCoursesModel != myRegisterCourseInfo {
+                    self.myRegisterCoursesModelIsUpdate.value = true
+                    self.myRegisterCourseData.value = myRegisterCourseInfo
+                    self.myRegisterCoursesModel = myRegisterCourseInfo
+                }
                 self.isSuccessGetMyRegisterCourseInfo.value = true
             case .reIssueJWT:
                 self.patchReissue { isSuccess in

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/MyCourse/Views/Cells/MyCourseListCollectionViewCell.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/MyCourse/Views/Cells/MyCourseListCollectionViewCell.swift
@@ -176,9 +176,13 @@ extension MyCourseListCollectionViewCell {
     
     func dataBind(_ viewedCourseData: MyCourseModel?, _ viewedCourseItemRow: Int?) {
         guard let viewedCourseData else { return }
-        self.thumbnailImageView.kf.setImage(with: URL(string: viewedCourseData.thumbnail), options: [.transition(.none),
-                                                                 .cacheOriginalImage,
-                                                                 .keepCurrentImageWhileLoading])
+        self.thumbnailImageView.kf.setImage(
+            with: URL(string: viewedCourseData.thumbnail),
+            options: [
+                .transition(.none),
+                .cacheOriginalImage
+            ]
+        )
         self.courseID = viewedCourseData.courseId
         self.heartButton.setTitle("\(viewedCourseData.like)", for: .normal)
         self.locationLabel.text = viewedCourseData.city

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/MyCourse/Views/Cells/MyCourseListCollectionViewCell.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/MyCourse/Views/Cells/MyCourseListCollectionViewCell.swift
@@ -176,13 +176,8 @@ extension MyCourseListCollectionViewCell {
     
     func dataBind(_ viewedCourseData: MyCourseModel?, _ viewedCourseItemRow: Int?) {
         guard let viewedCourseData else { return }
-        self.thumbnailImageView.kf.setImage(
-            with: URL(string: viewedCourseData.thumbnail),
-            options: [
-                .transition(.none),
-                .cacheOriginalImage
-            ]
-        )
+        self.thumbnailImageView.kf.setImage(with: URL(string: viewedCourseData.thumbnail),
+                                            options: [.transition(.none),.cacheOriginalImage])
         self.courseID = viewedCourseData.courseId
         self.heartButton.setTitle("\(viewedCourseData.like)", for: .normal)
         self.locationLabel.text = viewedCourseData.city

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/MyCourse/Views/Cells/MyCourseListCollectionViewCell.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/MyCourse/Views/Cells/MyCourseListCollectionViewCell.swift
@@ -61,7 +61,10 @@ final class MyCourseListCollectionViewCell: BaseCollectionViewCell {
     }
     
     override func setHierarchy() {
-        self.addSubviews(thumbnailImageView, heartButton, infoView)
+        self.addSubviews(thumbnailImageView,
+                         heartButton,
+                         infoView)
+        
         infoView.addSubviews(locationLabel,
                              titleLabel,
                              expenseButton,

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/MyCourse/Views/MyRegisterCourseViewController.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/MyCourse/Views/MyRegisterCourseViewController.swift
@@ -91,7 +91,6 @@ extension MyRegisterCourseViewController {
             guard let flag else { return }
             if flag {
                 DispatchQueue.main.async {
-//                    self?.myRegisterCourseView.myCourseListCollectionView.reloadData()
                     self?.myRegisterCourseView.myCourseListCollectionView.performBatchUpdates({
                         self?.myRegisterCourseView.myCourseListCollectionView.reloadSections(IndexSet(integer: 0))
                     })

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/MyCourse/Views/MyRegisterCourseViewController.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/MyCourse/Views/MyRegisterCourseViewController.swift
@@ -116,9 +116,18 @@ extension MyRegisterCourseViewController {
                     self?.contentView.isHidden = onLoading
                 } else {
                     self?.setEmptyView()
-                    self?.myRegisterCourseView.myCourseListCollectionView.reloadData()
-                    self?.contentView.isHidden = onLoading
-                    self?.hideLoadingView()
+                    
+                    if self?.myRegisterCourseViewModel.myRegisterCoursesModelIsUpdate.value == true {
+                        DispatchQueue.main.async {
+                            self?.myRegisterCourseView.myCourseListCollectionView.performBatchUpdates({
+                                self?.myRegisterCourseView.myCourseListCollectionView.reloadSections(IndexSet(integer: 0))
+                            })
+                            self?.contentView.isHidden = onLoading
+                            self?.hideLoadingView()
+                        }
+                        self?.myRegisterCourseViewModel.myRegisterCoursesModelIsUpdate.value = false
+                    }
+                    
                 }
             }
         }

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/MyCourse/Views/MyRegisterCourseViewController.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/MyCourse/Views/MyRegisterCourseViewController.swift
@@ -87,6 +87,19 @@ private extension MyRegisterCourseViewController {
 extension MyRegisterCourseViewController {
     
     func bindViewModel() {
+        self.myRegisterCourseViewModel.myRegisterCoursesModelIsUpdate.bind { [weak self] flag in
+            guard let flag else { return }
+            if flag {
+                DispatchQueue.main.async {
+//                    self?.myRegisterCourseView.myCourseListCollectionView.reloadData()
+                    self?.myRegisterCourseView.myCourseListCollectionView.performBatchUpdates({
+                        self?.myRegisterCourseView.myCourseListCollectionView.reloadSections(IndexSet(integer: 0))
+                    })
+                }
+                self?.myRegisterCourseViewModel.myRegisterCoursesModelIsUpdate.value = false
+            }
+        }
+        
         self.myRegisterCourseViewModel.onReissueSuccess.bind { [weak self] onSuccess in
             guard let onSuccess else { return }
             if onSuccess {
@@ -115,18 +128,12 @@ extension MyRegisterCourseViewController {
                     self?.showLoadingView(type: StringLiterals.MyRegisterCourse.title)
                     self?.contentView.isHidden = onLoading
                 } else {
-                    self?.setEmptyView()
-                    
-                    if self?.myRegisterCourseViewModel.myRegisterCoursesModelIsUpdate.value == true {
-                        DispatchQueue.main.async {
-                            self?.myRegisterCourseView.myCourseListCollectionView.reloadData()
-                            // performBatchUpdates 적용시 반짝여서 reloadData 적용
-                            self?.contentView.isHidden = onLoading
-                            self?.hideLoadingView()
-                        }
-                        self?.myRegisterCourseViewModel.myRegisterCoursesModelIsUpdate.value = false
+                    DispatchQueue.main.async {
+                        self?.setEmptyView()
+                        self?.myRegisterCourseView.myCourseListCollectionView.reloadData()
+                        self?.contentView.isHidden = onLoading
+                        self?.hideLoadingView()
                     }
-                    
                 }
             }
         }

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/MyCourse/Views/MyRegisterCourseViewController.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/MyCourse/Views/MyRegisterCourseViewController.swift
@@ -119,9 +119,8 @@ extension MyRegisterCourseViewController {
                     
                     if self?.myRegisterCourseViewModel.myRegisterCoursesModelIsUpdate.value == true {
                         DispatchQueue.main.async {
-                            self?.myRegisterCourseView.myCourseListCollectionView.performBatchUpdates({
-                                self?.myRegisterCourseView.myCourseListCollectionView.reloadSections(IndexSet(integer: 0))
-                            })
+                            self?.myRegisterCourseView.myCourseListCollectionView.reloadData()
+                            // performBatchUpdates 적용시 반짝여서 reloadData 적용
                             self?.contentView.isHidden = onLoading
                             self?.hideLoadingView()
                         }

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/MyCourse/Views/NavViewedCourseViewController.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/MyCourse/Views/NavViewedCourseViewController.swift
@@ -94,13 +94,8 @@ private extension NavViewedCourseViewController {
                 )
             }
         } else {
-            if self.viewedCourseViewModel.broughtViewedCoursesModelIsUpdate.value == true {
-                DispatchQueue.main.async {
-                    self.navViewedCourseView.myCourseListCollectionView.performBatchUpdates({
-                        self.navViewedCourseView.myCourseListCollectionView.reloadSections(IndexSet(integer: 0))
-                    })
-                }
-                self.viewedCourseViewModel.broughtViewedCoursesModelIsUpdate.value = false
+            DispatchQueue.main.async {
+                self.navViewedCourseView.myCourseListCollectionView.reloadData()
             }
         }
     }
@@ -113,6 +108,22 @@ private extension NavViewedCourseViewController {
 extension NavViewedCourseViewController {
     
     func bindViewModel() {
+        self.viewedCourseViewModel.broughtViewedCoursesModelIsUpdate.bind { [weak self] flag in
+            guard let flag else { return }
+            if flag {
+                DispatchQueue.main.async {
+                    self?.navViewedCourseView.myCourseListCollectionView.reloadData()
+                }
+                self?.viewedCourseViewModel.broughtViewedCoursesModelIsUpdate.value = false
+            }
+        }
+        
+        DispatchQueue.main.async {
+            self.navViewedCourseView.myCourseListCollectionView.performBatchUpdates({
+                self.navViewedCourseView.myCourseListCollectionView.reloadSections(IndexSet(integer: 0))
+            })
+        }
+        
         self.viewedCourseViewModel.onReissueSuccess.bind { [weak self] onSuccess in
             guard let onSuccess else { return }
             if onSuccess {
@@ -142,13 +153,11 @@ extension NavViewedCourseViewController {
                     self?.showLoadingView(type: StringLiterals.ViewedCourse.title)
                     self?.navViewedCourseView.isHidden = onLoading
                 } else {
-                    if self?.viewedCourseViewModel.broughtViewedCoursesModelIsUpdate.value == true {
-                        DispatchQueue.main.async {
-                            self?.setEmptyView()
-                            self?.navViewedCourseView.isHidden = onLoading
-                            self?.tabBarController?.tabBar.isHidden = false
-                            self?.hideLoadingView()
-                        }
+                    DispatchQueue.main.async {
+                        self?.setEmptyView()
+                        self?.navViewedCourseView.isHidden = onLoading
+                        self?.tabBarController?.tabBar.isHidden = false
+                        self?.hideLoadingView()
                     }
                 }
             }

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/MyCourse/Views/NavViewedCourseViewController.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/MyCourse/Views/NavViewedCourseViewController.swift
@@ -54,7 +54,7 @@ final class NavViewedCourseViewController: BaseNavBarViewController {
     override func setHierarchy() {
         super.setHierarchy()
         
-        self.contentView.addSubviews(navViewedCourseView)
+        self.contentView.addSubview(navViewedCourseView)
     }
     
     override func setLayout() {

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/MyCourse/Views/NavViewedCourseViewController.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/MyCourse/Views/NavViewedCourseViewController.swift
@@ -88,10 +88,7 @@ private extension NavViewedCourseViewController {
         navViewedCourseView.myCourseListCollectionView.isHidden = isEmpty
         if isEmpty {
             DispatchQueue.main.async {
-                self.navViewedCourseView.emptyView.setEmptyView(
-                    emptyImage: UIImage(resource: .emptyPastSchedule),
-                    emptyTitle: StringLiterals.EmptyView.emptyNavViewedCourse
-                )
+                self.navViewedCourseView.emptyView.setEmptyView(emptyImage: UIImage(resource: .emptyPastSchedule), emptyTitle: StringLiterals.EmptyView.emptyNavViewedCourse)
             }
         } else {
             DispatchQueue.main.async {
@@ -116,12 +113,6 @@ extension NavViewedCourseViewController {
                 }
                 self?.viewedCourseViewModel.broughtViewedCoursesModelIsUpdate.value = false
             }
-        }
-        
-        DispatchQueue.main.async {
-            self.navViewedCourseView.myCourseListCollectionView.performBatchUpdates({
-                self.navViewedCourseView.myCourseListCollectionView.reloadSections(IndexSet(integer: 0))
-            })
         }
         
         self.viewedCourseViewModel.onReissueSuccess.bind { [weak self] onSuccess in

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/MyCourse/Views/NavViewedCourseViewController.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/MyCourse/Views/NavViewedCourseViewController.swift
@@ -87,10 +87,21 @@ private extension NavViewedCourseViewController {
         navViewedCourseView.emptyView.isHidden = !isEmpty
         navViewedCourseView.myCourseListCollectionView.isHidden = isEmpty
         if isEmpty {
-            navViewedCourseView.emptyView.setEmptyView(emptyImage: UIImage(resource: .emptyPastSchedule),
-                                                       emptyTitle: StringLiterals.EmptyView.emptyNavViewedCourse)
+            DispatchQueue.main.async {
+                self.navViewedCourseView.emptyView.setEmptyView(
+                    emptyImage: UIImage(resource: .emptyPastSchedule),
+                    emptyTitle: StringLiterals.EmptyView.emptyNavViewedCourse
+                )
+            }
         } else {
-            self.navViewedCourseView.myCourseListCollectionView.reloadData()
+            if self.viewedCourseViewModel.broughtViewedCoursesModelIsUpdate.value == true {
+                DispatchQueue.main.async {
+                    self.navViewedCourseView.myCourseListCollectionView.performBatchUpdates({
+                        self.navViewedCourseView.myCourseListCollectionView.reloadSections(IndexSet(integer: 0))
+                    })
+                }
+                self.viewedCourseViewModel.broughtViewedCoursesModelIsUpdate.value = false
+            }
         }
     }
     
@@ -131,10 +142,15 @@ extension NavViewedCourseViewController {
                     self?.showLoadingView(type: StringLiterals.ViewedCourse.title)
                     self?.navViewedCourseView.isHidden = onLoading
                 } else {
-                    self?.setEmptyView()
-                    self?.navViewedCourseView.isHidden = onLoading
-                    self?.tabBarController?.tabBar.isHidden = false
-                    self?.hideLoadingView()
+                    if self?.viewedCourseViewModel.broughtViewedCoursesModelIsUpdate.value == true {
+                        DispatchQueue.main.async {
+                            print("🔥🔥🔥🔥🔥🔥🔥🔥🔥")
+                            self?.setEmptyView()
+                            self?.navViewedCourseView.isHidden = onLoading
+                            self?.tabBarController?.tabBar.isHidden = false
+                            self?.hideLoadingView()
+                        }
+                    }
                 }
             }
         }

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/MyCourse/Views/NavViewedCourseViewController.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/MyCourse/Views/NavViewedCourseViewController.swift
@@ -144,7 +144,6 @@ extension NavViewedCourseViewController {
                 } else {
                     if self?.viewedCourseViewModel.broughtViewedCoursesModelIsUpdate.value == true {
                         DispatchQueue.main.async {
-                            print("🔥🔥🔥🔥🔥🔥🔥🔥🔥")
                             self?.setEmptyView()
                             self?.navViewedCourseView.isHidden = onLoading
                             self?.tabBarController?.tabBar.isHidden = false

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/MyCourse/Views/ViewedCourseViewController.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/MyCourse/Views/ViewedCourseViewController.swift
@@ -169,22 +169,15 @@ private extension ViewedCourseViewController {
                 self.viewedCourseView.emptyView.setEmptyView(emptyImage: UIImage(resource: .emptyViewedCourse), emptyTitle: StringLiterals.EmptyView.emptyViewedCourse)
             }
         } else {
-            if self.viewedCourseViewModel.viewedCoursesModelIsUpdate.value == true {
-                DispatchQueue.main.async {
-                    self.viewedCourseView.myCourseListCollectionView.performBatchUpdates({
-                        self.viewedCourseView.myCourseListCollectionView.reloadSections(IndexSet(integer: 0))
-                    }, completion: { _ in
-                        self.topLabel.setAttributedText(
-                            fullText: "\(name)님이 지금까지\n열람한 데이트 코스\n\(self.viewedCourseViewModel.viewedCourseData.value?.count ?? 0)개",
-                            pointText: "\(self.viewedCourseViewModel.viewedCourseData.value?.count ?? 0)",
-                            pointColor: UIColor(resource: .mediumPurple),
-                            lineHeight: 1
-                        )
-                    })
-                }
-                self.viewedCourseViewModel.viewedCoursesModelIsUpdate.value = false
+            DispatchQueue.main.async {
+                self.viewedCourseView.myCourseListCollectionView.reloadData()
+                self.topLabel.setAttributedText(
+                    fullText: "\(name)님이 지금까지\n열람한 데이트 코스\n\(self.viewedCourseViewModel.viewedCourseData.value?.count ?? 0)개",
+                    pointText: "\(self.viewedCourseViewModel.viewedCourseData.value?.count ?? 0)",
+                    pointColor: UIColor(resource: .mediumPurple),
+                    lineHeight: 1
+                )
             }
-            
         }
     }
     
@@ -196,6 +189,18 @@ private extension ViewedCourseViewController {
 extension ViewedCourseViewController {
     
     func bindViewModel() {
+        self.viewedCourseViewModel.viewedCoursesModelIsUpdate.bind { [weak self] flag in
+            guard let flag else { return }
+            if flag {
+                DispatchQueue.main.async {
+                    self?.viewedCourseView.myCourseListCollectionView.performBatchUpdates({
+                        self?.viewedCourseView.myCourseListCollectionView.reloadSections(IndexSet(integer: 0))
+                    })
+                }
+                self?.viewedCourseViewModel.viewedCoursesModelIsUpdate.value = false
+            }
+        }
+        
         self.viewedCourseViewModel.onReissueSuccess.bind { [weak self] onSuccess in
             guard let onSuccess else { return }
             if onSuccess {

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/MyCourse/Views/ViewedCourseViewController.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/MyCourse/Views/ViewedCourseViewController.swift
@@ -67,11 +67,9 @@ final class ViewedCourseViewController: BaseViewController {
         
         self.view.addSubview(contentView)
         
-        self.contentView.addSubviews(
-            topLabel,
-            createCourseView,
-            viewedCourseView
-        )
+        self.contentView.addSubviews(topLabel,
+                                     createCourseView,
+                                     viewedCourseView)
         
         self.createCourseView.addSubviews(createCourseLabel, arrowButton)
     }

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/MyCourse/Views/ViewedCourseViewController.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/MyCourse/Views/ViewedCourseViewController.swift
@@ -27,7 +27,7 @@ final class ViewedCourseViewController: BaseViewController {
     private var viewedCourseView = MyCourseListView(type: "tab")
     
     private let errorView: DRErrorViewController = DRErrorViewController()
-        
+    
     
     // MARK: - Properties
     
@@ -67,9 +67,11 @@ final class ViewedCourseViewController: BaseViewController {
         
         self.view.addSubview(contentView)
         
-        self.contentView.addSubviews(topLabel,
-                                     createCourseView,
-                                     viewedCourseView)
+        self.contentView.addSubviews(
+            topLabel,
+            createCourseView,
+            viewedCourseView
+        )
         
         self.createCourseView.addSubviews(createCourseLabel, arrowButton)
     }
@@ -119,10 +121,12 @@ final class ViewedCourseViewController: BaseViewController {
         
         topLabel.do {
             $0.font = UIFont.suit(.title_extra_24)
-            $0.setAttributedText(fullText: "\(self.userName)님이 지금까지\n열람한 데이트 코스\n\(viewedCourseViewModel.viewedCourseData.value?.count ?? 0)개",
-                                 pointText: "\(viewedCourseViewModel.viewedCourseData.value?.count ?? 0)",
-                                 pointColor: UIColor(resource: .mediumPurple),
-                                 lineHeight: 1)
+            $0.setAttributedText(
+                fullText: "\(self.userName)님이 지금까지\n열람한 데이트 코스\n\(viewedCourseViewModel.viewedCourseData.value?.count ?? 0)개",
+                pointText: "\(viewedCourseViewModel.viewedCourseData.value?.count ?? 0)",
+                pointColor: UIColor(resource: .mediumPurple),
+                lineHeight: 1
+            )
             $0.numberOfLines = 3
         }
         
@@ -132,9 +136,11 @@ final class ViewedCourseViewController: BaseViewController {
             $0.isUserInteractionEnabled = true
         }
         
-        createCourseLabel.setLabel(text: StringLiterals.ViewedCourse.registerSchedule,
-                                   textColor: UIColor(resource: .drBlack),
-                                   font: UIFont.suit(.title_bold_18))
+        createCourseLabel.setLabel(
+            text: StringLiterals.ViewedCourse.registerSchedule,
+            textColor: UIColor(resource: .drBlack),
+            font: UIFont.suit(.title_bold_18)
+        )
         
         arrowButton.do {
             $0.setButtonStatus(buttonType: EnabledButton())
@@ -158,14 +164,27 @@ private extension ViewedCourseViewController {
         createCourseView.isHidden = isEmpty
         
         if isEmpty {
-            topLabel.text = "\(name)님,\n아직 열람한\n데이트코스가 없어요"
-            viewedCourseView.emptyView.setEmptyView(emptyImage: UIImage(resource: .emptyViewedCourse), emptyTitle: StringLiterals.EmptyView.emptyViewedCourse)
+            DispatchQueue.main.async {
+                self.topLabel.text = "\(name)님,\n아직 열람한\n데이트코스가 없어요"
+                self.viewedCourseView.emptyView.setEmptyView(emptyImage: UIImage(resource: .emptyViewedCourse), emptyTitle: StringLiterals.EmptyView.emptyViewedCourse)
+            }
         } else {
-            self.viewedCourseView.myCourseListCollectionView.reloadData()
-            self.topLabel.setAttributedText(fullText: "\(name)님이 지금까지\n열람한 데이트 코스\n\(self.viewedCourseViewModel.viewedCourseData.value?.count ?? 0)개",
-                                            pointText: "\(self.viewedCourseViewModel.viewedCourseData.value?.count ?? 0)",
-                                            pointColor: UIColor(resource: .mediumPurple),
-                                            lineHeight: 1)
+            if self.viewedCourseViewModel.viewedCoursesModelIsUpdate.value == true {
+                DispatchQueue.main.async {
+                    self.viewedCourseView.myCourseListCollectionView.performBatchUpdates({
+                        self.viewedCourseView.myCourseListCollectionView.reloadSections(IndexSet(integer: 0))
+                    }, completion: { _ in
+                        self.topLabel.setAttributedText(
+                            fullText: "\(name)님이 지금까지\n열람한 데이트 코스\n\(self.viewedCourseViewModel.viewedCourseData.value?.count ?? 0)개",
+                            pointText: "\(self.viewedCourseViewModel.viewedCourseData.value?.count ?? 0)",
+                            pointColor: UIColor(resource: .mediumPurple),
+                            lineHeight: 1
+                        )
+                    })
+                }
+                self.viewedCourseViewModel.viewedCoursesModelIsUpdate.value = false
+            }
+            
         }
     }
     

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/MyPage/ViewModels/MyPageViewModel.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/MyPage/ViewModels/MyPageViewModel.swift
@@ -27,6 +27,10 @@ final class MyPageViewModel: Serviceable {
     
     var onFailNetwork: ObservablePattern<Bool> = ObservablePattern(false)
     
+    var updateData: ObservablePattern<Bool> = ObservablePattern(false)
+    
+    var currentTags: [String] = []
+    
 }
 
 extension MyPageViewModel {
@@ -99,11 +103,22 @@ extension MyPageViewModel {
         NetworkService.shared.userService.getUserProfile( ) { response in
             switch response {
             case .success(let data):
-                self.userInfoData.value = MyPageUserInfoModel(nickname: data.name,
-                                                              tagList: data.tags,
-                                                              point: data.point,
-                                                              imageURL: data.imageURL)
-                self.tagData = data.tags
+                if self.userInfoData.value != MyPageUserInfoModel(
+                    nickname: data.name,
+                    tagList: data.tags,
+                    point: data.point,
+                    imageURL: data.imageURL
+                ) {
+                    self.currentTags = self.userInfoData.value?.tagList ?? []
+                    self.userInfoData.value = MyPageUserInfoModel(
+                        nickname: data.name,
+                        tagList: data.tags,
+                        point: data.point,
+                        imageURL: data.imageURL
+                    )
+                    self.tagData = data.tags
+                    self.updateData.value = true
+                }
                 self.onSuccessGetUserProfile.value = true
             case .reIssueJWT:
                 self.patchReissue { isSuccess in

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/MyPage/ViewModels/MyPageViewModel.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/MyPage/ViewModels/MyPageViewModel.swift
@@ -27,7 +27,7 @@ final class MyPageViewModel: Serviceable {
     
     var onFailNetwork: ObservablePattern<Bool> = ObservablePattern(false)
     
-    var updateData: ObservablePattern<Bool> = ObservablePattern(false)
+    var updateData: ObservablePattern<Bool> = ObservablePattern(nil)
     
     var currentTags: [String] = []
     

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/MyPage/ViewModels/MyPageViewModel.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/MyPage/ViewModels/MyPageViewModel.swift
@@ -22,7 +22,7 @@ final class MyPageViewModel: Serviceable {
     var onSuccessGetUserProfile: ObservablePattern<Bool> = ObservablePattern(false)
     
     var onReissueSuccess: ObservablePattern<Bool> = ObservablePattern(nil)
-        
+    
     var onAuthLoading: ObservablePattern<Bool> = ObservablePattern(nil)
     
     var onFailNetwork: ObservablePattern<Bool> = ObservablePattern(false)

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/MyPage/Views/MyPageViewController.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/MyPage/Views/MyPageViewController.swift
@@ -127,8 +127,9 @@ private extension MyPageViewController {
         
         self.myPageViewModel.onSuccessGetUserProfile.bind { [weak self] onSuccess in
             guard let onSuccess, let data = self?.myPageViewModel.userInfoData.value else { return }
+            guard let updateData = self?.myPageViewModel.updateData.value else { return }
             
-            if onSuccess {
+            if onSuccess && updateData {
                 self?.hideLoadingView()
                 DispatchQueue.main.async {
                     self?.myPageView.userInfoView.bindData(userInfo: data)
@@ -225,12 +226,14 @@ extension MyPageViewController {
     
     @objc
     func logOutSectionTapped() {
-        let customAlertVC = DRCustomAlertViewController(rightActionType: RightButtonType.logout,
-                                                        alertTextType: .noDescription,
-                                                        alertButtonType: .twoButton,
-                                                        titleText: StringLiterals.Alert.wouldYouLogOut,
-                                                        leftButtonText: StringLiterals.Common.cancel,
-                                                        rightButtonText: StringLiterals.MyPage.logout)
+        let customAlertVC = DRCustomAlertViewController(
+            rightActionType: RightButtonType.logout,
+            alertTextType: .noDescription,
+            alertButtonType: .twoButton,
+            titleText: StringLiterals.Alert.wouldYouLogOut,
+            leftButtonText: StringLiterals.Common.cancel,
+            rightButtonText: StringLiterals.MyPage.logout
+        )
         customAlertVC.delegate = self
         customAlertVC.modalPresentationStyle = .overFullScreen
         selectedAlertFlag = 0
@@ -239,13 +242,15 @@ extension MyPageViewController {
     
     @objc
     func withDrawalButtonTapped() {
-        let customAlertVC = DRCustomAlertViewController(rightActionType: RightButtonType.none,
-                                                        alertTextType: .noDescription,
-                                                        alertButtonType: .twoButton,
-                                                        titleText: StringLiterals.Alert.realWithdrawal,
-                                                        descriptionText: StringLiterals.Alert.lastWarning,
-                                                        leftButtonText: StringLiterals.MyPage.alertWithdrawal,
-                                                        rightButtonText: StringLiterals.Common.cancel)
+        let customAlertVC = DRCustomAlertViewController(
+            rightActionType: RightButtonType.none,
+            alertTextType: .noDescription,
+            alertButtonType: .twoButton,
+            titleText: StringLiterals.Alert.realWithdrawal,
+            descriptionText: StringLiterals.Alert.lastWarning,
+            leftButtonText: StringLiterals.MyPage.alertWithdrawal,
+            rightButtonText: StringLiterals.Common.cancel
+        )
         customAlertVC.delegate = self
         customAlertVC.modalPresentationStyle = .overFullScreen
         selectedAlertFlag = 1
@@ -276,6 +281,7 @@ extension MyPageViewController: DRCustomAlertDelegate {
     }
     
 }
+
 
 // MARK: - UICollectionView Delegates
 
@@ -314,6 +320,7 @@ extension MyPageViewController: UICollectionViewDataSource {
     }
     
 }
+
 
 // MARK: - UITableView Delegates
 

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/MyPage/Views/MyPageViewController.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/MyPage/Views/MyPageViewController.swift
@@ -129,11 +129,14 @@ private extension MyPageViewController {
             guard let onSuccess, let data = self?.myPageViewModel.userInfoData.value else { return }
             guard let updateData = self?.myPageViewModel.updateData.value else { return }
             
-            if onSuccess && updateData {
+            if onSuccess {
                 self?.hideLoadingView()
-                DispatchQueue.main.async {
-                    self?.myPageView.userInfoView.bindData(userInfo: data)
-                    self?.myPageView.userInfoView.tagCollectionView.reloadData()
+                if updateData {
+                    DispatchQueue.main.async {
+                        self?.myPageView.userInfoView.bindData(userInfo: data)
+                        self?.myPageView.userInfoView.tagCollectionView.reloadData()
+                    }
+                    self?.myPageViewModel.updateData.value = false
                 }
             } else {
                 self?.showLoadingView(type: StringLiterals.TabBar.myPage)

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/MyPage/Views/MyPageViewController.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/MyPage/Views/MyPageViewController.swift
@@ -126,8 +126,8 @@ private extension MyPageViewController {
         }
         
         self.myPageViewModel.onSuccessGetUserProfile.bind { [weak self] onSuccess in
-            guard let onSuccess, let data = self?.myPageViewModel.userInfoData.value else { return }
-            guard let updateData = self?.myPageViewModel.updateData.value else { return }
+            guard let onSuccess, let data = self?.myPageViewModel.userInfoData.value,
+                  let updateData = self?.myPageViewModel.updateData.value else { return }
             
             if onSuccess {
                 self?.hideLoadingView()

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/MyPage/Views/UserInfoView.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/MyPage/Views/UserInfoView.swift
@@ -173,10 +173,18 @@ extension UserInfoView {
     func bindData(userInfo: MyPageUserInfoModel) {
         if let imageURL = userInfo.imageURL  {
             let url = URL(string: imageURL)
-            self.profileImageView.kf.setImage(with: url, placeholder: UIImage(resource: .placeholder))
+            self.profileImageView.kf.setImage(
+                with: url,
+                placeholder: UIImage(resource: .placeholder),
+                options: [
+                    .transition(.none),
+                    .cacheOriginalImage
+                ]
+            )
         } else {
             self.profileImageView.image = UIImage(resource: .emptyProfileImg)
         }
+        
         self.nicknameLabel.text = userInfo.nickname
         self.userPointLabel.text = userInfo.nickname + "님의 포인트"
         self.pointLabel.text = String(userInfo.point) + " P"

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/MyPage/Views/UserInfoView.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/MyPage/Views/UserInfoView.swift
@@ -173,14 +173,9 @@ extension UserInfoView {
     func bindData(userInfo: MyPageUserInfoModel) {
         if let imageURL = userInfo.imageURL  {
             let url = URL(string: imageURL)
-            self.profileImageView.kf.setImage(
-                with: url,
-                placeholder: UIImage(resource: .placeholder),
-                options: [
-                    .transition(.none),
-                    .cacheOriginalImage
-                ]
-            )
+            self.profileImageView.kf.setImage(with: url,
+                                              placeholder: UIImage(resource: .placeholder),
+                                              options: [.transition(.none), .cacheOriginalImage])
         } else {
             self.profileImageView.image = UIImage(resource: .emptyProfileImg)
         }

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/PointDetail/ViewModels/PointViewModel.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/PointDetail/ViewModels/PointViewModel.swift
@@ -9,10 +9,6 @@ import Foundation
 
 final class PointViewModel: Serviceable {
     
-    private var currentGainedPointData: [PointDetailModel] = []
-    
-    private var currentUsedPointData: [PointDetailModel] = []
-    
     let updateGainedPointData: ObservablePattern<Bool> = ObservablePattern(false)
     
     let updateUsedPointData: ObservablePattern<Bool> = ObservablePattern(false)
@@ -76,15 +72,13 @@ final class PointViewModel: Serviceable {
                 }
                 
                 // 포인트 획득내역 기존 데이터와 비교
-                if self.currentGainedPointData != newGainedPointInfo {
-                    self.currentGainedPointData = newGainedPointInfo
+                if self.gainedPointData.value != newGainedPointInfo {
                     self.gainedPointData.value = newGainedPointInfo
                     self.updateGainedPointData.value = true
                 }
                 
                 // 포인트 사용내역 기존 데이터와 비교
-                if self.currentUsedPointData != newUsedPointInfo {
-                    self.currentUsedPointData = newUsedPointInfo
+                if self.usedPointData.value != newUsedPointInfo {
                     self.usedPointData.value = newUsedPointInfo
                     self.updateUsedPointData.value = true
                 }

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/PointDetail/ViewModels/PointViewModel.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/PointDetail/ViewModels/PointViewModel.swift
@@ -9,6 +9,14 @@ import Foundation
 
 final class PointViewModel: Serviceable {
     
+    private var currentGainedPointData: [PointDetailModel] = []
+    
+    private var currentUsedPointData: [PointDetailModel] = []
+    
+    let updateGainedPointData: ObservablePattern<Bool> = ObservablePattern(false)
+    
+    let updateUsedPointData: ObservablePattern<Bool> = ObservablePattern(false)
+    
     var userName: String
     
     var totalPoint: Int
@@ -57,22 +65,35 @@ final class PointViewModel: Serviceable {
         NetworkService.shared.pointDetailService.getPointDetail() { response in
             switch response {
             case .success(let data):
-                let pointGainedInfo = data.gained.points.map {
+                let newGainedPointInfo = data.gained.points.map {
                     PointDetailModel(sign: "+", point: $0.point, description: $0.description, createdAt: $0.createdAt)
                 }
-                let pointUsedInfo = data.used.points.map {
+                let newUsedPointInfo = data.used.points.map {
                     PointDetailModel(sign: "-", point: $0.point, description: $0.description, createdAt: $0.createdAt)
                 }
-                self.gainedPointData.value = pointGainedInfo
-                self.usedPointData.value = pointUsedInfo
+                
+                // 포인트 획득내역 기존 데이터와 비교
+                if self.currentGainedPointData != newGainedPointInfo {
+                    self.currentGainedPointData = newGainedPointInfo
+                    self.gainedPointData.value = newGainedPointInfo
+                    self.updateGainedPointData.value = true
+                }
+                
+                // 포인트 사용내역 기존 데이터와 비교
+                if self.currentUsedPointData != newUsedPointInfo {
+                    self.currentUsedPointData = newUsedPointInfo
+                    self.usedPointData.value = newUsedPointInfo
+                    self.updateUsedPointData.value = true
+                }
+                
                 self.updateData(nowEarnedPointHidden: nowEarnedPointHidden)
                 self.isSuccessGetPointInfo.value = true
             case .reIssueJWT:
                 self.patchReissue { isSuccess in
                     self.onReissueSuccess.value = isSuccess
                 }
-             default:
-                self.onFailNetwork.value = true //TODO: - 확인
+            default:
+                self.onFailNetwork.value = true
                 return
             }
         }

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/PointDetail/ViewModels/PointViewModel.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/PointDetail/ViewModels/PointViewModel.swift
@@ -69,7 +69,10 @@ final class PointViewModel: Serviceable {
                     PointDetailModel(sign: "+", point: $0.point, description: $0.description, createdAt: $0.createdAt)
                 }
                 let newUsedPointInfo = data.used.points.map {
-                    PointDetailModel(sign: "-", point: $0.point, description: $0.description, createdAt: $0.createdAt)
+                    PointDetailModel(sign: "-",
+                                     point: $0.point,
+                                     description: $0.description,
+                                     createdAt: $0.createdAt)
                 }
                 
                 // 포인트 획득내역 기존 데이터와 비교

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/PointDetail/Views/PointDetailViewController.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/PointDetail/Views/PointDetailViewController.swift
@@ -77,6 +77,26 @@ class PointDetailViewController: BaseNavBarViewController {
 extension PointDetailViewController {
     
     func bindViewModel() {
+        self.pointViewModel.updateGainedPointData.bind { [weak self] flag in
+            guard let flag else { return }
+            if flag {
+                self?.pointDetailView.pointCollectionView.performBatchUpdates({
+                    self?.pointDetailView.pointCollectionView.reloadSections(IndexSet(integer: 0))
+                })
+                self?.pointViewModel.updateGainedPointData.value = false
+            }
+        }
+        
+        self.pointViewModel.updateUsedPointData.bind { [weak self] flag in
+            guard let flag else { return }
+            if flag {
+                self?.pointDetailView.pointCollectionView.performBatchUpdates({
+                    self?.pointDetailView.pointCollectionView.reloadSections(IndexSet(integer: 0))
+                })
+                self?.pointViewModel.updateUsedPointData.value = false
+            }
+        }
+        
         self.pointViewModel.onFailNetwork.bind { [weak self] onFailure in
             guard let onFailure else { return }
             if onFailure {

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/PointDetail/Views/PointDetailViewController.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/PointDetail/Views/PointDetailViewController.swift
@@ -61,7 +61,7 @@ class PointDetailViewController: BaseNavBarViewController {
     override func setHierarchy() {
         super.setHierarchy()
         
-        self.contentView.addSubviews(pointDetailView)
+        self.contentView.addSubview(pointDetailView)
     }
     
     override func setLayout() {

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/Profile/Views/EditProfileViewController.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/Profile/Views/EditProfileViewController.swift
@@ -191,7 +191,7 @@ private extension EditProfileViewController {
         
         self.profileViewModel.isValidNicknameCount.bind { [weak self] isValidCount in
             guard let isValidCount,
-                    let initial = self?.initial,
+                  let initial = self?.initial,
                   let isValidNickname = self?.profileViewModel.isValidNickname.value
             else { return }
             if initial {

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/Profile/Views/EditProfileViewController.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/Profile/Views/EditProfileViewController.swift
@@ -17,6 +17,11 @@ final class EditProfileViewController: BaseNavBarViewController {
     
     private let imagePickerViewController = CustomImagePicker(isProfilePicker: true)
     
+    lazy var alertVC = DRBottomSheetViewController(contentView: profileImageSettingView,
+                                              height: 288,
+                                              buttonType: DisabledButton(),
+                                              buttonTitle: StringLiterals.Common.cancel)
+    
     
     // MARK: - Properties
     
@@ -256,13 +261,10 @@ private extension EditProfileViewController {
     
     @objc
     func presentEditBottomSheet() {
-        let alertVC = DRBottomSheetViewController(contentView: profileImageSettingView,
-                                                  height: 288,
-                                                  buttonType: DisabledButton(),
-                                                  buttonTitle: StringLiterals.Common.cancel)
         alertVC.delegate = self
-        alertVC.modalPresentationStyle = .overFullScreen
-        self.present(alertVC, animated: true)
+        DispatchQueue.main.async {
+            self.alertVC.presentBottomSheet(in: self)
+        }
     }
     
     @objc
@@ -398,7 +400,7 @@ extension EditProfileViewController: UITextFieldDelegate {
 extension EditProfileViewController: DRBottomSheetDelegate {
     
     func didTapBottomButton() {
-        self.dismiss(animated: true)
+        alertVC.dismissBottomSheet()
     }
     
     func didTapFirstLabel() {

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/Profile/Views/EditProfileViewController.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/Profile/Views/EditProfileViewController.swift
@@ -305,14 +305,14 @@ private extension EditProfileViewController {
     
     @objc
     func deletePhoto() {
-        self.dismiss(animated: true)
+        alertVC.dismissBottomSheet()
         profileView.updateProfileImage(image: UIImage(resource: .emptyProfileImg))
         profileViewModel.profileImage.value = UIImage(resource: .emptyProfileImg)
     }
     
     @objc
     func registerPhoto() {
-        self.dismiss(animated: true)
+        alertVC.dismissBottomSheet()
         imagePickerViewController.presentPicker(from: self)
     }
     

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/Profile/Views/EditProfileViewController.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/Profile/Views/EditProfileViewController.swift
@@ -18,9 +18,9 @@ final class EditProfileViewController: BaseNavBarViewController {
     private let imagePickerViewController = CustomImagePicker(isProfilePicker: true)
     
     lazy var alertVC = DRBottomSheetViewController(contentView: profileImageSettingView,
-                                              height: 288,
-                                              buttonType: DisabledButton(),
-                                              buttonTitle: StringLiterals.Common.cancel)
+                                                   height: 288,
+                                                   buttonType: DisabledButton(),
+                                                   buttonTitle: StringLiterals.Common.cancel)
     
     
     // MARK: - Properties

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/Profile/Views/ProfileViewController.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/Profile/Views/ProfileViewController.swift
@@ -18,9 +18,9 @@ final class ProfileViewController: BaseNavBarViewController {
     private let imagePickerViewController = CustomImagePicker(isProfilePicker: true)
     
     lazy var alertVC = DRBottomSheetViewController(contentView: profileImageSettingView,
-                                              height: 288,
-                                              buttonType: DisabledButton(),
-                                              buttonTitle: StringLiterals.Common.cancel)
+                                                   height: 288,
+                                                   buttonType: DisabledButton(),
+                                                   buttonTitle: StringLiterals.Common.cancel)
     
     
     // MARK: - Properties

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/Profile/Views/ProfileViewController.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/Profile/Views/ProfileViewController.swift
@@ -142,10 +142,8 @@ private extension ProfileViewController {
         
         // 중복 확인 결과 변수
         self.profileViewModel.isValidNickname.bind { [weak self] isValid in
-            guard let isValid,
-                    let initial = self?.initial,
-                    let nicknameCount = self?.profileViewModel.nickname.value?.count
-            else { return }
+            guard let isValid, let initial = self?.initial,
+                  let nicknameCount = self?.profileViewModel.nickname.value?.count else { return }
             
             if initial {
                 self?.profileView.nicknameErrMessageLabel.isHidden = nicknameCount > 5
@@ -193,7 +191,7 @@ private extension ProfileViewController {
             guard let isValid else { return }
             self?.profileView.updateRegisterButton(isValid: isValid)
         }
-
+        
         self.profileViewModel.onSuccessRegister = { [weak self] isSuccess in
             if isSuccess {
                 guard let userId = UserDefaults.standard.string(forKey: StringLiterals.Network.userID) else { return }
@@ -313,7 +311,7 @@ extension ProfileViewController: UICollectionViewDataSource {
         cell.tendencyTagButton.tag = indexPath.item
         cell.tendencyTagButton.addTarget(self, action: #selector(didTapTagButton(_:)), for: .touchUpInside)
         cell.updateButtonTitle(tag: self.profileViewModel.tagData[indexPath.item])
-
+        
         return cell
     }
     

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/Profile/Views/ProfileViewController.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/Profile/Views/ProfileViewController.swift
@@ -259,14 +259,14 @@ private extension ProfileViewController {
     
     @objc
     func deletePhoto() {
-        self.dismiss(animated: true)
+        alertVC.dismissBottomSheet()
         profileView.updateProfileImage(image: UIImage(resource: .emptyProfileImg))
         profileViewModel.profileImage.value = UIImage(resource: .emptyProfileImg)
     }
     
     @objc
     func registerPhoto() {
-        self.dismiss(animated: true)
+        alertVC.dismissBottomSheet()
         imagePickerViewController.presentPicker(from: self)
     }
     

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/Profile/Views/ProfileViewController.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/Profile/Views/ProfileViewController.swift
@@ -17,6 +17,11 @@ final class ProfileViewController: BaseNavBarViewController {
     
     private let imagePickerViewController = CustomImagePicker(isProfilePicker: true)
     
+    lazy var alertVC = DRBottomSheetViewController(contentView: profileImageSettingView,
+                                              height: 288,
+                                              buttonType: DisabledButton(),
+                                              buttonTitle: StringLiterals.Common.cancel)
+    
     
     // MARK: - Properties
     
@@ -210,13 +215,10 @@ private extension ProfileViewController {
     
     @objc
     func presentEditBottomSheet() {
-        let alertVC = DRBottomSheetViewController(contentView: profileImageSettingView,
-                                                  height: 288,
-                                                  buttonType: DisabledButton(),
-                                                  buttonTitle: StringLiterals.Common.cancel)
         alertVC.delegate = self
-        alertVC.modalPresentationStyle = .overFullScreen
-        self.present(alertVC, animated: true)
+        DispatchQueue.main.async {
+            self.alertVC.presentBottomSheet(in: self)
+        }
     }
     
     @objc
@@ -340,7 +342,7 @@ extension ProfileViewController: UITextFieldDelegate {
 extension ProfileViewController: DRBottomSheetDelegate {
     
     func didTapBottomButton() {
-        self.dismiss(animated: true)
+        alertVC.dismissBottomSheet()
     }
     
     func didTapFirstLabel() {


### PR DESCRIPTION
# 🔥*Pull requests*

## ⛳ **작업한 브랜치**
- fix/#266

## 👷 **작업한 내용**
<!-- 작업한 내용을 적어주세요. -->
- [x] 바텀 시트 동작 시 blurView 페이드인 효과 적용
- [x] '코스&일정 등록 2' `장소명` 공백 제한
- [x] '코스&일정 등록 2' `cell 장소명` 레이아웃 버그 수정
- [x] '코스&일정 등록 2' 장소 폰트 미적용 수정
  - 단순 일정등록 (불러오기 X)의 경우 datePlaceTextField에서 실시간 입력시 폰트가 적용되지 않아 수정하였습니다. 
- [x] 데이터 로딩 방식 변경
  - 참고: https://github.com/TeamDATEROAD/DATEROAD-iOS/pull/265

## 📬 **편지**
### 어머니에게
**`어머니 죄송합니다.. 결국 `좋아요` 자식에게 져버리고 말았습니다.. 기절했다가 일어나서 심기일전의 마음으로 다시금 도전할테니 지켜봐주십쇼..`**

## 🚨 참고 사항
<!-- 참고할 사항이 있다면 적어주세요. -->
- 데이터 로딩 방식 변경 할 함수 선정은 TargetType의 값이 `return .get`인 함수를 중점으로 진행하였습니다.
- 각각 `performBatchUpdates`를 적용한 것과 미적용한 것이 있는데 이처럼 진행한 이유에 대한 코멘트를 조금 적어보았습니다.
  - 피드백 주시면 바로바로 수정하겠습니다!🔥
- `: 클론` 을 기준으로 좌측은 TargetType `case Method` 값이고, 우측은 실제 코드에서 활용된 메소드 명 입니다.
  - 자세한 것은 아래 참고하여 주세요.
- 더불어 페이드인과 같은 사항들은 추후 작성하여 추가하겠습니다..!

### .getDateSchedule :

- getUpcomingDateScheduleData()
    - 다가올 데이트 일정 (카드 형태 list)
    - performBatchUpdates 적용 (근데 조금 어색)
- getPastDateScheduleData()
    - 지난 데이트 (카드 형태 list)
    - performBatchUpdates 미적용

### .getDateDetail : getDateDetailData(dateID: Int)

- 지난 데이트 일정 상세보기 & 다가올 데이트 일정 상세보기
    - performBatchUpdates 적용 (단, reloadData)

### .getPointDetail : getPointDetail(nowEarnedPointHidden: Bool)

- 포인트 획득 & 사용 내역
    - performBatchUpdates 적용

### .getCourseDetailInfo : getCourseDetail()

- ‘코스 상세보기’
    - performBatchUpdates 적용 (단, reloadData)

### .viewedCourse : setViewedCourseData()

- setViewedCourseData()
    - ‘내가 열람한 코스’
    - performBatchUpdates 적용
- setNavViewedCourseData()
    - 일정등록(불러오기 '내가 열람한 코스')
    - performBatchUpdates 미적용
- setViewedCourseData()
    - ‘내가 등록한 코스’
    - performBatchUpdates 미적용 (적용시 반짝임)

### .getBannerDetail : getBannerDetail()

- 배너 게시글 상세보기
    - performBatchUpdates 적용 (단, reloadData)
    - 추후 각 섹션에 맞는 파트만 업데이트 하도록 코드 뜯어봐야함..

### .myRegisterCourse : setMyRegisterCourseData()

- ‘내가 등록한 코스’
    - performBatchUpdates 미적용

### .getCourseInfo : getCourse() 

- ’코스 둘러보기’
    - performBatchUpdates 적용
    - 새로운 데이터가 코스에 추가되면 컬렉션뷰 새롭게 로드함


## 📟 관련 이슈
- Resolved: #266 
