### PR TITLE
[HOTFIX] 프로필(등록, 변경), 열람한코스(탭바) 수정 (#272)

### DIFF
--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/MyCourse/ViewModels/MyCourseListViewModel.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/MyCourse/ViewModels/MyCourseListViewModel.swift
@@ -15,7 +15,7 @@ final class MyCourseListViewModel: Serviceable {
     
     var myRegisterCoursesModel = MyRegisterCoursesManager.shared.myRegisterCoursesModel
     
-    var viewedCoursesModelIsUpdate: ObservablePattern<Bool> = ObservablePattern(nil)
+    var viewedCoursesModelIsUpdate: ObservablePattern<Bool> = ObservablePattern(false)
     
     var broughtViewedCoursesModelIsUpdate: ObservablePattern<Bool> = ObservablePattern(nil)
     

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/Profile/Views/EditProfileViewController.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/Profile/Views/EditProfileViewController.swift
@@ -261,7 +261,6 @@ private extension EditProfileViewController {
     
     @objc
     func presentEditBottomSheet() {
-        print("1️⃣1️⃣1️⃣")
         alertVC.delegate = self
         DispatchQueue.main.async {
             self.alertVC.presentBottomSheet(in: self)

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/Profile/Views/EditProfileViewController.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/Profile/Views/EditProfileViewController.swift
@@ -261,6 +261,7 @@ private extension EditProfileViewController {
     
     @objc
     func presentEditBottomSheet() {
+        print("1️⃣1️⃣1️⃣")
         alertVC.delegate = self
         DispatchQueue.main.async {
             self.alertVC.presentBottomSheet(in: self)
@@ -312,8 +313,10 @@ private extension EditProfileViewController {
     
     @objc
     func registerPhoto() {
-        alertVC.dismissBottomSheet()
-        imagePickerViewController.presentPicker(from: self)
+        alertVC.dismissBottomSheet() { [weak self] in
+            guard let self else { return }
+            self.imagePickerViewController.presentPicker(from: self)
+        }
     }
     
     @objc

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/Profile/Views/ProfileViewController.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/Profile/Views/ProfileViewController.swift
@@ -264,8 +264,10 @@ private extension ProfileViewController {
     
     @objc
     func registerPhoto() {
-        alertVC.dismissBottomSheet()
-        imagePickerViewController.presentPicker(from: self)
+        alertVC.dismissBottomSheet() { [weak self] in
+            guard let self else { return }
+            self.imagePickerViewController.presentPicker(from: self)
+        }
     }
     
     @objc


### PR DESCRIPTION
# 🔥*Pull requests*

## ⛳ **작업한 브랜치**
- hotfix/#272

## 👷 **작업한 내용**
<!-- 작업한 내용을 적어주세요. -->
- [x] 프로필(등록) 사진 관련 기능 오작동 수정
- [x] 프로필(변경) 사진 관련 기능 오작동 수정
- [x] 열람한코스(탭바) emptyView 오작동 수정

## 🚨 참고 사항
<!-- 참고할 사항이 있다면 적어주세요. -->
### 1️⃣ '프로필' 사진 등록 및 변경 관련
### 문제
- 현재 `프로필 등록 or 프로필 변경` 중 사진 등록 시 앨범Picker가 동작하지 않고 있습니다.
### 원인
```
@objc
func registerPhoto() {
    alertVC.dismissBottomSheet() // 1️⃣
    self.imagePickerViewController.presentPicker(from: self) // 2️⃣
}
```
- 위 코드를 보시면 1️⃣ 코드에서 이미 UINavigationController가 다른 VC를 표시하고 있는 상태에서 이후 2️⃣ 코드로 또 다른 VC를 추가 표시하려 시도하였기에 제대로 동작하지 않았습니다.
### 해결
```
@objc
func registerPhoto() {
    alertVC.dismissBottomSheet() { [weak self] in 1️⃣
        guard let self else { return }
        self.imagePickerViewController.presentPicker(from: self)
    }
}
```
- 위 해결 코드와 같이 1️⃣로 dismiss 되는 클로저를 열어두고, 그 안에 ImagePickerVC present관련 코드를 넣어준다면 이전 표시된 VC가 닫힌 이후 다음 VC가 표시되기에 위 오작동 사례를 해결할 수 있었습니다.

<br>

### 2️⃣ '열람한코스' setEmptyView() 로직 관련
### 문제
```swift
func setEmptyView() {
  guard let name = UserDefaults.standard.string(forKey: StringLiterals.Network.userName),
        let viewedCourseCount = self.viewedCourseViewModel.viewedCourseData.value?.count,
        let updateData = viewedCourseViewModel.viewedCoursesModelIsUpdate.value
  else { return }
...
}
``` 
- 위 코드 중 `updateData` `guard let` 당시 `value` 값이 `nil`로 처리되고 있어 해당 메서드가 제대로 동작하지 않고 있습니다.
### 원인
- `updateData`의 값으로 활용되는 `viewedCourseViewModel.viewedCoursesModelIsUpdate.value`의 초깃값이 `nil`로 설정되어 VC가 push된 이후 처음 해당 메서드가 동작할 때에는 `nil` 값으로 사용되기 때문 입니다.
### 해결
- VM에서 해당 프로퍼티 선언할 때 설정한 초깃값을 `nil` -> `false` 로 변경 해 이를 해결하였습니다.
`var viewedCoursesModelIsUpdate: ObservablePattern<Bool> = ObservablePattern(false)`

---

## 📟 관련 이슈
- Resolved: #272 
