### PR TITLE
[HOTFIX] 이슈 해결 (#268)

### DIFF
--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/AddCourse/Views/AddCourseThird/AddCourseThirdViewController.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/AddCourse/Views/AddCourseThird/AddCourseThirdViewController.swift
@@ -154,9 +154,7 @@ private extension AddCourseThirdViewController {
             guard let onLoading, let onFailNetwork = self?.viewModel.onFailNetwork.value else { return }
             
             if !onFailNetwork {
-                onLoading ? self?.showLoadingView() : self?.hideLoadingView()
-                self?.addCourseThirdView.isHidden = onLoading
-                self?.tabBarController?.tabBar.isHidden = onLoading
+                onLoading ? self?.showLoadingView(type: StringLiterals.TabBar.myPage) : self?.hideLoadingView()
             }
         }
         

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/AddSchedule/ViewModels/AddScheduleViewModel.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/AddSchedule/ViewModels/AddScheduleViewModel.swift
@@ -373,22 +373,22 @@ extension AddScheduleViewModel {
         print(addPlaceCollectionViewDataSource, "addPlaceCollectionViewDataSource : \(addPlaceCollectionViewDataSource)")
         print(places, "places : \(places)")
         
-        guard let dateName = dateName.value else {return}
-        guard let visitDate = visitDate.value else {return}
-        guard let dateStartAt = dateStartAt.value else {return}
+        guard let dateName = dateName.value,
+              let visitDate = visitDate.value,
+              let dateStartAt = dateStartAt.value
+        else {return}
         let country = country
         let city = city
         let postAddScheduleTags = selectedTagData.map { PostAddScheduleTag(tag: $0) }
         
-        NetworkService.shared.addScheduleService.postAddSchedule(course: PostAddScheduleRequest(
-            title: dateName,
-            date: visitDate,
-            startAt: dateStartAt,
-            tags: postAddScheduleTags,
-            country: country,
-            city: city,
-            places: places)) { result in
-                switch result {
+        NetworkService.shared.addScheduleService.postAddSchedule(course: PostAddScheduleRequest(title: dateName,
+                                                                                                date: visitDate,
+                                                                                                startAt: dateStartAt,
+                                                                                                tags: postAddScheduleTags,
+                                                                                                country: country,
+                                                                                                city: city,
+                                                                                                places: places)) { result in
+            switch result {
                 case .success(let response):
                     print("Success: \(response)")
                     self.setLoading(isLoading: false)

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/AddSchedule/Views/AddScheduleSecond/AddScheduleSecondViewController.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/AddSchedule/Views/AddScheduleSecond/AddScheduleSecondViewController.swift
@@ -90,9 +90,7 @@ final class AddScheduleSecondViewController: BaseNavBarViewController {
 private extension AddScheduleSecondViewController {
     
     func registerCell() {
-        addScheduleSecondView.addPlaceCollectionView.do {
-            $0.register(AddSecondViewCollectionViewCell.self, forCellWithReuseIdentifier: AddSecondViewCollectionViewCell.cellIdentifier)
-        }
+        addScheduleSecondView.addPlaceCollectionView.register(AddSecondViewCollectionViewCell.self, forCellWithReuseIdentifier: AddSecondViewCollectionViewCell.cellIdentifier)
     }
     
     func setDelegate() {
@@ -103,9 +101,8 @@ private extension AddScheduleSecondViewController {
             $0.dataSource = self
         }
         
-        [addScheduleSecondView.inAddScheduleSecondView.datePlaceTextField,
-         addScheduleSecondView.inAddScheduleSecondView.timeRequireTextField].forEach { i in
-            i.delegate = self
+        [addScheduleSecondView.inAddScheduleSecondView.datePlaceTextField, addScheduleSecondView.inAddScheduleSecondView.timeRequireTextField].forEach {
+            $0.delegate = self
         }
     }
     
@@ -158,9 +155,7 @@ private extension AddScheduleSecondViewController {
             guard let onLoading, let onFailNetwork = self?.viewModel.onFailNetwork.value else { return }
             
             if !onFailNetwork {
-                onLoading ? self?.showLoadingView() : self?.hideLoadingView()
-                self?.addScheduleSecondView.isHidden = onLoading
-                self?.tabBarController?.tabBar.isHidden = onLoading
+                onLoading ? self?.showLoadingView(type: StringLiterals.TabBar.myPage) : self?.hideLoadingView()
             }
         }
         
@@ -222,19 +217,19 @@ private extension AddScheduleSecondViewController {
     
     func setAddTarget() {
         addScheduleSecondView.editButton.addTarget(self, action: #selector(toggleEditMode), for: .touchUpInside)
+        
         addScheduleSecondView.inAddScheduleSecondView.addPlaceButton.addTarget(self, action: #selector(tapAddPlaceBtn), for: .touchUpInside)
+        
         addScheduleSecondView.nextBtn.addTarget(self, action: #selector(didTapNextBtn), for: .touchUpInside)
     }
     
     // 등록 완료 alertVC도 blurView 페이드인 적용 미정
     func successDone() {
-        let customAlertVC = DRCustomAlertViewController(
-            rightActionType: .none,
-            alertTextType: .hasDecription,
-            alertButtonType: .oneButton,
-            titleText: StringLiterals.AddCourseOrSchedule.AddCourseAlert.alertScheduelTitleLabel,
-            longButtonText: StringLiterals.AddCourseOrSchedule.AddCourseAlert.doneButton
-        )
+        let customAlertVC = DRCustomAlertViewController(rightActionType: .none,
+                                                        alertTextType: .hasDecription,
+                                                        alertButtonType: .oneButton,
+                                                        titleText: StringLiterals.AddCourseOrSchedule.AddCourseAlert.alertScheduelTitleLabel,
+                                                        longButtonText: StringLiterals.AddCourseOrSchedule.AddCourseAlert.doneButton)
         customAlertVC.delegate = self
         customAlertVC.modalPresentationStyle = .overFullScreen
         self.present(customAlertVC, animated: false)

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/Base/BaseViewController.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/Base/BaseViewController.swift
@@ -54,7 +54,8 @@ class BaseViewController: UIViewController {
         if type == StringLiterals.TabBar.home
             || type == StringLiterals.TabBar.myPage
             || type == StringLiterals.Course.course
-            || type == StringLiterals.Amplitude.ViewPath.courseDetail {
+            || type == StringLiterals.Amplitude.ViewPath.courseDetail
+            || type == StringLiterals.ViewedCourse.title {
             backgroundView.backgroundColor = UIColor.clear
             lottieView.backgroundColor = UIColor.clear
         } else {

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/Course/ViewModels/CourseViewModel.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/Course/ViewModels/CourseViewModel.swift
@@ -98,12 +98,8 @@ extension CourseViewModel {
                         like: filterList.like
                     )
                 }
-                
-                if self.courseListModel != courseModels {
-                    self.courseListModel = courseModels
-                    self.didUpdateCourseList?()
-                }
-                
+                self.courseListModel = courseModels
+                self.didUpdateCourseList?()
                 self.isSuccessGetData.value = true
             case .reIssueJWT:
                 self.patchReissue { isSuccess in

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/Course/Views/CourseListView.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/Course/Views/CourseListView.swift
@@ -30,10 +30,7 @@ final class CourseListView: BaseView {
     }
     
     override func setHierarchy() {
-        self.addSubviews(
-            emptyView,
-            courseListCollectionView
-        )
+        self.addSubviews(emptyView, courseListCollectionView)
     }
     
     override func setLayout() {

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/Course/Views/CourseViewController.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/Course/Views/CourseViewController.swift
@@ -29,6 +29,8 @@ final class CourseViewController: BaseViewController {
     
     private var selectedButton: UIButton?
     
+    private var loaded: Bool = false
+    
     
     // MARK: - Life Cycle
     
@@ -102,7 +104,10 @@ final class CourseViewController: BaseViewController {
         }
         
         self.courseViewModel.onLoading.bind { [weak self] onLoading in
-            guard let onLoading, let onFailNetwork = self?.courseViewModel.onFailNetwork.value else { return }
+            guard let onLoading,
+                  let loaded = self?.loaded,
+                  let onFailNetwork = self?.courseViewModel.onFailNetwork.value
+            else { return }
             
             if !onFailNetwork {
                 if !onFailNetwork {
@@ -111,7 +116,14 @@ final class CourseViewController: BaseViewController {
                         self?.courseView.courseListView.isHidden = true
                         self?.showLoadingView(type: StringLiterals.Course.course)
                     } else {
-                        self?.courseView.courseListView.courseListCollectionView.reloadData()
+                        if !loaded {
+                            UIView.performWithoutAnimation {
+                                self?.courseView.courseListView.courseListCollectionView.performBatchUpdates({
+                                    self?.courseView.courseListView.courseListCollectionView.reloadSections(IndexSet(integer: 0))
+                                })
+                            }
+                            self?.loaded = true
+                        }
                         self?.courseView.courseListView.isHidden = false
                         self?.courseView.courseSkeletonView.isHidden = true
                         self?.hideLoadingView()
@@ -146,7 +158,7 @@ final class CourseViewController: BaseViewController {
             
             // 새로운 데이터 추가됐을 때 스크롤 최상단으로 올리고자 한다면
             // 아래에 scrollToItem 코드 추가
-            DispatchQueue.main.async {
+            UIView.performWithoutAnimation {
                 self?.courseView.courseListView.courseListCollectionView.performBatchUpdates({
                     self?.courseView.courseListView.courseListCollectionView.reloadSections(IndexSet(integer: 0))
                 })

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/Course/Views/CourseViewController.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/Course/Views/CourseViewController.swift
@@ -112,8 +112,6 @@ final class CourseViewController: BaseViewController {
             if !onFailNetwork {
                 if !onFailNetwork {
                     if onLoading {
-                        self?.courseView.courseSkeletonView.isHidden = false
-                        self?.courseView.courseListView.isHidden = true
                         self?.showLoadingView(type: StringLiterals.Course.course)
                     } else {
                         if !loaded {

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/CourseDetail/Views/CourseDetailViewController.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/CourseDetail/Views/CourseDetailViewController.swift
@@ -603,9 +603,6 @@ extension CourseDetailViewController: UICollectionViewDelegate, UICollectionView
     
     private func configureBottomPageControlView(_ collectionView: UICollectionView, indexPath: IndexPath, imageData: [ThumbnailModel], isAccess: Bool) -> UICollectionReusableView {
         return collectionViewUtils.dequeueAndConfigureSupplementaryView(collectionView: collectionView, indexPath: indexPath, kind: BottomPageControllView.elementKinds, identifier: BottomPageControllView.identifier) { (view: BottomPageControllView) in
-//            if !isFirstLike {
-//                localLikeNum += courseDetailViewModel.isUserLiked.value == true ? 1 : -1
-//            }
             view.pageIndexSum = imageData.count
             view.bindData(like: localLikeNum)
         }

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/CourseDetail/Views/CourseDetailViewController.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/CourseDetail/Views/CourseDetailViewController.swift
@@ -307,61 +307,49 @@ extension CourseDetailViewController: ContentMaskViewDelegate {
     
     // 무료 사용 기회를 다 쓴 경우의 알림
     func showReadCourseAlert() {
-        presentCustomAlert(
-            title: StringLiterals.Alert.buyCourse,
-            description: StringLiterals.Alert.canNotRefund,
-            action: .checkCourse,
-            buttonText: StringLiterals.CourseDetail.check
-        )
+        presentCustomAlert(title: StringLiterals.Alert.buyCourse,
+                           description: StringLiterals.Alert.canNotRefund,
+                           action: .checkCourse,
+                           buttonText: StringLiterals.CourseDetail.check)
     }
     
     // 무료 사용 기회가 남은 경우의 알림
     func showFreeViewAlert() {
-        presentCustomAlert(
-            title: StringLiterals.CourseDetail.freeViewTitle,
-            description: StringLiterals.CourseDetail.freeViewDescription,
-            action: .checkCourse,
-            buttonText: StringLiterals.CourseDetail.check
-        )
+        presentCustomAlert(title: StringLiterals.CourseDetail.freeViewTitle,
+                           description: StringLiterals.CourseDetail.freeViewDescription,
+                           action: .checkCourse,
+                           buttonText: StringLiterals.CourseDetail.check)
     }
     
     //포인트가 부족할 때
     func showPointAlert(){
-        presentCustomAlert(
-            title: StringLiterals.CourseDetail.insufficientPointsTitle,
-            description: StringLiterals.CourseDetail.insufficientPointsDescription,
-            action: .addCourse,
-            buttonText: StringLiterals.CourseDetail.addCourse
-        )
+        presentCustomAlert(title: StringLiterals.CourseDetail.insufficientPointsTitle,
+                           description: StringLiterals.CourseDetail.insufficientPointsDescription,
+                           action: .addCourse,
+                           buttonText: StringLiterals.CourseDetail.addCourse)
     }
     
     //바텀 시트에서 신고하기 클릭시 팝업창
     func showDeclareAlert(){
-        presentCustomAlert(
-            title: StringLiterals.CourseDetail.declareTitle,
-            description: StringLiterals.CourseDetail.declareDescription,
-            action: .declareCourse
-        )
+        presentCustomAlert(title: StringLiterals.CourseDetail.declareTitle,
+                           description: StringLiterals.CourseDetail.declareDescription,
+                           action: .declareCourse)
     }
     
     //바텀 시트에서 삭제하기 클릭시 팝업창
     func showDeleteAlert(){
-        presentCustomAlert(
-            title: StringLiterals.CourseDetail.deleteTitle,
-            description: StringLiterals.CourseDetail.deleteDescription,
-            action: .deleteCourse
-        )
+        presentCustomAlert(title: StringLiterals.CourseDetail.deleteTitle,
+                           description: StringLiterals.CourseDetail.deleteDescription,
+                           action: .deleteCourse)
     }
     
     func presentCustomAlert(title: String, description: String, action: RightButtonType, buttonText: String = StringLiterals.Alert.confirm) {
-        let alertVC = DRCustomAlertViewController(
-            rightActionType: action,
-            alertTextType: .hasDecription,
-            alertButtonType: .twoButton,
-            titleText: title,
-            descriptionText: description,
-            rightButtonText: buttonText
-        )
+        let alertVC = DRCustomAlertViewController(rightActionType: action,
+                                                  alertTextType: .hasDecription,
+                                                  alertButtonType: .twoButton,
+                                                  titleText: title,
+                                                  descriptionText: description,
+                                                  rightButtonText: buttonText)
         alertVC.delegate = self
         alertVC.modalPresentationStyle = .overFullScreen
         present(alertVC, animated: false)
@@ -464,6 +452,8 @@ private extension CourseDetailViewController {
         guard let isLiked = courseDetailViewModel.isUserLiked.value else { return }
         courseDetailViewModel.isUserLiked.value?.toggle()
         
+        self.localLikeNum += isLiked ? -1 : 1
+        
         let likeAction = isLiked ? courseDetailViewModel.deleteLikeCourse : courseDetailViewModel.likeCourse
         likeAction(courseId ?? 0) { [weak self] isSuccess in
             DispatchQueue.main.async {
@@ -473,9 +463,12 @@ private extension CourseDetailViewController {
             }
         }
         
-        AmplitudeManager.shared.trackEventWithProperties(StringLiterals.Amplitude.EventName.clickCourseLikes, properties: [StringLiterals.Amplitude.Property.courseListLike : self.courseListLike])
+        // 해당 섹션의 헤더 뷰 가져오기
+        if let header = courseDetailView.mainCollectionView.supplementaryView(forElementKind: BottomPageControllView.elementKinds, at: IndexPath(item: 0, section: 0)) as? BottomPageControllView {
+            header.bindData(like: self.localLikeNum)
+        }
         
-        self.courseDetailView.mainCollectionView.reloadData()
+        AmplitudeManager.shared.trackEventWithProperties(StringLiterals.Amplitude.EventName.clickCourseLikes, properties: [StringLiterals.Amplitude.Property.courseListLike : self.courseListLike])
     }
     
 }
@@ -610,9 +603,9 @@ extension CourseDetailViewController: UICollectionViewDelegate, UICollectionView
     
     private func configureBottomPageControlView(_ collectionView: UICollectionView, indexPath: IndexPath, imageData: [ThumbnailModel], isAccess: Bool) -> UICollectionReusableView {
         return collectionViewUtils.dequeueAndConfigureSupplementaryView(collectionView: collectionView, indexPath: indexPath, kind: BottomPageControllView.elementKinds, identifier: BottomPageControllView.identifier) { (view: BottomPageControllView) in
-            if !isFirstLike {
-                localLikeNum += courseDetailViewModel.isUserLiked.value == true ? 1 : -1
-            }
+//            if !isFirstLike {
+//                localLikeNum += courseDetailViewModel.isUserLiked.value == true ? 1 : -1
+//            }
             view.pageIndexSum = imageData.count
             view.bindData(like: localLikeNum)
         }

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/DateSchedule/View/Cells/DateCardCollectionViewCell.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/DateSchedule/View/Cells/DateCardCollectionViewCell.swift
@@ -58,6 +58,11 @@ final class DateCardCollectionViewCell: BaseCollectionViewCell {
         fatalError("init(coder:) has not been implemented")
     }
     
+    override func prepareForReuse() {
+        self.secondTagButton.isHidden = true
+        self.thirdTagButton.isHidden = true
+    }
+    
     override func setHierarchy() {
         self.addSubviews(topImageView,
                          bottomImageView,
@@ -89,7 +94,6 @@ final class DateCardCollectionViewCell: BaseCollectionViewCell {
         dateLabel.snp.makeConstraints {
             $0.top.leading.equalToSuperview().inset(20)
             $0.height.equalTo(62)
-            // $0.trailing.equalTo(dDayButton.snp.leading).offset(10)
         }
         
         dDayButton.snp.makeConstraints {
@@ -145,19 +149,19 @@ final class DateCardCollectionViewCell: BaseCollectionViewCell {
     override func setStyle() {
         self.backgroundColor = .systemRed
         
-        self.roundCorners(cornerRadius: 20, maskedCorners: [.layerMaxXMaxYCorner, .layerMaxXMinYCorner, .layerMinXMaxYCorner, .layerMinXMinYCorner])
+        self.roundCorners(cornerRadius: 20, maskedCorners: [.layerMaxXMaxYCorner,
+                                                            .layerMaxXMinYCorner,
+                                                            .layerMinXMaxYCorner,
+                                                            .layerMinXMinYCorner])
         
-        topImageView.do {
-            $0.contentMode = .scaleAspectFill
-        }
+        topImageView.contentMode = .scaleAspectFill
         
-        bottomImageView.do {
-            $0.contentMode = .scaleAspectFill
-        }
+        bottomImageView.contentMode = .scaleAspectFill
         
-        dateLabel.do {
-            $0.setLabel(alignment: .left, numberOfLines: 2, textColor: UIColor(resource: .drBlack), font: UIFont.suit(.title_extra_24))
-        }
+        dateLabel.setLabel(alignment: .left,
+                           numberOfLines: 2,
+                           textColor: UIColor(resource: .drBlack),
+                           font: UIFont.suit(.title_extra_24))
         
         dDayButton.do {
             $0.titleLabel?.font = UIFont.suit(.cap_bold_11)
@@ -207,21 +211,13 @@ final class DateCardCollectionViewCell: BaseCollectionViewCell {
             $0.adjustsImageWhenDisabled = false
         }
         
-        dotDividerView.do {
-            $0.image = UIImage(resource: .dottedLine)
-        }
+        dotDividerView.image = UIImage(resource: .dottedLine)
         
-        leftCircleInsetImageView.do {
-            $0.image = UIImage(resource: .leftCardInset)
-        }
+        leftCircleInsetImageView.image = UIImage(resource: .leftCardInset)
         
-        rightCircleInsetImageView.do {
-            $0.image = UIImage(resource: .rightCardInset)
-        }
+        rightCircleInsetImageView.image = UIImage(resource: .rightCardInset)
         
-        locationLabel.do {
-            $0.setLabel(textColor: UIColor(resource: .gray500), font: UIFont.suit(.body_med_15))
-        }
+        locationLabel.setLabel(textColor: UIColor(resource: .gray500), font: UIFont.suit(.body_med_15))
         
         titleLabel.do {
             $0.setLabel(alignment: .left, numberOfLines: 2, textColor: UIColor(resource: .drBlack), font: UIFont.suit(.title_extra_24))

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/DateSchedule/View/UpcomingDateScheduleView.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/DateSchedule/View/UpcomingDateScheduleView.swift
@@ -81,9 +81,9 @@ final class UpcomingDateScheduleView: BaseView {
     override func setStyle() {
         self.backgroundColor = UIColor(resource: .drWhite)
         
-        titleLabel.do {
-            $0.setLabel(text: StringLiterals.DateSchedule.upcomingDate, textColor: UIColor(resource: .drBlack), font: UIFont.suit(.title_bold_20))
-        }
+        titleLabel.setLabel(text: StringLiterals.DateSchedule.upcomingDate,
+                            textColor: UIColor(resource: .drBlack),
+                            font: UIFont.suit(.title_bold_20))
         
         cardCollectionView.do {
             $0.backgroundColor = UIColor(resource: .drWhite)
@@ -112,7 +112,10 @@ final class UpcomingDateScheduleView: BaseView {
         dateRegisterButton.do {
             $0.backgroundColor = UIColor(resource: .deepPurple)
             $0.setImage(UIImage(resource: .plusSchedule), for: .normal)
-            $0.roundedButton(cornerRadius: 15, maskedCorners: [.layerMaxXMaxYCorner, .layerMaxXMinYCorner, .layerMinXMaxYCorner, .layerMinXMinYCorner])
+            $0.roundedButton(cornerRadius: 15, maskedCorners: [.layerMaxXMaxYCorner,
+                                                               .layerMaxXMinYCorner,
+                                                               .layerMinXMaxYCorner,
+                                                               .layerMinXMinYCorner])
         }
         
         pastDateButton.do {
@@ -120,7 +123,10 @@ final class UpcomingDateScheduleView: BaseView {
             $0.backgroundColor = UIColor(resource: .gray100)
             $0.titleLabel?.font = UIFont.suit(.body_bold_15)
             $0.setTitleColor(UIColor(resource: .drBlack), for: .normal)
-            $0.roundedButton(cornerRadius: 13, maskedCorners: [.layerMaxXMaxYCorner, .layerMaxXMinYCorner, .layerMinXMaxYCorner, .layerMinXMinYCorner])
+            $0.roundedButton(cornerRadius: 13, maskedCorners: [.layerMaxXMaxYCorner,
+                                                               .layerMaxXMinYCorner,
+                                                               .layerMinXMaxYCorner,
+                                                               .layerMinXMinYCorner])
         }
     }
     

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/DateSchedule/View/UpcomingDateScheduleViewController.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/DateSchedule/View/UpcomingDateScheduleViewController.swift
@@ -94,9 +94,11 @@ private extension UpcomingDateScheduleViewController {
             guard let flag else { return }
             if flag {
                 DispatchQueue.main.async {
-                    self?.upcomingDateScheduleView.cardCollectionView.performBatchUpdates({
-                        self?.upcomingDateScheduleView.cardCollectionView.reloadSections(IndexSet(integer: 0))
-                    })
+                    UIView.performWithoutAnimation {
+                        self?.upcomingDateScheduleView.cardCollectionView.performBatchUpdates({
+                            self?.upcomingDateScheduleView.cardCollectionView.reloadSections(IndexSet(integer: 0))
+                        })
+                    }
                 }
                 self?.upcomingDateScheduleViewModel.updateUpcomingDateScheduleData.value = false
             }

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/DateSchedule/View/UpcomingDateScheduleViewController.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/DateSchedule/View/UpcomingDateScheduleViewController.swift
@@ -170,7 +170,12 @@ extension UpcomingDateScheduleViewController: DRCustomAlertDelegate {
     @objc
     private func dateRegisterButtonTapped() {
         if upcomingDateScheduleViewModel.isMoreThanFiveSchedule {
-            let customAlertVC = DRCustomAlertViewController(rightActionType: RightButtonType.none, alertTextType: .hasDecription, alertButtonType: .oneButton, titleText: StringLiterals.Alert.noMoreSchedule, descriptionText: StringLiterals.Alert.noMoreThanFive, longButtonText: StringLiterals.Alert.iChecked)
+            let customAlertVC = DRCustomAlertViewController(rightActionType: RightButtonType.none,
+                                                            alertTextType: .hasDecription, 
+                                                            alertButtonType: .oneButton,
+                                                            titleText: StringLiterals.Alert.noMoreSchedule,
+                                                            descriptionText: StringLiterals.Alert.noMoreThanFive,
+                                                            longButtonText: StringLiterals.Alert.iChecked)
             customAlertVC.delegate = self
             customAlertVC.modalPresentationStyle = .overFullScreen
             self.present(customAlertVC, animated: false)
@@ -243,9 +248,7 @@ extension UpcomingDateScheduleViewController: UICollectionViewDataSource {
     
     func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
         let data = upcomingDateScheduleViewModel.upcomingDateScheduleData.value?[indexPath.item] ?? DateCardModel.emptyModel
-        guard let cell = collectionView.dequeueReusableCell(withReuseIdentifier: DateCardCollectionViewCell.cellIdentifier, for: indexPath) as? DateCardCollectionViewCell else {
-            return UICollectionViewCell()
-        }
+        guard let cell = collectionView.dequeueReusableCell(withReuseIdentifier: DateCardCollectionViewCell.cellIdentifier, for: indexPath) as? DateCardCollectionViewCell else { return UICollectionViewCell() }
         cell.dataBind(data, indexPath.item)
         cell.setColor(index: indexPath.item)
         cell.addGestureRecognizer(UITapGestureRecognizer(target: self, action: #selector(pushToUpcomingDateDetailVC(_:))))

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/Main/Views/Cells/MainHeaderView.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/Main/Views/Cells/MainHeaderView.swift
@@ -111,8 +111,9 @@ extension MainHeaderView {
             titleLabel.do {
                 $0.setAttributedText(fullText: nickname + StringLiterals.Main.hotDateTitle,
                                      pointText: nickname+"님,",
-                                     pointColor: UIColor(resource: .deepPurple), lineHeight: 1.04)
-                $0.font = UIFont.suit(.title_extra_24)
+                                     pointColor: UIColor(resource: .deepPurple), 
+                                     lineHeight: 1.04)
+                $0.font = UIFont.systemFont(ofSize: 24, weight: .black)
                 $0.textAlignment = .left
                 $0.numberOfLines = 2
             }

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/Main/Views/Cells/UpcomingDateCell.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/Main/Views/Cells/UpcomingDateCell.swift
@@ -35,7 +35,6 @@ final class UpcomingDateCell: BaseCollectionViewCell {
         self.profileImage.image = nil
         self.pointLabel.text = nil
         self.profileImage.backgroundColor = .clear // 배경색 초기화
-        self.profileImage.layer.cornerRadius = self.profileImage.frame.size.width / 2  // cornerRadius 다시 적용
         self.profileImage.clipsToBounds = true
     }
     
@@ -122,19 +121,20 @@ extension UpcomingDateCell {
         guard let point = mainUserData?.point else { return }
         pointLabel.text = "\(point) P"
         
+        guard let imageUrl = mainUserData?.imageUrl else {
+            self.profileImage.image = UIImage(resource: .emptyProfileImg)
+            return
+        }
+        
+        let url = URL(string: imageUrl)
+        self.profileImage.kf.setImage(with: url, options: [.transition(.none),
+                                                           .cacheOriginalImage,
+                                                           .keepCurrentImageWhileLoading])
         profileImage.do {
             $0.clipsToBounds = true
             $0.layer.cornerRadius = $0.frame.size.width / 2
             $0.backgroundColor = .clear
         }
-        guard let imageUrl = mainUserData?.imageUrl else {
-            self.profileImage.image = UIImage(resource: .emptyProfileImg)
-            return
-        }
-        let url = URL(string: imageUrl)
-        self.profileImage.kf.setImage(with: url, options: [.transition(.none),
-                                                           .cacheOriginalImage,
-                                                           .keepCurrentImageWhileLoading])
     }
     
 }

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/Main/Views/MainViewController.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/Main/Views/MainViewController.swift
@@ -100,9 +100,11 @@ extension MainViewController {
         self.mainViewModel.updateSectionIndex.bind { [weak self] index in
             guard let index, let loaded = self?.loaded else { return }
             if loaded {
-                self?.mainView.mainCollectionView.performBatchUpdates({
-                    self?.mainView.mainCollectionView.reloadSections(IndexSet(integer: index))
-                })
+                UIView.performWithoutAnimation {
+                    self?.mainView.mainCollectionView.performBatchUpdates({
+                        self?.mainView.mainCollectionView.reloadSections(IndexSet(integer: index))
+                    })
+                }
             }
         }
         

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/MyCourse/Views/Cells/MyCourseListCollectionViewCell.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/MyCourse/Views/Cells/MyCourseListCollectionViewCell.swift
@@ -179,8 +179,7 @@ extension MyCourseListCollectionViewCell {
     
     func dataBind(_ viewedCourseData: MyCourseModel?, _ viewedCourseItemRow: Int?) {
         guard let viewedCourseData else { return }
-        self.thumbnailImageView.kf.setImage(with: URL(string: viewedCourseData.thumbnail),
-                                            options: [.transition(.none),.cacheOriginalImage])
+        self.thumbnailImageView.kf.setImage(with: URL(string: viewedCourseData.thumbnail), options: [.transition(.none),.cacheOriginalImage])
         self.courseID = viewedCourseData.courseId
         self.heartButton.setTitle("\(viewedCourseData.like)", for: .normal)
         self.locationLabel.text = viewedCourseData.city

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/MyCourse/Views/MyRegisterCourseViewController.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/MyCourse/Views/MyRegisterCourseViewController.swift
@@ -91,9 +91,11 @@ extension MyRegisterCourseViewController {
             guard let flag else { return }
             if flag {
                 DispatchQueue.main.async {
-                    self?.myRegisterCourseView.myCourseListCollectionView.performBatchUpdates({
-                        self?.myRegisterCourseView.myCourseListCollectionView.reloadSections(IndexSet(integer: 0))
-                    })
+                    UIView.performWithoutAnimation {
+                        self?.myRegisterCourseView.myCourseListCollectionView.performBatchUpdates({
+                            self?.myRegisterCourseView.myCourseListCollectionView.reloadSections(IndexSet(integer: 0))
+                        })
+                    }
                 }
                 self?.myRegisterCourseViewModel.myRegisterCoursesModelIsUpdate.value = false
             }

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/MyCourse/Views/ViewedCourseViewController.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/MyCourse/Views/ViewedCourseViewController.swift
@@ -35,6 +35,11 @@ final class ViewedCourseViewController: BaseViewController {
     
     private let userName: String = UserDefaults.standard.string(forKey: StringLiterals.Network.userName) ?? ""
     
+    private var loaded: Bool = false
+    
+    
+    // MARK: - LifeCycle
+    
     init(viewedCourseViewModel: MyCourseListViewModel) {
         self.viewedCourseViewModel = viewedCourseViewModel
         
@@ -44,9 +49,6 @@ final class ViewedCourseViewController: BaseViewController {
     required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
-    
-    
-    // MARK: - LifeCycle
     
     override func viewWillAppear(_ animated: Bool) {
         self.viewedCourseViewModel.setViewedCourseData()
@@ -118,13 +120,11 @@ final class ViewedCourseViewController: BaseViewController {
         super.setStyle()
         
         topLabel.do {
-            $0.font = UIFont.suit(.title_extra_24)
-            $0.setAttributedText(
-                fullText: "\(self.userName)님이 지금까지\n열람한 데이트 코스\n\(viewedCourseViewModel.viewedCourseData.value?.count ?? 0)개",
-                pointText: "\(viewedCourseViewModel.viewedCourseData.value?.count ?? 0)",
-                pointColor: UIColor(resource: .mediumPurple),
-                lineHeight: 1
-            )
+            $0.font = UIFont.systemFont(ofSize: 24, weight: .black)
+            $0.setAttributedText(fullText: "\(self.userName)님이 지금까지\n열람한 데이트 코스\n\(viewedCourseViewModel.viewedCourseData.value?.count ?? 0)개",
+                                 pointText: "\(viewedCourseViewModel.viewedCourseData.value?.count ?? 0)",
+                                 pointColor: UIColor(resource: .mediumPurple),
+                                 lineHeight: 1)
             $0.numberOfLines = 3
         }
         
@@ -134,16 +134,17 @@ final class ViewedCourseViewController: BaseViewController {
             $0.isUserInteractionEnabled = true
         }
         
-        createCourseLabel.setLabel(
-            text: StringLiterals.ViewedCourse.registerSchedule,
-            textColor: UIColor(resource: .drBlack),
-            font: UIFont.suit(.title_bold_18)
-        )
+        createCourseLabel.setLabel(text: StringLiterals.ViewedCourse.registerSchedule,
+                                   textColor: UIColor(resource: .drBlack),
+                                   font: UIFont.suit(.title_bold_18))
         
         arrowButton.do {
             $0.setButtonStatus(buttonType: EnabledButton())
             $0.setImage(UIImage(resource: .createCourseArrow), for: .normal)
-            $0.roundedButton(cornerRadius: 13, maskedCorners: [.layerMinXMinYCorner, .layerMaxXMinYCorner, .layerMinXMaxYCorner, .layerMaxXMaxYCorner])
+            $0.roundedButton(cornerRadius: 13, maskedCorners: [.layerMinXMinYCorner,
+                                                               .layerMaxXMinYCorner,
+                                                               .layerMinXMaxYCorner,
+                                                               .layerMaxXMaxYCorner])
             $0.isUserInteractionEnabled = false
         }
     }
@@ -169,12 +170,10 @@ private extension ViewedCourseViewController {
         } else {
             DispatchQueue.main.async {
                 self.viewedCourseView.myCourseListCollectionView.reloadData()
-                self.topLabel.setAttributedText(
-                    fullText: "\(name)님이 지금까지\n열람한 데이트 코스\n\(self.viewedCourseViewModel.viewedCourseData.value?.count ?? 0)개",
-                    pointText: "\(self.viewedCourseViewModel.viewedCourseData.value?.count ?? 0)",
-                    pointColor: UIColor(resource: .mediumPurple),
-                    lineHeight: 1
-                )
+                self.topLabel.setAttributedText(fullText: "\(name)님이 지금까지\n열람한 데이트 코스\n\(self.viewedCourseViewModel.viewedCourseData.value?.count ?? 0)개",
+                                                pointText: "\(self.viewedCourseViewModel.viewedCourseData.value?.count ?? 0)",
+                                                pointColor: UIColor(resource: .mediumPurple),
+                                                lineHeight: 1)
             }
         }
     }
@@ -217,11 +216,17 @@ extension ViewedCourseViewController {
         }
         
         self.viewedCourseViewModel.onViewedCourseLoading.bind { [weak self] onLoading in
-            guard let onLoading, let onFailNetwork = self?.viewedCourseViewModel.onViewedCourseFailNetwork.value else { return }
+            guard let onLoading,
+                  let loaded = self?.loaded,
+                  let onFailNetwork = self?.viewedCourseViewModel.onViewedCourseFailNetwork.value
+            else { return }
             if !onFailNetwork {
                 if onLoading {
                     self?.showLoadingView(type: StringLiterals.ViewedCourse.title)
-                    self?.contentView.isHidden = true
+                    if !loaded {
+                        self?.contentView.isHidden = true
+                        self?.loaded = true
+                    }
                 } else {
                     self?.setEmptyView()
                     self?.contentView.isHidden = false

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/MyCourse/Views/ViewedCourseViewController.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/MyCourse/Views/ViewedCourseViewController.swift
@@ -189,7 +189,9 @@ extension ViewedCourseViewController {
         self.viewedCourseViewModel.viewedCoursesModelIsUpdate.bind { [weak self] flag in
             guard let flag else { return }
             if flag {
-                self?.viewedCourseView.myCourseListCollectionView.reloadSections(IndexSet(integer: 0))
+                UIView.performWithoutAnimation {
+                    self?.viewedCourseView.myCourseListCollectionView.reloadSections(IndexSet(integer: 0))
+                }
                 self?.viewedCourseViewModel.viewedCoursesModelIsUpdate.value = false
             }
         }

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/MyCourse/Views/ViewedCourseViewController.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/MyCourse/Views/ViewedCourseViewController.swift
@@ -190,11 +190,7 @@ extension ViewedCourseViewController {
         self.viewedCourseViewModel.viewedCoursesModelIsUpdate.bind { [weak self] flag in
             guard let flag else { return }
             if flag {
-                DispatchQueue.main.async {
-                    self?.viewedCourseView.myCourseListCollectionView.performBatchUpdates({
-                        self?.viewedCourseView.myCourseListCollectionView.reloadSections(IndexSet(integer: 0))
-                    })
-                }
+                self?.viewedCourseView.myCourseListCollectionView.reloadSections(IndexSet(integer: 0))
                 self?.viewedCourseViewModel.viewedCoursesModelIsUpdate.value = false
             }
         }

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/MyPage/Views/UserInfoView.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/MyPage/Views/UserInfoView.swift
@@ -107,9 +107,7 @@ final class UserInfoView: BaseView {
             $0.contentMode = .scaleAspectFill
         }
         
-        nicknameLabel.do {
-            $0.setLabel(textColor: UIColor(resource: .drBlack), font: UIFont.suit(.title_extra_24))
-        }
+        nicknameLabel.setLabel(textColor: UIColor(resource: .drBlack), font: UIFont.systemFont(ofSize: 24, weight: .black))
         
         editProfileButton.do {
             $0.image = UIImage(resource: .icPencil)
@@ -135,7 +133,7 @@ final class UserInfoView: BaseView {
             $0.setLabel(text: "님의 포인트",
                         alignment: .left,
                         textColor: UIColor(resource: .gray400),
-                        font: UIFont.suit(.body_med_13))
+                        font: UIFont.systemFont(ofSize: 13, weight: .medium))
             $0.numberOfLines = 1
             $0.textAlignment = .left
         }
@@ -147,23 +145,17 @@ final class UserInfoView: BaseView {
             $0.isUserInteractionEnabled = true
         }
         
-        pointLabel.do {
-            $0.setLabel(text: "0 P",
-                        alignment: .left,
-                        textColor: UIColor(resource: .drBlack),
-                        font: UIFont.suit(.title_extra_24))
-        }
+        pointLabel.setLabel(text: "0 P",
+                            alignment: .left,
+                            textColor: UIColor(resource: .drBlack),
+                            font: UIFont.suit(.title_extra_24))
         
-        goToPointHistoryLabel.do {
-            $0.setLabel(text: StringLiterals.MyPage.goToPointHistory,
-                        alignment: .left,
-                        textColor: UIColor(resource: .gray400),
-                        font: UIFont.suit(.body_med_13))
-        }
+        goToPointHistoryLabel.setLabel(text: StringLiterals.MyPage.goToPointHistory,
+                                       alignment: .left,
+                                       textColor: UIColor(resource: .gray400),
+                                       font: UIFont.suit(.body_med_13))
         
-        rightArrowButton.do {
-            $0.image = UIImage(resource: .arrowRightMini)
-        }
+        rightArrowButton.image = UIImage(resource: .arrowRightMini)
     }
     
 }

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/PointDetail/Views/PointDetailView.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/PointDetail/Views/PointDetailView.swift
@@ -112,7 +112,7 @@ final class PointDetailView: BaseView {
         }
         
         userNameLabel.do {
-            $0.font = UIFont.suit(.body_med_13)
+            $0.font = UIFont.systemFont(ofSize: 13, weight: .medium)
             $0.textColor = UIColor(resource: .drWhite)
             $0.textAlignment = .left
         }

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/Profile/Views/EditProfileViewController.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/Profile/Views/EditProfileViewController.swift
@@ -255,7 +255,7 @@ private extension EditProfileViewController {
         
         self.profileViewModel.onEditProfileLoading.bind { [weak self] onLoading in
             guard let onLoading else { return }
-            onLoading ? self?.showLoadingView() : self?.hideLoadingView()
+            onLoading ? self?.showLoadingView(type: StringLiterals.TabBar.myPage) : self?.hideLoadingView()
         }
     }
     


### PR DESCRIPTION
# 🔥*Pull requests*

## ⛳ **작업한 브랜치**
- hotfix/#268 

## 👷 **작업한 내용**
<!-- 작업한 내용을 적어주세요. -->
- [x] '코스 상세' 좋아요 개수 이슈 해결
- [x] 코스 둘러보기 이미지 로딩 깜빡임 이슈 해결
- [x] 다가오는 데이트 일정 카드 내 성향 태그 이슈 해결
- [x] 일정 및 코스 등록 후 로딩 배경 투명으로 변경
- [x] 폰트 지원 이슈 해결
- [x] 사용성 보완

## 🚨 참고 사항
<!-- 참고할 사항이 있다면 적어주세요. -->
### 1️⃣ '코스 상세' 좋아요 개수 바인딩 이슈
**Issue** : 좋아요 버튼 클릭 이벤트나 개수 반영은 잘 되었으나, 좋아요 버튼을 클릭 후 화면을 스크롤하면 좋아요를 등록한 경우에는 계속 +1이 되고 좋아요를 해제한 경우에는 계속 -1이 되는 이슈 발생
**Cause**: 기존에는 셀을 재사용하기 위해 사용하는 `dequeueReusableCell(withReuseIdentifier:for:)` 메소드 내부에서 좋아요 등록 및 해제 여부에 따라 좋아요 총 개수를 +1/-1 해주고 뷰에 바인딩하는 로직을 처리해주었습니다. 그렇기 때문에 스크롤해서 해당 셀이 다시 보이게 되면 이 재사용 메소드 또한 다시 호출되기 때문에 개수 증감이 중복으로 처리되었습니다
**Solution**: 좋아요 개수 관련 로직을 셀 재사용 메소드가 아닌 좋아요 버튼 액션 메소드 내부에서 처리해주었습니다.
``` Swift
@objc
func didTapLikeButton() {
    ...
    // 셀 재사용 메소드 내부에서 라벨에 개수를 바인딩할 때 self.localLikeNum을 사용하기 때문에 
    // 좋아요 버튼이 눌릴 때마다 개수를 해당 프로퍼티에 저장해주었습니다
    **self.localLikeNum += isLiked ? -1 : 1**
    ...
    }
```

### 2️⃣ 폰트 지원 이슈
**Issue** : '흿뤩', '츷츯' 와 같이 올바르지 않은 글씨는 화면에 나타나지 않는 이슈 발생
**Cause**: 현재 사용하는 폰트가 글자를 지원하지 않음
**Solution**: 올바르지 않은 글씨가 사용될만한 닉네임이 들어간 라벨과, 입력할 수 있는 텍스트필드 및 텍스트뷰 등에서는 시스템 폰트로 변경해주었습니다. 이 부분은 추후 디쟌선생님들과 논의해보고 다시 수정해야 할 것 같아요


## 📟 관련 이슈
- Resolved: #268 
