### PR TITLE
[REFACTOR] '일정 등록' 리펙토링 (#282)

### DIFF
--- a/DATEROAD-iOS/DATEROAD-iOS.xcodeproj/project.pbxproj
+++ b/DATEROAD-iOS/DATEROAD-iOS.xcodeproj/project.pbxproj
@@ -144,6 +144,7 @@
 		9EB91E782C3628BA00D7A836 /* AddCourseImageCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9EB91E772C3628BA00D7A836 /* AddCourseImageCollectionViewCell.swift */; };
 		9EBD5C712C7C557900EDE081 /* DRDateFormatterManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9EBD5C702C7C557900EDE081 /* DRDateFormatterManager.swift */; };
 		9EBD5C732C7C850400EDE081 /* UINavigationController+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9EBD5C722C7C850400EDE081 /* UINavigationController+.swift */; };
+		9EC22A982D1FCAF80076A1D8 /* DatePickerMode.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9EC22A972D1FCAF80076A1D8 /* DatePickerMode.swift */; };
 		9EDD6B102CDD37B5001B4D02 /* UITextView+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9EDD6B0F2CDD37B5001B4D02 /* UITextView+.swift */; };
 		CA0A963E2C2B131300F39EBE /* BaseViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA0A963D2C2B131300F39EBE /* BaseViewController.swift */; };
 		CA0A96432C2C60E800F39EBE /* LoginModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA0A96422C2C60E800F39EBE /* LoginModel.swift */; };
@@ -432,6 +433,7 @@
 		9EB91E772C3628BA00D7A836 /* AddCourseImageCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddCourseImageCollectionViewCell.swift; sourceTree = "<group>"; };
 		9EBD5C702C7C557900EDE081 /* DRDateFormatterManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DRDateFormatterManager.swift; sourceTree = "<group>"; };
 		9EBD5C722C7C850400EDE081 /* UINavigationController+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UINavigationController+.swift"; sourceTree = "<group>"; };
+		9EC22A972D1FCAF80076A1D8 /* DatePickerMode.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DatePickerMode.swift; sourceTree = "<group>"; };
 		9EDD6B0F2CDD37B5001B4D02 /* UITextView+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UITextView+.swift"; sourceTree = "<group>"; };
 		CA0A963D2C2B131300F39EBE /* BaseViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BaseViewController.swift; sourceTree = "<group>"; };
 		CA0A96422C2C60E800F39EBE /* LoginModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginModel.swift; sourceTree = "<group>"; };
@@ -1392,6 +1394,7 @@
 				CA5B979F2C9C7B4200F90A4C /* Header.swift */,
 				CA5B97A12CA2FCD700F90A4C /* NetworkType.swift */,
 				CA5B97A32CA5562000F90A4C /* CourseDetailSection.swift */,
+				9EC22A972D1FCAF80076A1D8 /* DatePickerMode.swift */,
 			);
 			path = Enums;
 			sourceTree = "<group>";
@@ -2001,6 +2004,7 @@
 				743D5BF02C3FB7ED007C156C /* MyCourseListModel.swift in Sources */,
 				74CDE26B2C3B7AA400A7459B /* DateCardCollectionViewCell.swift in Sources */,
 				CA80C0CB2C445480002CAA9B /* BaseTargetType.swift in Sources */,
+				9EC22A982D1FCAF80076A1D8 /* DatePickerMode.swift in Sources */,
 				743D5BF22C3FC60F007C156C /* MyRegisterCourseViewController.swift in Sources */,
 				745547532C3B862100B526F3 /* DateScheduleModel.swift in Sources */,
 				0DC9BF092C47F57C00A817A8 /* CourseDetailService.swift in Sources */,

--- a/DATEROAD-iOS/DATEROAD-iOS/Global/Utils/Enums/DatePickerMode.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Global/Utils/Enums/DatePickerMode.swift
@@ -1,0 +1,8 @@
+//
+//  DatePickerMode.swift
+//  DATEROAD-iOS
+//
+//  Created by 박신영 on 12/28/24.
+//
+
+import Foundation

--- a/DATEROAD-iOS/DATEROAD-iOS/Global/Utils/Enums/DatePickerMode.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Global/Utils/Enums/DatePickerMode.swift
@@ -6,3 +6,10 @@
 //
 
 import Foundation
+
+enum DatePickerMode {
+    
+    case date
+    case time
+    
+}

--- a/DATEROAD-iOS/DATEROAD-iOS/Global/Utils/ObservablePattern.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Global/Utils/ObservablePattern.swift
@@ -26,4 +26,8 @@ final class ObservablePattern<T: Equatable> {
         self.listener = listener
     }
     
+    func lazyBind(_ listener: @escaping (T?) -> Void) {
+        self.listener = listener
+    }
+    
 }

--- a/DATEROAD-iOS/DATEROAD-iOS/Network/AddSchedule/DTO/PostAddScheduleRequest.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Network/AddSchedule/DTO/PostAddScheduleRequest.swift
@@ -7,21 +7,6 @@
 
 import Foundation
 
-struct PostAddScheduleRequest2: Codable {
-    
-    var dateName: String = ""
-    var date: String = ""
-    var startAt: String = ""
-    
-    var tags: [PostAddScheduleTag] = []
-    
-    var country: String = ""
-    var city: String = ""
-    
-    var places: [PostAddSchedulePlace] = []
-    
-}
-
 // MARK: - PostAddScheduleRequest
 
 struct PostAddScheduleRequest: Codable {

--- a/DATEROAD-iOS/DATEROAD-iOS/Network/AddSchedule/DTO/PostAddScheduleRequest.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Network/AddSchedule/DTO/PostAddScheduleRequest.swift
@@ -7,6 +7,21 @@
 
 import Foundation
 
+struct PostAddScheduleRequest2: Codable {
+    
+    var dateName: String = ""
+    var date: String = ""
+    var startAt: String = ""
+    
+    var tags: [PostAddScheduleTag] = []
+    
+    var country: String = ""
+    var city: String = ""
+    
+    var places: [PostAddSchedulePlace] = []
+    
+}
+
 // MARK: - PostAddScheduleRequest
 
 struct PostAddScheduleRequest: Codable {

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/AddCourse/Cells/AddSecondViewTableViewCell.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/AddCourse/Cells/AddSecondViewTableViewCell.swift
@@ -67,9 +67,13 @@ final class AddSecondViewCollectionViewCell: BaseCollectionViewCell {
     }
     
     override func setStyle() {
+        self.do {
+            $0.layer.cornerRadius = 14
+            $0.clipsToBounds = true
+        }
+        
         contentView.do {
             $0.backgroundColor = UIColor(resource: .gray100)
-            $0.layer.cornerRadius = 14
         }
         
         placeTitleLabel.do {

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/AddCourse/ViewModels/AddCoursePlaceModel.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/AddCourse/ViewModels/AddCoursePlaceModel.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-struct AddCoursePlaceModel {
+struct AddCoursePlaceModel: Equatable {
     
     let placeTitle: String
     

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/AddCourse/Views/AddCourseFirst/AddCourseFirstViewController.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/AddCourse/Views/AddCourseFirst/AddCourseFirstViewController.swift
@@ -300,13 +300,6 @@ private extension AddCourseFirstViewController {
         }
     }
     
-    /// 사용하지 않는 코드
-    @objc
-    func broughtTagBtn(_ sender: UIButton) {
-        self.addCourseFirstView.addFirstView.updateTag(button: sender, buttonType: SelectedButton())
-        self.viewModel.isValidTag.value = true
-    }
-    
     @objc
     func sixCheckBtnTapped() {
         let secondVC = AddCourseSecondViewController(viewModel: self.viewModel)

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/AddCourse/Views/AddCourseFirst/AddCourseFirstViewController.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/AddCourse/Views/AddCourseFirst/AddCourseFirstViewController.swift
@@ -300,6 +300,7 @@ private extension AddCourseFirstViewController {
         }
     }
     
+    /// 사용하지 않는 코드
     @objc
     func broughtTagBtn(_ sender: UIButton) {
         self.addCourseFirstView.addFirstView.updateTag(button: sender, buttonType: SelectedButton())

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/AddCourse/Views/AddCourseFirst/AddCourseFirstViewController.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/AddCourse/Views/AddCourseFirst/AddCourseFirstViewController.swift
@@ -204,7 +204,7 @@ private extension AddCourseFirstViewController {
     }
     
     func setAddTarget() {
-        addCourseFirstView.addFirstView.dateNameTextField.addTarget(self, action: #selector(textFieldDidChanacge(_:)), for: .editingChanged)
+        addCourseFirstView.addFirstView.dateNameTextField.addTarget(self, action: #selector(textFieldDidChange(_:)), for: .editingChanged)
         
         addCourseFirstView.addFirstView.sixCheckNextButton.addTarget(self, action: #selector(sixCheckBtnTapped), for: .touchUpInside)
         
@@ -245,7 +245,7 @@ private extension AddCourseFirstViewController {
     }
     
     @objc
-    func textFieldDidChanacge(_ textField: UITextField) {
+    func textFieldDidChange(_ textField: UITextField) {
         guard let text = textField.text else {return}
         viewModel.dateName.value = text
         viewModel.satisfyDateName(str: text)

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/AddSchedule/ViewModels/AddScheduleViewModel.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/AddSchedule/ViewModels/AddScheduleViewModel.swift
@@ -11,6 +11,8 @@ final class AddScheduleViewModel: Serviceable {
     
     private let minimumDateNameLength = 5
     
+    var tagData: [ProfileTagModel] = []
+    
     var viewPath: String
     
     var isBroughtData = false
@@ -43,19 +45,8 @@ final class AddScheduleViewModel: Serviceable {
     let inputDateStartAt: ObservablePattern<String> = ObservablePattern(nil)
     let outputDateStartAtVaild: ObservablePattern<Bool> = ObservablePattern(nil)
     
-    // 코스 등록 태그 생성
-    var tagData: [ProfileTagModel] = []
-    
-    // 선택된 태그
-    let isOverCount: ObservablePattern<Bool> = ObservablePattern(false)
-    
-    let isValidTag: ObservablePattern<Bool> = ObservablePattern(nil)
-    
-    let tagCount: ObservablePattern<Int> = ObservablePattern(0)
-    
-    private let minTagCnt = 1
-    
-    private let maxTagCnt = 3
+    // 데이트 태그
+    let outputDateTag: ObservablePattern<Bool> = ObservablePattern(false)
     
     // 코스 지역 유효성 판별
     let dateLocation: ObservablePattern<String> = ObservablePattern(nil)
@@ -106,7 +97,7 @@ final class AddScheduleViewModel: Serviceable {
     }
     
     // tag 세팅 함수
-    func fetchTagData() {
+    private func fetchTagData() {
         tagData = TendencyTag.allCases.map { $0.tag }
     }
     
@@ -176,8 +167,8 @@ extension AddScheduleViewModel {
                     pastDateTagIndex.sort()
                     
                     print("pastDateTagIndex values: \(pastDateTagIndex)")
-                    
-                    checkTagCount(min: minTagCnt, max: maxTagCnt)
+                    outputDateTag.value = true
+                    addScheduleAmplitude.dateTagNum = selectedTagData.count
                     
                     outputDateNameVaild.value = true
                     outputDateStartAtVaild.value = true
@@ -234,23 +225,9 @@ extension AddScheduleViewModel {
                 selectedTagData.remove(at: index)
             }
         }
-        checkTagCount(min: minTagCnt, max: maxTagCnt)
-    }
-    
-    func checkTagCount(min: Int, max: Int) {
-        let count = selectedTagData.count
-        self.tagCount.value = count
-        
-        if count >= min && count <= max {
-            self.isValidTag.value = true
-            self.isOverCount.value = false
-        } else {
-            self.isValidTag.value = false
-            if count > max {
-                self.isOverCount.value = true
-            }
-        }
-        print(count)
+        print("selectedTagData: \(selectedTagData.count)")
+        outputDateTag.value = true
+        addScheduleAmplitude.dateTagNum = selectedTagData.count
     }
     
     func satisfyDateLocation(str: String) {
@@ -260,7 +237,7 @@ extension AddScheduleViewModel {
     
     func isEnableNextButton() -> Bool {
         guard let dateNameVaild = outputDateNameVaild.value,
-              let isValidTag = isValidTag.value,
+              let isValidTag = outputDateTag.value,
               let visitDateVaild = outputVisitDateVaild.value,
               let dateStartAtVaild = outputDateStartAtVaild.value,
               let isDateLocationVaild = isDateLocationVaild.value

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/AddSchedule/ViewModels/AddScheduleViewModel.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/AddSchedule/ViewModels/AddScheduleViewModel.swift
@@ -9,6 +9,8 @@ import UIKit
 
 final class AddScheduleViewModel: Serviceable {
     
+    private let minimumDateNameLength = 5
+    
     var viewPath: String
     
     var isBroughtData = false
@@ -28,12 +30,9 @@ final class AddScheduleViewModel: Serviceable {
     
     //MARK: - AddFirstCourse 사용되는 ViewModel
     
-    // 데이트 이름 유효성 판별 (true는 통과)
-    let dateName: ObservablePattern<String> = ObservablePattern(nil)
-    
-    let isDateNameVaild: ObservablePattern<Bool> = ObservablePattern(nil)
-    
-    private let minimumDateNameLength = 5
+    // 데이트 이름
+    let inputDateName: ObservablePattern<String> = ObservablePattern(nil)
+    let outputDateNameVaild: ObservablePattern<Bool> = ObservablePattern(false)    
     
     // 방문 일자 유효성 판별 (true는 통과)
     let visitDate: ObservablePattern<String> = ObservablePattern(nil)
@@ -104,11 +103,21 @@ final class AddScheduleViewModel: Serviceable {
     init(viewPath: String) {
         self.viewPath = viewPath
         fetchTagData()
+        bindViewModel()
     }
     
     // tag 세팅 함수
     func fetchTagData() {
         tagData = TendencyTag.allCases.map { $0.tag }
+    }
+    
+    private func bindViewModel() {
+        inputDateName.bind { [weak self] value in
+            guard let self,
+                  let value else {return}
+            self.addScheduleAmplitude.dateTitle = !value.isEmpty ? true : false
+            self.satisfyDateName(str: value)
+        }
     }
     
 }
@@ -125,7 +134,7 @@ extension AddScheduleViewModel {
             if isSuccess == true {
                 self.setLoading(isLoading: true)
                 if let data = self.viewedDateCourseByMeData {
-                    dateName.value = data.titleHeaderData.value?.title
+                    inputDateName.value = data.titleHeaderData.value?.title
                     dateLocation.value = data.titleHeaderData.value?.city
                     dateStartAt.value = data.startAt
                     
@@ -149,7 +158,7 @@ extension AddScheduleViewModel {
                     
                     checkTagCount(min: minTagCnt, max: maxTagCnt)
                     
-                    isDateNameVaild.value = true
+                    outputDateNameVaild.value = true
                     isDateStartAtVaild.value = true
                     isDateLocationVaild.value = true
                     
@@ -180,7 +189,8 @@ extension AddScheduleViewModel {
 extension AddScheduleViewModel {
     
     func satisfyDateName(str: String) {
-        isDateNameVaild.value = str.count >= minimumDateNameLength
+        outputDateNameVaild.value = str.count >= minimumDateNameLength
+        
     }
     
     func setVisitDate(_ date: Date) {
@@ -233,7 +243,7 @@ extension AddScheduleViewModel {
     }
     
     func isEnableNextButton() -> Bool {
-        guard let isDateNameVaild = isDateNameVaild.value,
+        guard let outputDateNameVaild = outputDateNameVaild.value,
               let isValidTag = isValidTag.value,
               let isVisitDateVaild = isVisitDateVaild.value,
               let isDateStartAtVaild = isDateStartAtVaild.value,
@@ -243,7 +253,7 @@ extension AddScheduleViewModel {
             return false
         }
         
-        return [isDateNameVaild, isValidTag, isVisitDateVaild, isDateLocationVaild, isDateStartAtVaild].allSatisfy { $0 }
+        return [outputDateNameVaild, isValidTag, isVisitDateVaild, isDateLocationVaild, isDateStartAtVaild].allSatisfy { $0 }
     }
     
 }
@@ -326,7 +336,7 @@ extension AddScheduleViewModel {
         print(addPlaceCollectionViewDataSource, "addPlaceCollectionViewDataSource : \(addPlaceCollectionViewDataSource)")
         print(places, "places : \(places)")
         
-        guard let dateName = dateName.value,
+        guard let dateName = inputDateName.value,
               let visitDate = visitDate.value,
               let dateStartAt = dateStartAt.value
         else {return}

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/AddSchedule/ViewModels/AddScheduleViewModel.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/AddSchedule/ViewModels/AddScheduleViewModel.swift
@@ -65,15 +65,12 @@ final class AddScheduleViewModel: Serviceable {
     let inputPrepareBroughtData: ObservablePattern<Bool> = ObservablePattern(false)
     let outputConfigureBroughtData: ObservablePattern<Bool> = ObservablePattern(false)
     
-//    let datePlace: ObservablePattern<String> = ObservablePattern(nil)
     let inputDatePlace: ObservablePattern<String> = ObservablePattern("")
     let outputDatePlace: ObservablePattern<String> = ObservablePattern("")
     
-//    let timeRequire: ObservablePattern<String> = ObservablePattern(nil)
     let outputTimeRequire: ObservablePattern<String> = ObservablePattern("")
     let inputUpdateTimeRequire: ObservablePattern<String> = ObservablePattern("")
     
-//    let editBtnEnableState: ObservablePattern<Bool> = ObservablePattern(false)
     let inputCheckEditBtnState: ObservablePattern<Bool> = ObservablePattern(nil)
     let outputEditBtnEnableState: ObservablePattern<Bool> = ObservablePattern(false)
     
@@ -84,7 +81,6 @@ final class AddScheduleViewModel: Serviceable {
     let outputIstValidateRegisterBtn: ObservablePattern<Bool> = ObservablePattern(false)
     
     let inputPreparePostSchedule: ObservablePattern<Bool> = ObservablePattern(false)
-    
     
     var isEditMode: Bool = false
     
@@ -140,7 +136,8 @@ final class AddScheduleViewModel: Serviceable {
             guard let self, let isBroughtData else {return}
             if isBroughtData {
                 self.fetchPastDate()
-                AmplitudeManager.shared.trackEventWithProperties(StringLiterals.Amplitude.EventName.viewAddBringcourse, properties: [StringLiterals.Amplitude.Property.viewPath: viewPath])
+                AmplitudeManager.shared.trackEventWithProperties(StringLiterals.Amplitude.EventName.viewAddBringcourse,
+                                                                 properties: [StringLiterals.Amplitude.Property.viewPath: viewPath])
             }
         }
         
@@ -330,10 +327,6 @@ extension AddScheduleViewModel {
 //MARK: - viewModel: AddScheduleSecondVC 함수
 
 extension AddScheduleViewModel {
-    
-//    func updatePlaceCollectionView() {
-//        print(addPlaceCollectionViewDataSource)
-//    }
     
     private func updateTimeRequireTextField(text: String) {
         var formattedText = text

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/AddSchedule/ViewModels/AddScheduleViewModel.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/AddSchedule/ViewModels/AddScheduleViewModel.swift
@@ -9,6 +9,8 @@ import UIKit
 
 final class AddScheduleViewModel: Serviceable {
     
+    var viewPath: String
+    
     var isBroughtData = false
     
     var viewedDateCourseByMeData: CourseDetailViewModel?
@@ -116,7 +118,8 @@ final class AddScheduleViewModel: Serviceable {
     
     // MARK: - Initializer
     
-    init() {
+    init(viewPath: String) {
+        self.viewPath = viewPath
         initAmplitudeVar()
         fetchTagData()
     }
@@ -382,27 +385,27 @@ extension AddScheduleViewModel {
         let postAddScheduleTags = selectedTagData.map { PostAddScheduleTag(tag: $0) }
         
         NetworkService.shared.addScheduleService.postAddSchedule(course: PostAddScheduleRequest(title: dateName,
-                                                                                                date: visitDate,
-                                                                                                startAt: dateStartAt,
-                                                                                                tags: postAddScheduleTags,
-                                                                                                country: country,
-                                                                                                city: city,
-                                                                                                places: places)) { result in
+                                                                                                    date: visitDate,
+                                                                                                    startAt: dateStartAt,
+                                                                                                    tags: postAddScheduleTags,
+                                                                                                    country: country,
+                                                                                                    city: city,
+                                                                                                    places: places)) { result in
             switch result {
-                case .success(let response):
-                    print("Success: \(response)")
-                    self.setLoading(isLoading: false)
-                    self.isSuccessPostData.value = true
-                case .reIssueJWT:
-                    self.patchReissue { isSuccess in
-                        self.onReissueSuccess.value = isSuccess
-                    }
-                default:
-                    self.onFailNetwork.value = true
-                    print("Failed to another reason")
-                    return
+            case .success(let response):
+                print("Success: \(response)")
+                self.setLoading(isLoading: false)
+                self.isSuccessPostData.value = true
+            case .reIssueJWT:
+                self.patchReissue { isSuccess in
+                    self.onReissueSuccess.value = isSuccess
                 }
+            default:
+                self.onFailNetwork.value = true
+                print("Failed to another reason")
+                return
             }
+        }
     }
     
 }

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/AddSchedule/ViewModels/AddScheduleViewModel.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/AddSchedule/ViewModels/AddScheduleViewModel.swift
@@ -28,9 +28,7 @@ final class AddScheduleViewModel: Serviceable {
     //MARK: - AddFirstCourse 사용되는 ViewModel
     
     let tagData = TendencyTag.allCases.map { $0.tag }
-    
     var pastDateTagIndex = [Int]()
-    
     var selectedTagData: [String] = []
     
     // 데이트 이름
@@ -61,7 +59,11 @@ final class AddScheduleViewModel: Serviceable {
     
     var pastDatePlaces = [TimelineModel]()
     
-    var addPlaceCollectionViewDataSource: [AddCoursePlaceModel] = []
+    //장소등록 collectionView 데이터
+    let dataSourceOfAddPlaceCollectionView: ObservablePattern<[AddCoursePlaceModel]> = ObservablePattern([])
+    
+    let inputPrepareBroughtData: ObservablePattern<Bool> = ObservablePattern(false)
+    let outputConfigureBroughtData: ObservablePattern<Bool> = ObservablePattern(false)
     
 //    let datePlace: ObservablePattern<String> = ObservablePattern(nil)
     let inputDatePlace: ObservablePattern<String> = ObservablePattern("")
@@ -75,18 +77,20 @@ final class AddScheduleViewModel: Serviceable {
     let inputCheckEditBtnState: ObservablePattern<Bool> = ObservablePattern(nil)
     let outputEditBtnEnableState: ObservablePattern<Bool> = ObservablePattern(false)
     
+    let inputValidateAddPlcae: ObservablePattern<Bool> = ObservablePattern(false)
+    let outputSuccessedAddPlcae: ObservablePattern<Bool> = ObservablePattern(false)
     
-    let isValidOfSecondNextBtn: ObservablePattern<Bool> = ObservablePattern(false)
+    let inputValidateRegisterBtn: ObservablePattern<Bool> = ObservablePattern(false)
+    let outputIstValidateRegisterBtn: ObservablePattern<Bool> = ObservablePattern(false)
     
+    let inputPreparePostSchedule: ObservablePattern<Bool> = ObservablePattern(false)
     
-    
-    var isChange: (() -> Void)?
     
     var isEditMode: Bool = false
     
     let onReissueSuccess: ObservablePattern<Bool> = ObservablePattern(nil)
     
-    let isSuccessPostData: ObservablePattern<Bool> = ObservablePattern(false)
+    let outputIsSuccessPostData: ObservablePattern<Bool> = ObservablePattern(false)
     
     let onLoading: ObservablePattern<Bool> = ObservablePattern(false)
     
@@ -157,6 +161,41 @@ final class AddScheduleViewModel: Serviceable {
             } else {
                 addScheduleAmplitude.dateDetailLocation = false
             }
+        }
+        
+        inputValidateAddPlcae.lazyBind { [weak self] _ in
+            guard let self else {return}
+            let datePlace = outputDatePlace.value ?? ""
+            let timeRequire = outputTimeRequire.value ?? ""
+            tapAddBtn(datePlace: datePlace, timeRequire: timeRequire)
+        }
+        
+        inputValidateRegisterBtn.lazyBind { [weak self] _ in
+            self?.isSourceMoreThanOne()
+        }
+        
+        inputPrepareBroughtData.lazyBind { [weak self] _ in
+            guard let self else {return}
+            switch isBroughtData {
+            case true:
+                for i in pastDatePlaces {
+                    if let doubleValue = Double(String(i.duration)) {
+                        let text = doubleValue.truncatingRemainder(dividingBy: 1) == 0 ?
+                        String(Int(doubleValue)) : String(doubleValue)
+                        tapAddBtn(datePlace: i.title, timeRequire: "\(text) 시간")
+                    } else {
+                        tapAddBtn(datePlace: i.title, timeRequire: "\(String(i.duration)) 시간")
+                    }
+                }
+                pastDatePlaces.removeAll()
+                AmplitudeManager.shared.trackEvent(StringLiterals.Amplitude.EventName.viewAddBringcourse2)
+            case false:
+                AmplitudeManager.shared.trackEvent(StringLiterals.Amplitude.EventName.viewAddSchedule2)
+            }
+        }
+        
+        inputPreparePostSchedule.lazyBind { [weak self] _ in
+            self?.postAddScheduel()
         }
     }
     
@@ -244,7 +283,6 @@ extension AddScheduleViewModel {
     private func satisfyDateName(str: String) {
         let minimumDateNameLength = 5
         outputDateNameVaild.value = str.count >= minimumDateNameLength
-        
     }
     
     private func setVisitDate() {
@@ -253,7 +291,7 @@ extension AddScheduleViewModel {
         outputVisitDateVaild.value = !(formattedDate.isEmpty)
     }
     
-    func setDateStartAt() {
+    private func setDateStartAt() {
         outputDateStartAtVaild.value = !(inputDateStartAt.value?.isEmpty ?? true)
     }
     
@@ -308,7 +346,8 @@ extension AddScheduleViewModel {
     
     /// 데이터 0개면 true 반환
     private func isDataSourceNotEmpty() {
-        let flag = (addPlaceCollectionViewDataSource.count >= 1) ? true : false
+        guard let count = dataSourceOfAddPlaceCollectionView.value?.count else {return}
+        let flag = (count >= 1) ? true : false
         outputEditBtnEnableState.value = flag
     }
     
@@ -317,33 +356,34 @@ extension AddScheduleViewModel {
         && !(outputTimeRequire.value?.isEmpty ?? true)
     }
     
-    func tapAddBtn(datePlace: String, timeRequire: String) {
-        addPlaceCollectionViewDataSource.append(AddCoursePlaceModel(placeTitle: datePlace, timeRequire: timeRequire))
-        
-        //viewmodel 값 초기화
+    private func tapAddBtn(datePlace: String, timeRequire: String) {
+        dataSourceOfAddPlaceCollectionView.value?.append(AddCoursePlaceModel(placeTitle: datePlace, timeRequire: timeRequire))
+    
+        //등록 마쳤으니 각 값들 초기화
         self.outputDatePlace.value = ""
         self.outputTimeRequire.value = ""
         
         self.addScheduleAmplitude.dateDetailLocation = false
         self.addScheduleAmplitude.dateDetailTime = false
-        self.isChange?()
+        
+        outputSuccessedAddPlcae.value = true
     }
     
-    /// dataSource 개수 >= 2 라면 '확인' 버튼 활성화
-    func isSourceMoreThanOne() {
-        let cnt = addPlaceCollectionViewDataSource.count
+    // 등록된 장소 count >= 2 라면 '완료' 버튼 활성화
+    private func isSourceMoreThanOne() {
+        let cnt = dataSourceOfAddPlaceCollectionView.value?.count ?? 0
         self.addScheduleAmplitude.dateCourseNum = cnt
         let flag = (cnt >= 2)
-        print("지금 데이터소스 개수 : \(addPlaceCollectionViewDataSource.count)\nflag: \(flag)")
-        isValidOfSecondNextBtn.value = flag
+        outputIstValidateRegisterBtn.value = flag
     }
     
-    func postAddScheduel() {
+    private func postAddScheduel() {
         self.setLoading(isLoading: true)
         
         var places: [PostAddSchedulePlace] = []
         
-        for (index, model) in addPlaceCollectionViewDataSource.enumerated() {
+        guard let body = dataSourceOfAddPlaceCollectionView.value else {return}
+        for (index, model) in body.enumerated() {
             // Extract the numeric part from the timeRequire string
             let timeComponents = model.timeRequire.split(separator: " ")
             
@@ -359,7 +399,6 @@ extension AddScheduleViewModel {
                 print("❌❌❌ Step 2: Failed to extract timeString from \(model.timeRequire)")
             }
         }
-        print(addPlaceCollectionViewDataSource, "addPlaceCollectionViewDataSource : \(addPlaceCollectionViewDataSource)")
         
         guard let dateName = inputDateName.value,
               let visitDate = inputVisitDate.value,
@@ -381,7 +420,7 @@ extension AddScheduleViewModel {
             case .success(let response):
                 print("Success: \(response)")
                 self.setLoading(isLoading: false)
-                self.isSuccessPostData.value = true
+                self.outputIsSuccessPostData.value = true
             case .reIssueJWT:
                 self.patchReissue { isSuccess in
                     self.onReissueSuccess.value = isSuccess

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/AddSchedule/ViewModels/AddScheduleViewModel.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/AddSchedule/ViewModels/AddScheduleViewModel.swift
@@ -103,7 +103,6 @@ final class AddScheduleViewModel: Serviceable {
     
     init(viewPath: String) {
         self.viewPath = viewPath
-//        initAmplitudeVar()
         fetchTagData()
     }
     
@@ -377,7 +376,6 @@ struct AddScheduleAmplitudeState {
     var dateDetailLocation: Bool = false
     var dateDetailTime: Bool = false
     var dateCourseNum: Int = 0
-    
     
     func sendAmplitudeEvent(for step: Int) {
         switch step {

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/AddSchedule/ViewModels/AddScheduleViewModel.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/AddSchedule/ViewModels/AddScheduleViewModel.swift
@@ -21,14 +21,13 @@ final class AddScheduleViewModel: Serviceable {
         self.viewPath = viewPath
         self.isBroughtData = isBroughtData
         
-        fetchTagData()
         bindViewModel()
     }
     
     
     //MARK: - AddFirstCourse 사용되는 ViewModel
     
-    var tagData: [ProfileTagModel] = []
+    let tagData = TendencyTag.allCases.map { $0.tag }
     
     var pastDateTagIndex = [Int]()
     
@@ -88,11 +87,6 @@ final class AddScheduleViewModel: Serviceable {
     //MARK: - AddSchedule Amplitude 관련 변수
     
     var addScheduleAmplitude = AddScheduleAmplitudeState()
-    
-    // tag 세팅 함수
-    private func fetchTagData() {
-        tagData = TendencyTag.allCases.map { $0.tag }
-    }
     
     private func bindViewModel() {
         inputDateName.bind { [weak self] value in

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/AddSchedule/ViewModels/AddScheduleViewModel.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/AddSchedule/ViewModels/AddScheduleViewModel.swift
@@ -34,10 +34,9 @@ final class AddScheduleViewModel: Serviceable {
     let inputDateName: ObservablePattern<String> = ObservablePattern(nil)
     let outputDateNameVaild: ObservablePattern<Bool> = ObservablePattern(false)    
     
-    // 방문 일자 유효성 판별 (true는 통과)
-    let visitDate: ObservablePattern<String> = ObservablePattern(nil)
-    
-    let isVisitDateVaild: ObservablePattern<Bool> = ObservablePattern(nil)
+    // 방문일자
+    let inputVisitDate: ObservablePattern<Date> = ObservablePattern(nil)
+    let outputVisitDateVaild: ObservablePattern<Bool> = ObservablePattern(false)
     
     // 데이트 시작시간 유효성 판별 (self.count > 0 인지)
     let dateStartAt: ObservablePattern<String> = ObservablePattern(nil)
@@ -118,6 +117,12 @@ final class AddScheduleViewModel: Serviceable {
             self.addScheduleAmplitude.dateTitle = !value.isEmpty ? true : false
             self.satisfyDateName(str: value)
         }
+        
+        inputVisitDate.bind { [weak self] _ in
+            guard let self else {return}
+            self.addScheduleAmplitude.dateDate = true
+            self.setVisitDate()
+        }
     }
     
 }
@@ -193,10 +198,10 @@ extension AddScheduleViewModel {
         
     }
     
-    func setVisitDate(_ date: Date) {
+    func setVisitDate() {
+        guard let date = inputVisitDate.value else {return}
         let formattedDate = DateFormatterManager.shared.dateFormatter.string(from: date)
-        visitDate.value = formattedDate
-        isVisitDateVaild.value = !(visitDate.value?.isEmpty ?? true)
+        outputVisitDateVaild.value = !(formattedDate.isEmpty)
     }
     
     func setDateStartAt(_ time: Date) {
@@ -243,9 +248,9 @@ extension AddScheduleViewModel {
     }
     
     func isEnableNextButton() -> Bool {
-        guard let outputDateNameVaild = outputDateNameVaild.value,
+        guard let dateNameVaild = outputDateNameVaild.value,
               let isValidTag = isValidTag.value,
-              let isVisitDateVaild = isVisitDateVaild.value,
+              let visitDateVaild = outputVisitDateVaild.value,
               let isDateStartAtVaild = isDateStartAtVaild.value,
               let isDateLocationVaild = isDateLocationVaild.value
         else {
@@ -253,7 +258,7 @@ extension AddScheduleViewModel {
             return false
         }
         
-        return [outputDateNameVaild, isValidTag, isVisitDateVaild, isDateLocationVaild, isDateStartAtVaild].allSatisfy { $0 }
+        return [dateNameVaild, isValidTag, visitDateVaild, isDateLocationVaild, isDateStartAtVaild].allSatisfy { $0 }
     }
     
 }
@@ -336,16 +341,19 @@ extension AddScheduleViewModel {
         print(addPlaceCollectionViewDataSource, "addPlaceCollectionViewDataSource : \(addPlaceCollectionViewDataSource)")
         print(places, "places : \(places)")
         
+        
+        
         guard let dateName = inputDateName.value,
-              let visitDate = visitDate.value,
+              let visitDate = inputVisitDate.value,
               let dateStartAt = dateStartAt.value
         else {return}
         let country = country
         let city = city
         let postAddScheduleTags = selectedTagData.map { PostAddScheduleTag(tag: $0) }
+        let formattedDate = DateFormatterManager.shared.dateFormatter.string(from: visitDate)
         
         NetworkService.shared.addScheduleService.postAddSchedule(course: PostAddScheduleRequest(title: dateName,
-                                                                                                date: visitDate,
+                                                                                                date: formattedDate,
                                                                                                 startAt: dateStartAt,
                                                                                                 tags: postAddScheduleTags,
                                                                                                 country: country,

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/AddSchedule/ViewModels/AddScheduleViewModel.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/AddSchedule/ViewModels/AddScheduleViewModel.swift
@@ -5,7 +5,7 @@
 //  Created by 박신영 on 7/18/24.
 //
 
-import UIKit
+import Foundation
 
 final class AddScheduleViewModel: Serviceable {
     
@@ -34,14 +34,14 @@ final class AddScheduleViewModel: Serviceable {
     let inputDateName: ObservablePattern<String> = ObservablePattern(nil)
     let outputDateNameVaild: ObservablePattern<Bool> = ObservablePattern(false)    
     
-    // 방문일자
+    // 데이트 방문일자
     let inputVisitDate: ObservablePattern<Date> = ObservablePattern(nil)
     let outputVisitDateVaild: ObservablePattern<Bool> = ObservablePattern(false)
     
-    // 데이트 시작시간 유효성 판별 (self.count > 0 인지)
-    let dateStartAt: ObservablePattern<String> = ObservablePattern(nil)
-    
-    let isDateStartAtVaild: ObservablePattern<Bool> = ObservablePattern(nil)
+    // 데이트 시작시간
+    let inputDataStartAtTransForm: ObservablePattern<Date> = ObservablePattern(nil)
+    let inputDateStartAt: ObservablePattern<String> = ObservablePattern(nil)
+    let outputDateStartAtVaild: ObservablePattern<Bool> = ObservablePattern(nil)
     
     // 코스 등록 태그 생성
     var tagData: [ProfileTagModel] = []
@@ -123,6 +123,22 @@ final class AddScheduleViewModel: Serviceable {
             self.addScheduleAmplitude.dateDate = true
             self.setVisitDate()
         }
+        
+        inputDataStartAtTransForm.lazyBind { [weak self] selectedDate in
+            guard let self,
+                  let selectedDate else {return}
+            var formattedTime = DateFormatterManager.shared.timeFormatter.string(from: selectedDate)
+            formattedTime = formattedTime
+                .replacingOccurrences(of: "오전", with: "AM")
+                .replacingOccurrences(of: "오후", with: "PM")
+            self.inputDateStartAt.value = formattedTime
+        }
+        
+        inputDateStartAt.bind { [weak self] _ in
+            guard let self else {return}
+            self.addScheduleAmplitude.dateTime = true
+            self.setDateStartAt()
+        }
     }
     
 }
@@ -140,8 +156,8 @@ extension AddScheduleViewModel {
                 self.setLoading(isLoading: true)
                 if let data = self.viewedDateCourseByMeData {
                     inputDateName.value = data.titleHeaderData.value?.title
+                    inputDateStartAt.value = data.startAt
                     dateLocation.value = data.titleHeaderData.value?.city
-                    dateStartAt.value = data.startAt
                     
                     //동네.KOR 불러와서 지역, 동네 ENG 버전 알아내는 미친 로직
                     let cityName = data.titleHeaderData.value?.city ?? ""
@@ -164,7 +180,7 @@ extension AddScheduleViewModel {
                     checkTagCount(min: minTagCnt, max: maxTagCnt)
                     
                     outputDateNameVaild.value = true
-                    isDateStartAtVaild.value = true
+                    outputDateStartAtVaild.value = true
                     isDateLocationVaild.value = true
                     
                     ///코스 등록 2 AddPlaceCollectionView 구성
@@ -204,13 +220,8 @@ extension AddScheduleViewModel {
         outputVisitDateVaild.value = !(formattedDate.isEmpty)
     }
     
-    func setDateStartAt(_ time: Date) {
-        var formattedTime = DateFormatterManager.shared.timeFormatter.string(from: time)
-        formattedTime = formattedTime
-            .replacingOccurrences(of: "오전", with: "AM")
-            .replacingOccurrences(of: "오후", with: "PM")
-        dateStartAt.value = formattedTime
-        isDateStartAtVaild.value = !(dateStartAt.value?.isEmpty ?? true)
+    func setDateStartAt() {
+        outputDateStartAtVaild.value = !(inputDateStartAt.value?.isEmpty ?? true)
     }
     
     func countSelectedTag(isSelected: Bool, tag: String) {
@@ -251,14 +262,14 @@ extension AddScheduleViewModel {
         guard let dateNameVaild = outputDateNameVaild.value,
               let isValidTag = isValidTag.value,
               let visitDateVaild = outputVisitDateVaild.value,
-              let isDateStartAtVaild = isDateStartAtVaild.value,
+              let dateStartAtVaild = outputDateStartAtVaild.value,
               let isDateLocationVaild = isDateLocationVaild.value
         else {
             print("isOkSixBtn guard let Error")
             return false
         }
         
-        return [dateNameVaild, isValidTag, visitDateVaild, isDateLocationVaild, isDateStartAtVaild].allSatisfy { $0 }
+        return [dateNameVaild, isValidTag, visitDateVaild, isDateLocationVaild, dateStartAtVaild].allSatisfy { $0 }
     }
     
 }
@@ -345,7 +356,7 @@ extension AddScheduleViewModel {
         
         guard let dateName = inputDateName.value,
               let visitDate = inputVisitDate.value,
-              let dateStartAt = dateStartAt.value
+              let dateStartAt = inputDateStartAt.value
         else {return}
         let country = country
         let city = city

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/AddSchedule/ViewModels/AddScheduleViewModel.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/AddSchedule/ViewModels/AddScheduleViewModel.swift
@@ -48,14 +48,9 @@ final class AddScheduleViewModel: Serviceable {
     // 데이트 태그
     let outputDateTag: ObservablePattern<Bool> = ObservablePattern(false)
     
-    // 코스 지역 유효성 판별
-    let dateLocation: ObservablePattern<String> = ObservablePattern(nil)
-    
-    let isDateLocationVaild: ObservablePattern<Bool> = ObservablePattern(nil)
-    
-    var country = ""
-    
-    var city = ""
+    // 데이트 로케이션
+    let inputDateLocation: ObservablePattern<[String]> = ObservablePattern(Array(repeating: "", count: 2))
+    let outputDateLocation: ObservablePattern<String> = ObservablePattern("")
     
     
     //MARK: - AddSecondView 전용 Viewmodel 변수
@@ -130,6 +125,11 @@ final class AddScheduleViewModel: Serviceable {
             self.addScheduleAmplitude.dateTime = true
             self.setDateStartAt()
         }
+        
+        inputDateLocation.lazyBind { [weak self] locationArr in
+            guard let self, let locationArr else {return}
+            isDateLocationValid(LocationArr: locationArr)
+        }
     }
     
 }
@@ -138,6 +138,13 @@ final class AddScheduleViewModel: Serviceable {
 //MARK: - AddScheduleViewModel: PastDateSetting
 
 extension AddScheduleViewModel {
+    
+    func isDateLocationValid(LocationArr: [String]) {
+        if !LocationArr.contains("") && LocationArr.count == 2 {
+            addScheduleAmplitude.dateArea = true
+            outputDateLocation.value = LocationArr[1]
+        }
+    }
     
     // 일정등록(불러오기) 시 데이터 세팅 함수
     func fetchPastDate() {
@@ -148,16 +155,16 @@ extension AddScheduleViewModel {
                 if let data = self.viewedDateCourseByMeData {
                     inputDateName.value = data.titleHeaderData.value?.title
                     inputDateStartAt.value = data.startAt
-                    dateLocation.value = data.titleHeaderData.value?.city
+                    outputDateLocation.value = data.titleHeaderData.value?.city
                     
                     //동네.KOR 불러와서 지역, 동네 ENG 버전 알아내는 미친 로직
                     let cityName = data.titleHeaderData.value?.city ?? ""
                     if let result = LocationMapper.getCountryAndCity(from: cityName) {
                         let country = result.country.rawValue
                         let city = result.city.rawValue
-                        self.city = city
-                        self.country = country
-                        self.isDateLocationVaild.value = true
+                        self.inputDateLocation.value?[0] = country
+                        self.inputDateLocation.value?[1] = city
+                        self.outputDateLocation.value = city
                     }
                     
                     //태그 추적해서 미리 셀렉 및 개수 표시 해버리는 진짜 미쳐버린 로직
@@ -172,7 +179,6 @@ extension AddScheduleViewModel {
                     
                     outputDateNameVaild.value = true
                     outputDateStartAtVaild.value = true
-                    isDateLocationVaild.value = true
                     
                     ///코스 등록 2 AddPlaceCollectionView 구성
                     if let result = data.timelineData.value {
@@ -230,21 +236,16 @@ extension AddScheduleViewModel {
         addScheduleAmplitude.dateTagNum = selectedTagData.count
     }
     
-    func satisfyDateLocation(str: String) {
-        let flag = !str.isEmpty
-        isDateLocationVaild.value = flag
-    }
-    
     func isEnableNextButton() -> Bool {
         guard let dateNameVaild = outputDateNameVaild.value,
               let isValidTag = outputDateTag.value,
               let visitDateVaild = outputVisitDateVaild.value,
-              let dateStartAtVaild = outputDateStartAtVaild.value,
-              let isDateLocationVaild = isDateLocationVaild.value
+              let dateStartAtVaild = outputDateStartAtVaild.value
         else {
             print("isOkSixBtn guard let Error")
             return false
         }
+        let isDateLocationVaild = outputDateLocation.value != ""
         
         return [dateNameVaild, isValidTag, visitDateVaild, isDateLocationVaild, dateStartAtVaild].allSatisfy { $0 }
     }
@@ -327,16 +328,13 @@ extension AddScheduleViewModel {
             }
         }
         print(addPlaceCollectionViewDataSource, "addPlaceCollectionViewDataSource : \(addPlaceCollectionViewDataSource)")
-        print(places, "places : \(places)")
-        
-        
         
         guard let dateName = inputDateName.value,
               let visitDate = inputVisitDate.value,
               let dateStartAt = inputDateStartAt.value
         else {return}
-        let country = country
-        let city = city
+        let country = inputDateLocation.value?[0] ?? ""
+        let city = inputDateLocation.value?[1] ?? ""
         let postAddScheduleTags = selectedTagData.map { PostAddScheduleTag(tag: $0) }
         let formattedDate = DateFormatterManager.shared.dateFormatter.string(from: visitDate)
         

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/AddSchedule/ViewModels/AddScheduleViewModel.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/AddSchedule/ViewModels/AddScheduleViewModel.swift
@@ -193,12 +193,12 @@ extension AddScheduleViewModel {
 
 extension AddScheduleViewModel {
     
-    func satisfyDateName(str: String) {
+    private func satisfyDateName(str: String) {
         outputDateNameVaild.value = str.count >= minimumDateNameLength
         
     }
     
-    func setVisitDate() {
+    private func setVisitDate() {
         guard let date = inputVisitDate.value else {return}
         let formattedDate = DateFormatterManager.shared.dateFormatter.string(from: date)
         outputVisitDateVaild.value = !(formattedDate.isEmpty)

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/AddSchedule/ViewModels/AddScheduleViewModel.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/AddSchedule/ViewModels/AddScheduleViewModel.swift
@@ -64,9 +64,6 @@ final class AddScheduleViewModel: Serviceable {
     
     let isDateLocationVaild: ObservablePattern<Bool> = ObservablePattern(nil)
     
-    // 기타
-    var isTimePicker: Bool?
-    
     var country = ""
     
     var city = ""
@@ -124,7 +121,15 @@ final class AddScheduleViewModel: Serviceable {
         fetchTagData()
     }
     
+    // tag 세팅 함수
+    func fetchTagData() {
+        tagData = TendencyTag.allCases.map { $0.tag }
+    }
+    
 }
+
+
+//MARK: - AddScheduleViewModel: Amplitude
 
 extension AddScheduleViewModel {
     
@@ -172,12 +177,14 @@ extension AddScheduleViewModel {
         )
     }
     
-    func getTagIndices(from tags: [String]) -> [Int] {
-        return tags.compactMap { tag in
-            TendencyTag.allCases.firstIndex { $0.tag.english == tag }
-        }
-    }
+}
+
+
+//MARK: - AddScheduleViewModel: PastDateSetting
+
+extension AddScheduleViewModel {
     
+    // 일정등록(불러오기) 시 데이터 세팅 함수
     func fetchPastDate() {
         viewedDateCourseByMeData?.isSuccessGetData.bind { [weak self] isSuccess in
             guard let self = self else { return }
@@ -224,30 +231,22 @@ extension AddScheduleViewModel {
         }
     }
     
-    
-    //MARK: - AddSchedule First 함수
-    
-    func satisfyDateName(str: String) {
-        isDateNameVaild.value = str.count >= minimumDateNameLength
-    }
-    
-    func isFutureDate(date: Date, dateType: String) {
-        if dateType == "date" {
-            let formattedDate = DateFormatterManager.shared.dateFormatter.string(from: date)
-            visitDate.value = formattedDate
-            self.isVisitDateVaild.value = true
-        } else {
-            var formattedDate = DateFormatterManager.shared.timeFormatter.string(from: date)
-            formattedDate = formattedDate
-                .replacingOccurrences(of: "오전", with: "AM")
-                .replacingOccurrences(of: "오후", with: "PM")
-            dateStartAt.value = formattedDate
-            self.isDateStartAtVaild.value = !(dateStartAt.value?.isEmpty ?? true)
+    //불러온 데이터에 선택된 tag index 값 넣어주는 함수
+    func getTagIndices(from tags: [String]) -> [Int] {
+        return tags.compactMap { tag in
+            TendencyTag.allCases.firstIndex { $0.tag.english == tag }
         }
     }
     
-    func fetchTagData() {
-        tagData = TendencyTag.allCases.map { $0.tag }
+}
+
+
+//MARK: - viewModel: AddScheduleFirstVC 함수
+
+extension AddScheduleViewModel {
+    
+    func satisfyDateName(str: String) {
+        isDateNameVaild.value = str.count >= minimumDateNameLength
     }
     
     func countSelectedTag(isSelected: Bool, tag: String) {
@@ -261,6 +260,21 @@ extension AddScheduleViewModel {
             }
         }
         checkTagCount(min: minTagCnt, max: maxTagCnt)
+    }
+    
+    func setVisitDate(_ date: Date) {
+        let formattedDate = DateFormatterManager.shared.dateFormatter.string(from: date)
+        visitDate.value = formattedDate
+        isVisitDateVaild.value = !(visitDate.value?.isEmpty ?? true)
+    }
+    
+    func setDateStartAt(_ time: Date) {
+        var formattedTime = DateFormatterManager.shared.timeFormatter.string(from: time)
+        formattedTime = formattedTime
+            .replacingOccurrences(of: "오전", with: "AM")
+            .replacingOccurrences(of: "오후", with: "PM")
+        dateStartAt.value = formattedTime
+        isDateStartAtVaild.value = !(dateStartAt.value?.isEmpty ?? true)
     }
     
     func checkTagCount(min: Int, max: Int) {
@@ -300,8 +314,12 @@ extension AddScheduleViewModel {
         return true
     }
     
-    
-    //MARK: - AddSecondView 전용 func
+}
+
+
+//MARK: - viewModel: AddScheduleSecondVC 함수
+
+extension AddScheduleViewModel {
     
     func updatePlaceCollectionView() {
         print(addPlaceCollectionViewDataSource)
@@ -332,7 +350,7 @@ extension AddScheduleViewModel {
         self.isChange?()
     }
     
-    /// dataSource 개수 >= 2 라면 (다음 2/3) 버튼 활성화
+    /// dataSource 개수 >= 2 라면 '확인' 버튼 활성화
     func isSourceMoreThanOne() {
         let cnt = addPlaceCollectionViewDataSource.count
         self.dateCourseNum = cnt
@@ -385,12 +403,12 @@ extension AddScheduleViewModel {
         let postAddScheduleTags = selectedTagData.map { PostAddScheduleTag(tag: $0) }
         
         NetworkService.shared.addScheduleService.postAddSchedule(course: PostAddScheduleRequest(title: dateName,
-                                                                                                    date: visitDate,
-                                                                                                    startAt: dateStartAt,
-                                                                                                    tags: postAddScheduleTags,
-                                                                                                    country: country,
-                                                                                                    city: city,
-                                                                                                    places: places)) { result in
+                                                                                                date: visitDate,
+                                                                                                startAt: dateStartAt,
+                                                                                                tags: postAddScheduleTags,
+                                                                                                country: country,
+                                                                                                city: city,
+                                                                                                places: places)) { result in
             switch result {
             case .success(let response):
                 print("Success: \(response)")

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/AddSchedule/ViewModels/AddScheduleViewModel.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/AddSchedule/ViewModels/AddScheduleViewModel.swift
@@ -9,28 +9,30 @@ import Foundation
 
 final class AddScheduleViewModel: Serviceable {
     
-    private let minimumDateNameLength = 5
+    let viewPath: String
     
-    var tagData: [ProfileTagModel] = []
-    
-    var viewPath: String
-    
-    var isBroughtData = false
+    var isBroughtData: Bool
     
     var viewedDateCourseByMeData: CourseDetailViewModel?
     
-    let ispastDateVaild: ObservablePattern<Bool> = ObservablePattern(nil)
+    // MARK: - Initializer
     
-    let isSuccessGetData: ObservablePattern<Bool> = ObservablePattern(false)
-    
-    var pastDatePlaces = [TimelineModel]()
-    
-    var selectedTagData: [String] = []
-    
-    var pastDateTagIndex = [Int]()
+    init(viewPath: String, isBroughtData: Bool) {
+        self.viewPath = viewPath
+        self.isBroughtData = isBroughtData
+        
+        fetchTagData()
+        bindViewModel()
+    }
     
     
     //MARK: - AddFirstCourse 사용되는 ViewModel
+    
+    var tagData: [ProfileTagModel] = []
+    
+    var pastDateTagIndex = [Int]()
+    
+    var selectedTagData: [String] = []
     
     // 데이트 이름
     let inputDateName: ObservablePattern<String> = ObservablePattern(nil)
@@ -52,8 +54,13 @@ final class AddScheduleViewModel: Serviceable {
     let inputDateLocation: ObservablePattern<[String]> = ObservablePattern(Array(repeating: "", count: 2))
     let outputDateLocation: ObservablePattern<String> = ObservablePattern("")
     
+    let inputIsBroughtData: ObservablePattern<Bool> = ObservablePattern(false)
+    let outputIsBroughtDataConfigured: ObservablePattern<Bool> = ObservablePattern(false)
+    
     
     //MARK: - AddSecondView 전용 Viewmodel 변수
+    
+    var pastDatePlaces = [TimelineModel]()
     
     var addPlaceCollectionViewDataSource: [AddCoursePlaceModel] = []
     
@@ -81,15 +88,6 @@ final class AddScheduleViewModel: Serviceable {
     //MARK: - AddSchedule Amplitude 관련 변수
     
     var addScheduleAmplitude = AddScheduleAmplitudeState()
-    
-    
-    // MARK: - Initializer
-    
-    init(viewPath: String) {
-        self.viewPath = viewPath
-        fetchTagData()
-        bindViewModel()
-    }
     
     // tag 세팅 함수
     private func fetchTagData() {
@@ -130,6 +128,14 @@ final class AddScheduleViewModel: Serviceable {
             guard let self, let locationArr else {return}
             isDateLocationValid(LocationArr: locationArr)
         }
+        
+        inputIsBroughtData.lazyBind { [weak self] isBroughtData in
+            guard let self, let isBroughtData else {return}
+            if isBroughtData {
+                self.fetchPastDate()
+                AmplitudeManager.shared.trackEventWithProperties(StringLiterals.Amplitude.EventName.viewAddBringcourse, properties: [StringLiterals.Amplitude.Property.viewPath: viewPath])
+            }
+        }
     }
     
 }
@@ -148,6 +154,8 @@ extension AddScheduleViewModel {
     
     // 일정등록(불러오기) 시 데이터 세팅 함수
     func fetchPastDate() {
+        //isSuccessGetData가 true인 시점에 불러와야 data안의 값들이 공란이 아님.
+        //추후 리펙
         viewedDateCourseByMeData?.isSuccessGetData.bind { [weak self] isSuccess in
             guard let self = self else { return }
             if isSuccess == true {
@@ -186,7 +194,7 @@ extension AddScheduleViewModel {
                     }
                     
                     self.setLoading(isLoading: false)
-                    isSuccessGetData.value = true
+                    outputIsBroughtDataConfigured.value = true
                 }
             }
         }
@@ -207,6 +215,7 @@ extension AddScheduleViewModel {
 extension AddScheduleViewModel {
     
     private func satisfyDateName(str: String) {
+        let minimumDateNameLength = 5
         outputDateNameVaild.value = str.count >= minimumDateNameLength
         
     }

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/AddSchedule/ViewModels/AddScheduleViewModel.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/AddSchedule/ViewModels/AddScheduleViewModel.swift
@@ -63,7 +63,9 @@ final class AddScheduleViewModel: Serviceable {
     
     var addPlaceCollectionViewDataSource: [AddCoursePlaceModel] = []
     
-    let datePlace: ObservablePattern<String> = ObservablePattern(nil)
+//    let datePlace: ObservablePattern<String> = ObservablePattern(nil)
+    let inputDatePlace: ObservablePattern<String> = ObservablePattern("")
+    let outputDatePlace: ObservablePattern<String> = ObservablePattern("")
     
 //    let timeRequire: ObservablePattern<String> = ObservablePattern(nil)
     let outputTimeRequire: ObservablePattern<String> = ObservablePattern("")
@@ -145,6 +147,16 @@ final class AddScheduleViewModel: Serviceable {
         
         inputCheckEditBtnState.lazyBind { [weak self] isCheck in
             self?.isDataSourceNotEmpty()
+        }
+        
+        inputDatePlace.lazyBind { [weak self] text in
+            guard let self, let text else {return}
+            if !text.isEmpty {
+                addScheduleAmplitude.dateDetailLocation = true
+                outputDatePlace.value = text
+            } else {
+                addScheduleAmplitude.dateDetailLocation = false
+            }
         }
     }
     
@@ -301,7 +313,7 @@ extension AddScheduleViewModel {
     }
     
     func isAbleAddBtn() -> Bool {
-        return !(datePlace.value?.isEmpty ?? true)
+        return !(outputDatePlace.value?.isEmpty ?? true)
         && !(outputTimeRequire.value?.isEmpty ?? true)
     }
     
@@ -309,7 +321,7 @@ extension AddScheduleViewModel {
         addPlaceCollectionViewDataSource.append(AddCoursePlaceModel(placeTitle: datePlace, timeRequire: timeRequire))
         
         //viewmodel 값 초기화
-        self.datePlace.value = ""
+        self.outputDatePlace.value = ""
         self.outputTimeRequire.value = ""
         
         self.addScheduleAmplitude.dateDetailLocation = false

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/AddSchedule/ViewModels/AddScheduleViewModel.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/AddSchedule/ViewModels/AddScheduleViewModel.swift
@@ -377,32 +377,46 @@ struct AddScheduleAmplitudeState {
     var dateDetailTime: Bool = false
     var dateCourseNum: Int = 0
     
-    func sendAmplitudeEvent(for step: Int) {
+    func sendAmplitudeEvent(step: Int) {
+        guard let eventName = makeEventName(step: step) else {
+            print("Invalid EventName in sendAmplitudeEvent")
+            return
+        }
+        let properties = makeProperties(step: step)
+        AmplitudeManager.shared.trackEventWithProperties(eventName, properties: properties)
+    }
+    
+    func makeEventName(step: Int) -> String? {
         switch step {
         case 1:
-            let properties: [String: Any] = [
+            return StringLiterals.Amplitude.EventName.clickSchedule1Back
+        case 2:
+            return StringLiterals.Amplitude.EventName.clickSchedule2Back
+        default:
+            print("makeEventName Error")
+            return nil
+        }
+    }
+    
+    func makeProperties(step: Int) -> [String: Any] {
+        switch step {
+        case 1:
+            return [
                 StringLiterals.Amplitude.Property.dateTitle: self.dateTitle,
                 StringLiterals.Amplitude.Property.dateDate: self.dateDate,
                 StringLiterals.Amplitude.Property.dateTime: self.dateTime,
                 StringLiterals.Amplitude.Property.dateTagNum: self.dateTagNum,
                 StringLiterals.Amplitude.Property.dateArea: self.dateArea
             ]
-            AmplitudeManager.shared.trackEventWithProperties(
-                StringLiterals.Amplitude.EventName.clickSchedule1Back,
-                properties: properties
-            )
         case 2:
-            let properties: [String: Any] = [
+            return [
                 StringLiterals.Amplitude.Property.dateDetailLocation: dateDetailLocation,
                 StringLiterals.Amplitude.Property.dateDetailTime: dateDetailTime,
                 StringLiterals.Amplitude.Property.dateCourseNum: dateCourseNum
             ]
-            AmplitudeManager.shared.trackEventWithProperties(
-                StringLiterals.Amplitude.EventName.clickSchedule2Back,
-                properties: properties
-            )
         default:
-            print("sendAmplitudeEvent Error")
+            print("makeProperties Error")
+            return [:]
         }
     }
     

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/AddSchedule/ViewModels/AddScheduleViewModel.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/AddSchedule/ViewModels/AddScheduleViewModel.swift
@@ -183,19 +183,6 @@ extension AddScheduleViewModel {
         isDateNameVaild.value = str.count >= minimumDateNameLength
     }
     
-    func countSelectedTag(isSelected: Bool, tag: String) {
-        if isSelected {
-            if !selectedTagData.contains(tag) {
-                selectedTagData.append(tag)
-            }
-        } else {
-            if let index = selectedTagData.firstIndex(of: tag) {
-                selectedTagData.remove(at: index)
-            }
-        }
-        checkTagCount(min: minTagCnt, max: maxTagCnt)
-    }
-    
     func setVisitDate(_ date: Date) {
         let formattedDate = DateFormatterManager.shared.dateFormatter.string(from: date)
         visitDate.value = formattedDate
@@ -209,6 +196,19 @@ extension AddScheduleViewModel {
             .replacingOccurrences(of: "오후", with: "PM")
         dateStartAt.value = formattedTime
         isDateStartAtVaild.value = !(dateStartAt.value?.isEmpty ?? true)
+    }
+    
+    func countSelectedTag(isSelected: Bool, tag: String) {
+        if isSelected {
+            if !selectedTagData.contains(tag) {
+                selectedTagData.append(tag)
+            }
+        } else {
+            if let index = selectedTagData.firstIndex(of: tag) {
+                selectedTagData.remove(at: index)
+            }
+        }
+        checkTagCount(min: minTagCnt, max: maxTagCnt)
     }
     
     func checkTagCount(min: Int, max: Int) {
@@ -232,20 +232,18 @@ extension AddScheduleViewModel {
         isDateLocationVaild.value = flag
     }
     
-    func isOkSixBtn() -> Bool {
-        let isDateNameVaild = isDateNameVaild.value ?? false
-        let isValidTag = isValidTag.value ?? false
-        let isVisitDateVaild = isVisitDateVaild.value ?? false
-        let isDateStartAtVaild = isDateStartAtVaild.value ?? false
-        let isDateLocationVaild = isDateLocationVaild.value ?? false
-        
-        for i in [isDateNameVaild, isValidTag, isVisitDateVaild, isDateLocationVaild, isDateStartAtVaild] {
-            if i == false {
-                print("\(i) == false")
-                return false
-            }
+    func isEnableNextButton() -> Bool {
+        guard let isDateNameVaild = isDateNameVaild.value,
+              let isValidTag = isValidTag.value,
+              let isVisitDateVaild = isVisitDateVaild.value,
+              let isDateStartAtVaild = isDateStartAtVaild.value,
+              let isDateLocationVaild = isDateLocationVaild.value
+        else {
+            print("isOkSixBtn guard let Error")
+            return false
         }
-        return true
+        
+        return [isDateNameVaild, isValidTag, isVisitDateVaild, isDateLocationVaild, isDateStartAtVaild].allSatisfy { $0 }
     }
     
 }

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/AddSchedule/ViewModels/AddScheduleViewModel.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/AddSchedule/ViewModels/AddScheduleViewModel.swift
@@ -65,7 +65,10 @@ final class AddScheduleViewModel: Serviceable {
     
     let datePlace: ObservablePattern<String> = ObservablePattern(nil)
     
-    let timeRequire: ObservablePattern<String> = ObservablePattern(nil)
+//    let timeRequire: ObservablePattern<String> = ObservablePattern(nil)
+    let outputTimeRequire: ObservablePattern<String> = ObservablePattern("")
+    let inputUpdateTimeRequire: ObservablePattern<String> = ObservablePattern("")
+    
     
     let isValidOfSecondNextBtn: ObservablePattern<Bool> = ObservablePattern(false)
     
@@ -130,6 +133,16 @@ final class AddScheduleViewModel: Serviceable {
                 AmplitudeManager.shared.trackEventWithProperties(StringLiterals.Amplitude.EventName.viewAddBringcourse, properties: [StringLiterals.Amplitude.Property.viewPath: viewPath])
             }
         }
+        
+        inputUpdateTimeRequire.lazyBind { [weak self] value in
+            guard let value else {return}
+            self?.updateTimeRequireTextField(text: value)
+        }
+    }
+    
+    // 로딩뷰 세팅 함수
+    private func setLoading(isLoading: Bool) {
+        self.onLoading.value = isLoading
     }
     
 }
@@ -260,21 +273,22 @@ extension AddScheduleViewModel {
 
 extension AddScheduleViewModel {
     
-    func updatePlaceCollectionView() {
-        print(addPlaceCollectionViewDataSource)
-    }
+//    func updatePlaceCollectionView() {
+//        print(addPlaceCollectionViewDataSource)
+//    }
     
-    func updateTimeRequireTextField(text: String) {
+    private func updateTimeRequireTextField(text: String) {
         var formattedText = text
         if let doubleValue = Double(text) {
             formattedText = doubleValue.truncatingRemainder(dividingBy: 1) == 0 ? String(Int(doubleValue)) : String(doubleValue)
         }
-        timeRequire.value = "\(formattedText) 시간"
+        addScheduleAmplitude.dateDetailTime = true
+        outputTimeRequire.value = "\(formattedText) 시간"
     }
     
     func isAbleAddBtn() -> Bool {
         return !(datePlace.value?.isEmpty ?? true)
-        && !(timeRequire.value?.isEmpty ?? true)
+        && !(outputTimeRequire.value?.isEmpty ?? true)
     }
     
     func tapAddBtn(datePlace: String, timeRequire: String) {
@@ -282,7 +296,7 @@ extension AddScheduleViewModel {
         
         //viewmodel 값 초기화
         self.datePlace.value = ""
-        self.timeRequire.value = ""
+        self.outputTimeRequire.value = ""
         
         self.addScheduleAmplitude.dateDetailLocation = false
         self.addScheduleAmplitude.dateDetailTime = false
@@ -302,11 +316,6 @@ extension AddScheduleViewModel {
     func isDataSourceNotEmpty() {
         let flag = (addPlaceCollectionViewDataSource.count >= 1) ? true : false
         editBtnEnableState.value = flag
-    }
-    
-    /// 로딩뷰 세팅 함수
-    func setLoading(isLoading: Bool) {
-        self.onLoading.value = isLoading
     }
     
     func postAddScheduel() {

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/AddSchedule/ViewModels/AddScheduleViewModel.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/AddSchedule/ViewModels/AddScheduleViewModel.swift
@@ -370,45 +370,73 @@ extension AddScheduleViewModel {
         outputIstValidateRegisterBtn.value = flag
     }
     
+    // 장소 추출
+    private func extractPlaces(from models: [AddCoursePlaceModel]?) -> [PostAddSchedulePlace] {
+        guard let models else { return [] }
+        var places: [PostAddSchedulePlace] = []
+        
+        for (index, model) in models.enumerated() {
+            if let duration = extractDuration(from: model.timeRequire) {
+                let place = PostAddSchedulePlace(title: model.placeTitle, duration: duration, sequence: index)
+                places.append(place)
+                print("👍 place added: \(place)")
+            } else {
+                print("❌ Failed timeRequire: \(model.timeRequire)")
+            }
+        }
+        return places
+    }
+    
+    // 소요시간 추출
+    private func extractDuration(from timeRequire: String) -> Float? {
+        let timeComponents = timeRequire.split(separator: " ")
+        guard let timeString = timeComponents.first else { return nil }
+        return Float(timeString)
+    }
+    
+    // 기타 값 추출
+    private func validateInputData() -> (title: String, date: String, startAt: String, country: String, city: String)? {
+        guard let dateName = inputDateName.value,
+              let visitDate = inputVisitDate.value,
+              let dateStartAt = inputDateStartAt.value else {
+            return nil
+        }
+        let country = inputDateLocation.value?[0] ?? ""
+        let city = inputDateLocation.value?[1] ?? ""
+        let formattedDate = DateFormatterManager.shared.dateFormatter.string(from: visitDate)
+        
+        return (dateName, formattedDate, dateStartAt, country, city)
+    }
+    
+    // request 반환
+    private func createPostRequest() -> PostAddScheduleRequest? {
+        guard let validatedData = validateInputData() else { return nil }
+        
+        let postAddScheduleTags = selectedTagData.map { PostAddScheduleTag(tag: $0) }
+        let places = extractPlaces(from: dataSourceOfAddPlaceCollectionView.value)
+        
+        return PostAddScheduleRequest(
+            title: validatedData.title,
+            date: validatedData.date,
+            startAt: validatedData.startAt,
+            tags: postAddScheduleTags,
+            country: validatedData.country,
+            city: validatedData.city,
+            places: places
+        )
+    }
+    
     private func postAddScheduel() {
         self.setLoading(isLoading: true)
         
-        var places: [PostAddSchedulePlace] = []
-        
-        guard let body = dataSourceOfAddPlaceCollectionView.value else {return}
-        for (index, model) in body.enumerated() {
-            // Extract the numeric part from the timeRequire string
-            let timeComponents = model.timeRequire.split(separator: " ")
-            
-            if let timeString = timeComponents.first {
-                if let duration = Float(timeString) {
-                    let place = PostAddSchedulePlace(title: model.placeTitle, duration: duration, sequence: index)
-                    places.append(place)
-                    print("👍👍👍👍 : place added - \(place)")
-                } else {
-                    print("❌❌❌ Step 1: Failed to convert timeString \(timeString) to Float")
-                }
-            } else {
-                print("❌❌❌ Step 2: Failed to extract timeString from \(model.timeRequire)")
-            }
+        // requestData 세팅
+        guard let request = createPostRequest() else {
+            self.setLoading(isLoading: false)
+            return
         }
         
-        guard let dateName = inputDateName.value,
-              let visitDate = inputVisitDate.value,
-              let dateStartAt = inputDateStartAt.value
-        else {return}
-        let country = inputDateLocation.value?[0] ?? ""
-        let city = inputDateLocation.value?[1] ?? ""
-        let postAddScheduleTags = selectedTagData.map { PostAddScheduleTag(tag: $0) }
-        let formattedDate = DateFormatterManager.shared.dateFormatter.string(from: visitDate)
-        
-        NetworkService.shared.addScheduleService.postAddSchedule(course: PostAddScheduleRequest(title: dateName,
-                                                                                                date: formattedDate,
-                                                                                                startAt: dateStartAt,
-                                                                                                tags: postAddScheduleTags,
-                                                                                                country: country,
-                                                                                                city: city,
-                                                                                                places: places)) { result in
+        // api 호출
+        NetworkService.shared.addScheduleService.postAddSchedule(course: request) { result in
             switch result {
             case .success(let response):
                 print("Success: \(response)")

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/AddSchedule/ViewModels/AddScheduleViewModel.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/AddSchedule/ViewModels/AddScheduleViewModel.swift
@@ -69,10 +69,14 @@ final class AddScheduleViewModel: Serviceable {
     let outputTimeRequire: ObservablePattern<String> = ObservablePattern("")
     let inputUpdateTimeRequire: ObservablePattern<String> = ObservablePattern("")
     
+//    let editBtnEnableState: ObservablePattern<Bool> = ObservablePattern(false)
+    let inputCheckEditBtnState: ObservablePattern<Bool> = ObservablePattern(nil)
+    let outputEditBtnEnableState: ObservablePattern<Bool> = ObservablePattern(false)
+    
     
     let isValidOfSecondNextBtn: ObservablePattern<Bool> = ObservablePattern(false)
     
-    let editBtnEnableState: ObservablePattern<Bool> = ObservablePattern(false)
+    
     
     var isChange: (() -> Void)?
     
@@ -137,6 +141,10 @@ final class AddScheduleViewModel: Serviceable {
         inputUpdateTimeRequire.lazyBind { [weak self] value in
             guard let value else {return}
             self?.updateTimeRequireTextField(text: value)
+        }
+        
+        inputCheckEditBtnState.lazyBind { [weak self] isCheck in
+            self?.isDataSourceNotEmpty()
         }
     }
     
@@ -286,6 +294,12 @@ extension AddScheduleViewModel {
         outputTimeRequire.value = "\(formattedText) 시간"
     }
     
+    /// 데이터 0개면 true 반환
+    private func isDataSourceNotEmpty() {
+        let flag = (addPlaceCollectionViewDataSource.count >= 1) ? true : false
+        outputEditBtnEnableState.value = flag
+    }
+    
     func isAbleAddBtn() -> Bool {
         return !(datePlace.value?.isEmpty ?? true)
         && !(outputTimeRequire.value?.isEmpty ?? true)
@@ -310,12 +324,6 @@ extension AddScheduleViewModel {
         let flag = (cnt >= 2)
         print("지금 데이터소스 개수 : \(addPlaceCollectionViewDataSource.count)\nflag: \(flag)")
         isValidOfSecondNextBtn.value = flag
-    }
-    
-    /// 데이터 0개면 true 반환
-    func isDataSourceNotEmpty() {
-        let flag = (addPlaceCollectionViewDataSource.count >= 1) ? true : false
-        editBtnEnableState.value = flag
     }
     
     func postAddScheduel() {

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/AddSchedule/ViewModels/AddScheduleViewModel.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/AddSchedule/ViewModels/AddScheduleViewModel.swift
@@ -101,7 +101,7 @@ final class AddScheduleViewModel: Serviceable {
         inputDateName.bind { [weak self] value in
             guard let self,
                   let value else {return}
-            self.addScheduleAmplitude.dateTitle = !value.isEmpty ? true : false
+            self.addScheduleAmplitude.dateTitle = !value.isEmpty
             self.satisfyDateName(str: value)
         }
         
@@ -340,7 +340,7 @@ extension AddScheduleViewModel {
     /// 데이터 0개면 true 반환
     private func isDataSourceNotEmpty() {
         guard let count = dataSourceOfAddPlaceCollectionView.value?.count else {return}
-        let flag = (count >= 1) ? true : false
+        let flag = (count >= 1)
         outputEditBtnEnableState.value = flag
     }
     

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/AddSchedule/ViewModels/AddScheduleViewModel.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/AddSchedule/ViewModels/AddScheduleViewModel.swift
@@ -96,85 +96,20 @@ final class AddScheduleViewModel: Serviceable {
     
     //MARK: - AddSchedule Amplitude 관련 변수
     
-    var dateTitle: Bool = false
-    
-    var dateDate: Bool = false
-    
-    var dateTime: Bool = false
-    
-    var dateTagNum: Int = 0
-    
-    var dateArea: Bool = false
-    
-    var dateDetailLocation: Bool = false
-    
-    var dateDetailTime: Bool = false
-    
-    var dateCourseNum: Int = 0
+    var addScheduleAmplitude = AddScheduleAmplitudeState()
     
     
     // MARK: - Initializer
     
     init(viewPath: String) {
         self.viewPath = viewPath
-        initAmplitudeVar()
+//        initAmplitudeVar()
         fetchTagData()
     }
     
     // tag 세팅 함수
     func fetchTagData() {
         tagData = TendencyTag.allCases.map { $0.tag }
-    }
-    
-}
-
-
-//MARK: - AddScheduleViewModel: Amplitude
-
-extension AddScheduleViewModel {
-    
-    func initAmplitudeVar() {
-        dateTitle = false
-        dateDate = false
-        dateTime = false
-        dateTagNum = 0
-        dateArea = false
-        dateDetailLocation = false
-        dateDetailTime = false
-        dateCourseNum = 0
-    }
-    
-    func resetAddFirstScheduleAmplitude() {
-        dateTitle = false
-        dateDate = false
-        dateTime = false
-        dateTagNum = 0
-        dateArea = false
-    }
-    
-    func schedule1BackAmplitude() {
-        AmplitudeManager.shared.trackEventWithProperties(
-            StringLiterals.Amplitude.EventName.clickSchedule1Back,
-            properties: [
-                StringLiterals.Amplitude.Property.dateTitle: self.dateTitle,
-                StringLiterals.Amplitude.Property.dateDate: self.dateDate,
-                StringLiterals.Amplitude.Property.dateTime: self.dateTime,
-                StringLiterals.Amplitude.Property.dateTagNum: self.dateTagNum,
-                StringLiterals.Amplitude.Property.dateArea: self.dateArea
-            ]
-        )
-        self.resetAddFirstScheduleAmplitude()
-    }
-    
-    func schedule2BackAmplitude() {
-        AmplitudeManager.shared.trackEventWithProperties(
-            StringLiterals.Amplitude.EventName.clickSchedule2Back,
-            properties: [
-                StringLiterals.Amplitude.Property.dateDetailLocation: self.dateDetailLocation,
-                StringLiterals.Amplitude.Property.dateDetailTime: self.dateDetailTime,
-                StringLiterals.Amplitude.Property.dateCourseNum: self.dateCourseNum
-            ]
-        )
     }
     
 }
@@ -345,15 +280,15 @@ extension AddScheduleViewModel {
         self.datePlace.value = ""
         self.timeRequire.value = ""
         
-        self.dateDetailLocation = false
-        self.dateDetailTime = false
+        self.addScheduleAmplitude.dateDetailLocation = false
+        self.addScheduleAmplitude.dateDetailTime = false
         self.isChange?()
     }
     
     /// dataSource 개수 >= 2 라면 '확인' 버튼 활성화
     func isSourceMoreThanOne() {
         let cnt = addPlaceCollectionViewDataSource.count
-        self.dateCourseNum = cnt
+        self.addScheduleAmplitude.dateCourseNum = cnt
         let flag = (cnt >= 2)
         print("지금 데이터소스 개수 : \(addPlaceCollectionViewDataSource.count)\nflag: \(flag)")
         isValidOfSecondNextBtn.value = flag
@@ -423,6 +358,53 @@ extension AddScheduleViewModel {
                 print("Failed to another reason")
                 return
             }
+        }
+    }
+    
+}
+
+
+//MARK: - AddScheduleAmplitudeState
+
+struct AddScheduleAmplitudeState {
+    
+    // addSchedule 관련 amplitude 변수들
+    var dateTitle: Bool = false
+    var dateDate: Bool = false
+    var dateTime: Bool = false
+    var dateTagNum: Int = 0
+    var dateArea: Bool = false
+    var dateDetailLocation: Bool = false
+    var dateDetailTime: Bool = false
+    var dateCourseNum: Int = 0
+    
+    
+    func sendAmplitudeEvent(for step: Int) {
+        switch step {
+        case 1:
+            let properties: [String: Any] = [
+                StringLiterals.Amplitude.Property.dateTitle: self.dateTitle,
+                StringLiterals.Amplitude.Property.dateDate: self.dateDate,
+                StringLiterals.Amplitude.Property.dateTime: self.dateTime,
+                StringLiterals.Amplitude.Property.dateTagNum: self.dateTagNum,
+                StringLiterals.Amplitude.Property.dateArea: self.dateArea
+            ]
+            AmplitudeManager.shared.trackEventWithProperties(
+                StringLiterals.Amplitude.EventName.clickSchedule1Back,
+                properties: properties
+            )
+        case 2:
+            let properties: [String: Any] = [
+                StringLiterals.Amplitude.Property.dateDetailLocation: dateDetailLocation,
+                StringLiterals.Amplitude.Property.dateDetailTime: dateDetailTime,
+                StringLiterals.Amplitude.Property.dateCourseNum: dateCourseNum
+            ]
+            AmplitudeManager.shared.trackEventWithProperties(
+                StringLiterals.Amplitude.EventName.clickSchedule2Back,
+                properties: properties
+            )
+        default:
+            print("sendAmplitudeEvent Error")
         }
     }
     

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/AddSchedule/Views/AddScheduleBottomSheetViewController.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/AddSchedule/Views/AddScheduleBottomSheetViewController.swift
@@ -137,7 +137,8 @@ private extension AddScheduleBottomSheetViewController {
     func didTapDoneBtn() {
         let selectedRow = addSheetView.customPickerView.selectedRow(inComponent: 0)
         let selectedValue = customPickerValues[selectedRow]
-        viewModel?.updateTimeRequireTextField(text: String(selectedValue))
+        viewModel?.inputUpdateTimeRequire.value = String(selectedValue)
+//        viewModel?.updateTimeRequireTextField(text: String(selectedValue))
         self.dismissBottomSheet()
     }
     

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/AddSchedule/Views/AddScheduleFirst/AddScheduleFirstViewController.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/AddSchedule/Views/AddScheduleFirst/AddScheduleFirstViewController.swift
@@ -57,7 +57,8 @@ final class AddScheduleFirstViewController: BaseNavBarViewController {
         setDelegate()
         bindViewModel()
         setupKeyboardDismissRecognizer()
-        pastDateBindViewModel()
+        broughtButtonHandling()
+        
         AmplitudeManager.shared.trackEventWithProperties(StringLiterals.Amplitude.EventName.viewAddSchedule, properties: [StringLiterals.Amplitude.Property.viewPath: viewModel.viewPath])
     }
     
@@ -97,10 +98,9 @@ final class AddScheduleFirstViewController: BaseNavBarViewController {
 private extension AddScheduleFirstViewController {
     
     func bindViewModel() {
-        self.viewModel.isSuccessGetData.bind { [weak self] isSuccess in
+        self.viewModel.outputIsBroughtDataConfigured.lazyBind { [weak self] isSuccess in
             guard let isSuccess else { return }
             if isSuccess {
-                print("지금 tendencyTagCollectionView reload")
                 self?.addScheduleFirstView.inAddScheduleFirstView.tendencyTagCollectionView.reloadData()
             }
         }
@@ -225,16 +225,15 @@ private extension AddScheduleFirstViewController {
 
 extension AddScheduleFirstViewController {
     
-    /// 일정등록 시 '불러오기' 여부 분기처리
-    /// 다른 파일에서 해당 함수 사용하기에 private 미사용schedule1BackAmplitude
-    func pastDateBindViewModel() {
-        if !viewModel.isBroughtData {
+    // '일정 등록' 중 불러오기 버튼 핸들링
+    func broughtButtonHandling() {
+        switch viewModel.isBroughtData {
+        case true:
+            self.showLoadingView(type: StringLiterals.AddCourseOrSchedule.addScheduleTitle)
+            viewModel.inputIsBroughtData.value = true
+        case false:
             setRightBtnStyle()
             setRightButtonAction(target: self, action: #selector(didTapNavRightBtn))
-        } else {
-            self.showLoadingView(type: StringLiterals.AddCourseOrSchedule.addScheduleTitle)
-            self.viewModel.fetchPastDate()
-            AmplitudeManager.shared.trackEventWithProperties(StringLiterals.Amplitude.EventName.viewAddBringcourse, properties: [StringLiterals.Amplitude.Property.viewPath: viewModel.viewPath])
         }
     }
     

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/AddSchedule/Views/AddScheduleFirst/AddScheduleFirstViewController.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/AddSchedule/Views/AddScheduleFirst/AddScheduleFirstViewController.swift
@@ -352,9 +352,6 @@ extension AddScheduleFirstViewController: UICollectionViewDelegate, UICollection
         cell.tendencyTagButton.tag = indexPath.item
         cell.tendencyTagButton.addTarget(self, action: #selector(didTapTagButton(_:)), for: .touchUpInside)
         
-        print("Setting up cell for tag: \(cell.tendencyTagButton.tag)")
-        print("pastDateTagIndex: \(viewModel.pastDateTagIndex)")
-        
         if viewModel.pastDateTagIndex.contains(cell.tendencyTagButton.tag) {
             cell.tendencyTagButton.isSelected = true
             self.addScheduleFirstView.inAddScheduleFirstView.updateTag(button: cell.tendencyTagButton, buttonType: SelectedButton())

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/AddSchedule/Views/AddScheduleFirst/AddScheduleFirstViewController.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/AddSchedule/Views/AddScheduleFirst/AddScheduleFirstViewController.swift
@@ -125,18 +125,11 @@ private extension AddScheduleFirstViewController {
             guard let onLoading, let onFailNetwork = self?.viewModel.onFailNetwork.value else { return }
             // getData 중이거나, 에러 발생 X라면
             if onFailNetwork == false || onLoading == false {
-//                self?.loadingView.isHidden = !onLoading
                 self?.hideLoadingView()
                 self?.addScheduleFirstView.isHidden = onLoading
                 self?.tabBarController?.tabBar.isHidden = onLoading
             }
         }
-        
-//        viewModel.ispastDateVaild.bind { [weak self] isValid in
-//            guard let self = self else { return }
-//            self.viewModel.fetchPastDate()
-//            AmplitudeManager.shared.trackEventWithProperties(StringLiterals.Amplitude.EventName.viewAddBringcourse, properties: [StringLiterals.Amplitude.Property.viewPath: viewPath])
-//        }
         
         viewModel.isDateNameVaild.bind { date in
             guard let date else {return}
@@ -229,6 +222,19 @@ private extension AddScheduleFirstViewController {
         addScheduleFirstView.inAddScheduleFirstView.datePlaceContainer.isUserInteractionEnabled = true
     }
     
+    /// 일정등록 시 '불러오기' 여부 분기처리
+    func pastDateBindViewModel() {
+        if !viewModel.isBroughtData {
+            setRightBtnStyle()
+            setRightButtonAction(target: self, action: #selector(didTapNavRightBtn))
+        } else {
+            self.showLoadingView(type: StringLiterals.AddCourseOrSchedule.addScheduleTitle)
+            self.viewModel.fetchPastDate()
+            AmplitudeManager.shared.trackEventWithProperties(StringLiterals.Amplitude.EventName.viewAddBringcourse, properties: [StringLiterals.Amplitude.Property.viewPath: viewModel.viewPath])
+        }
+    }
+    
+    /// 우측 상단 '불러오기' 버튼 함수
     @objc
     func didTapNavRightBtn() {
         let vc = NavViewedCourseViewController(viewedCourseViewModel: MyCourseListViewModel())
@@ -236,28 +242,35 @@ private extension AddScheduleFirstViewController {
         self.navigationController?.pushViewController(vc, animated: false)
     }
     
+}
+
+
+//MARK: - AddScheduleFirstViewController: BaseNavBarViewController
+
+extension AddScheduleFirstViewController {
+    
+    /// BaseNavBarViewController에서 backButtonTapped() 오버라이드
     @objc
-    func visitDate() {
-        addSheetView.datePickerMode(isDatePicker: true)
-        viewModel.isTimePicker = false
-        alertVC.delegate = self
-        addScheduleFirstView.inAddScheduleFirstView.dateNameTextField.resignFirstResponder()
-        DispatchQueue.main.async {
-            self.alertVC.presentBottomSheet(in: self)
-        }
+    override func backButtonTapped() {
+        viewModel.schedule1BackAmplitude()
+        super.backButtonTapped()
     }
     
-    @objc
-    func dateStartAt() {
-        addSheetView.datePickerMode(isDatePicker: false)
-        viewModel.isTimePicker = true
+}
+
+//MARK: - AddScheduleFirstViewController: '일정등록 뷰1 프로퍼티' 관련 함수
+
+private extension AddScheduleFirstViewController {
+    
+    /// DatePicker 관련
+    func presentDatePicker(mode: DatePickerMode) {
+        addSheetView.datePickerMode(isDatePicker: mode == .date)
         alertVC.delegate = self
         addScheduleFirstView.inAddScheduleFirstView.dateNameTextField.resignFirstResponder()
-        DispatchQueue.main.async {
-            self.alertVC.presentBottomSheet(in: self)
-        }
+        alertVC.presentBottomSheet(in: self)
     }
     
+    /// '데이트 이름' 관련
     @objc
     func textFieldDidChanacge(_ textField: UITextField) {
         guard let text = textField.text else {return}
@@ -266,6 +279,19 @@ private extension AddScheduleFirstViewController {
         self.viewModel.dateTitle = !text.isEmpty ? true : false
     }
     
+    /// '방문일자' 관련
+    @objc
+    func visitDate() {
+        presentDatePicker(mode: .date)
+    }
+    
+    /// '데이트 시작 시간' 관련
+    @objc
+    func dateStartAt() {
+        presentDatePicker(mode: .time)
+    }
+    
+    /// dateTag 관련
     @objc
     func didTapTagButton(_ sender: UIButton) {
         guard let tag = TendencyTag(rawValue: sender.tag)?.tag.english else { return }
@@ -286,18 +312,7 @@ private extension AddScheduleFirstViewController {
         }
     }
     
-    @objc
-    func broughtTagBtn(_ sender: UIButton) {
-        self.addScheduleFirstView.inAddScheduleFirstView.updateTag(button: sender, buttonType: SelectedButton())
-        self.viewModel.isValidTag.value = true
-    }
-    
-    @objc
-    func sixCheckBtnTapped() {
-        let secondVC = AddScheduleSecondViewController(viewModel: self.viewModel)
-        navigationController?.pushViewController(secondVC, animated: false)
-    }
-    
+    /// datePlace 관련
     @objc
     func datePlaceContainerTapped() {
         locationFilterVC.isAddType = true
@@ -307,26 +322,11 @@ private extension AddScheduleFirstViewController {
         }
     }
     
-}
-
-extension AddScheduleFirstViewController {
-    
-    func pastDateBindViewModel() {
-        if !viewModel.isBroughtData {
-            setRightBtnStyle()
-            setRightButtonAction(target: self, action: #selector(didTapNavRightBtn))
-        } else {
-            self.showLoadingView(type: StringLiterals.AddCourseOrSchedule.addScheduleTitle)
-            self.viewModel.fetchPastDate()
-            AmplitudeManager.shared.trackEventWithProperties(StringLiterals.Amplitude.EventName.viewAddBringcourse, properties: [StringLiterals.Amplitude.Property.viewPath: viewModel.viewPath])
-        }
-    }
-    
-    /// BaseNavBarViewController에서 backButtonTapped() 오버라이드
+    /// 일정등록 뷰1 '다음' 버튼 관련
     @objc
-    override func backButtonTapped() {
-        viewModel.schedule1BackAmplitude()
-        super.backButtonTapped()
+    func sixCheckBtnTapped() {
+        let secondVC = AddScheduleSecondViewController(viewModel: self.viewModel)
+        navigationController?.pushViewController(secondVC, animated: false)
     }
     
 }
@@ -404,19 +404,23 @@ extension AddScheduleFirstViewController: UITextFieldDelegate {
 extension AddScheduleFirstViewController: DRBottomSheetDelegate {
     
     func didTapBottomButton() {
+        let selectedDate = addSheetView.datePicker.date
         alertVC.dismissBottomSheet()
-        updateTextField()
+        
+        if addSheetView.datePicker.datePickerMode == .date {
+            updateTextField(selectedDate: selectedDate, mode: .date)
+        } else {
+            updateTextField(selectedDate: selectedDate, mode: .time)
+        }
     }
     
-    func updateTextField() {
-        let isTimePickerFlag = viewModel.isTimePicker ?? false
-        
-        if !isTimePickerFlag {
-            let selectedDate = addSheetView.datePicker.date
-            viewModel.isFutureDate(date: selectedDate, dateType: "date")
-        } else {
-            let formattedDate = addSheetView.datePicker.date
-            viewModel.isFutureDate(date: formattedDate, dateType: "time")
+    //'방문일자', '시작시간' 업데이트 함수
+    func updateTextField(selectedDate: Date, mode: DatePickerMode) {
+        switch mode {
+        case .date:
+            viewModel.setVisitDate(selectedDate)
+        case .time:
+            viewModel.setDateStartAt(selectedDate)
         }
     }
     

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/AddSchedule/Views/AddScheduleFirst/AddScheduleFirstViewController.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/AddSchedule/Views/AddScheduleFirst/AddScheduleFirstViewController.swift
@@ -134,9 +134,10 @@ private extension AddScheduleFirstViewController {
             }
         }
         
-        viewModel.isDateNameVaild.bind { date in
-            guard let date else {return}
-            self.addScheduleFirstView.updateDateNameTextField(isPassValid: date)
+        viewModel.outputDateNameVaild.lazyBind { [weak self] value in
+            guard let self, let value else {return}
+            self.addScheduleFirstView.updateDateNameTextField(isPassValid: value)
+            self.addScheduleFirstView.inAddScheduleFirstView.updateDateName(text: viewModel.inputDateName.value ?? "")
             self.addScheduleFirstView.inAddScheduleFirstView.updateSixCheckButton(isValid: self.viewModel.isEnableNextButton())
         }
         
@@ -156,12 +157,6 @@ private extension AddScheduleFirstViewController {
         
         viewModel.isDateLocationVaild.bind { _ in
             self.addScheduleFirstView.inAddScheduleFirstView.updateSixCheckButton(isValid: self.viewModel.isEnableNextButton())
-        }
-        
-        viewModel.dateName.bind { date in
-            guard let text = date else {return}
-            self.addScheduleFirstView.inAddScheduleFirstView.updateDateName(text: text)
-            self.viewModel.addScheduleAmplitude.dateTitle = true
         }
         
         viewModel.visitDate.bind { date in
@@ -202,7 +197,7 @@ private extension AddScheduleFirstViewController {
     }
     
     func setAddTarget() {
-        addScheduleFirstView.inAddScheduleFirstView.dateNameTextField.addTarget(self, action: #selector(textFieldDidChanacge(_:)), for: .editingChanged)
+        addScheduleFirstView.inAddScheduleFirstView.dateNameTextField.addTarget(self, action: #selector(dateNameTextFieldDidChange(_:)), for: .editingChanged)
         
         addScheduleFirstView.inAddScheduleFirstView.sixCheckNextButton.addTarget(self, action: #selector(sixCheckBtnTapped), for: .touchUpInside)
         
@@ -270,13 +265,10 @@ private extension AddScheduleFirstViewController {
         alertVC.presentBottomSheet(in: self)
     }
     
-    /// '데이트 이름' 관련
+    /// about 데이트이름
     @objc
-    func textFieldDidChanacge(_ textField: UITextField) {
-        guard let text = textField.text else {return}
-        viewModel.dateName.value = text
-        viewModel.satisfyDateName(str: text)
-        self.viewModel.addScheduleAmplitude.dateTitle = !text.isEmpty ? true : false
+    func dateNameTextFieldDidChange(_ textField: UITextField) {
+        viewModel.inputDateName.value = textField.text
     }
     
     /// '방문일자' 관련

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/AddSchedule/Views/AddScheduleFirst/AddScheduleFirstViewController.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/AddSchedule/Views/AddScheduleFirst/AddScheduleFirstViewController.swift
@@ -143,21 +143,25 @@ private extension AddScheduleFirstViewController {
         
         viewModel.outputVisitDateVaild.bind { [weak self] value in
             guard let self, let value,
-                  let date = self.viewModel.inputVisitDate.value
+                  let data = self.viewModel.inputVisitDate.value
             else {return}
             
             self.addScheduleFirstView.updateVisitDateTextField(isPassValid: value)
             
-            let formattedDate = DateFormatterManager.shared.dateFormatter.string(from: date)
+            let formattedDate = DateFormatterManager.shared.dateFormatter.string(from: data)
             self.addScheduleFirstView.inAddScheduleFirstView.updateVisitDate(text: formattedDate)
             isValidNextBtn()
         }
         
-        // ㅡ여기부터 재시작ㅡ
-        
-        viewModel.isDateStartAtVaild.bind { _ in
-            self.addScheduleFirstView.inAddScheduleFirstView.updateSixCheckButton(isValid: self.viewModel.isEnableNextButton())
+        viewModel.outputDateStartAtVaild.bind { [weak self] value in
+            guard let self, let value,
+                  let data = self.viewModel.inputDateStartAt.value
+            else {return}
+            self.addScheduleFirstView.inAddScheduleFirstView.updatedateStartTime(text: data)
+            isValidNextBtn()
         }
+        
+        // ㅡ여기부터 재시작ㅡ
         
         viewModel.isValidTag.bind { _ in
             self.addScheduleFirstView.inAddScheduleFirstView.updateSixCheckButton(isValid: self.viewModel.isEnableNextButton())
@@ -167,11 +171,7 @@ private extension AddScheduleFirstViewController {
             self.addScheduleFirstView.inAddScheduleFirstView.updateSixCheckButton(isValid: self.viewModel.isEnableNextButton())
         }
         
-        viewModel.dateStartAt.bind { date in
-            guard let text = date else {return}
-            self.addScheduleFirstView.inAddScheduleFirstView.updatedateStartTime(text: text)
-            self.viewModel.addScheduleAmplitude.dateTime = true
-        }
+        
         
         viewModel.tagCount.bind { count in
             guard let count else {return}
@@ -207,7 +207,7 @@ private extension AddScheduleFirstViewController {
         addScheduleFirstView.inAddScheduleFirstView.visitDateContainer.addGestureRecognizer(tapGesture1)
         addScheduleFirstView.inAddScheduleFirstView.visitDateContainer.isUserInteractionEnabled = true
         
-        let tapGesture2 = UITapGestureRecognizer(target: self, action: #selector(dateStartAt))
+        let tapGesture2 = UITapGestureRecognizer(target: self, action: #selector(dateStartAtTapped))
         addScheduleFirstView.inAddScheduleFirstView.dateStartAtContainer.addGestureRecognizer(tapGesture2)
         addScheduleFirstView.inAddScheduleFirstView.dateStartAtContainer.isUserInteractionEnabled = true
         
@@ -285,7 +285,7 @@ private extension AddScheduleFirstViewController {
     
     /// '데이트 시작 시간' 관련
     @objc
-    func dateStartAt() {
+    func dateStartAtTapped() {
         presentDatePicker(mode: .time)
     }
     
@@ -420,7 +420,7 @@ extension AddScheduleFirstViewController: DRBottomSheetDelegate {
         case .date:
             viewModel.inputVisitDate.value = selectedValue
         case .time:
-            viewModel.setDateStartAt(selectedValue)
+            viewModel.inputDataStartAtTransForm.value = selectedValue
         }
     }
     

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/AddSchedule/Views/AddScheduleFirst/AddScheduleFirstViewController.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/AddSchedule/Views/AddScheduleFirst/AddScheduleFirstViewController.swift
@@ -168,16 +168,10 @@ private extension AddScheduleFirstViewController {
             isValidNextBtn()
         }
         
-        // ㅡ여기부터 재시작ㅡ
-        
-        viewModel.isDateLocationVaild.bind { _ in
-            self.addScheduleFirstView.inAddScheduleFirstView.updateSixCheckButton(isValid: self.viewModel.isEnableNextButton())
-        }
-        
-        viewModel.dateLocation.bind { date in
-            guard let date else {return}
-            self.addScheduleFirstView.inAddScheduleFirstView.updateDateLocation(text: date)
-            self.viewModel.addScheduleAmplitude.dateArea = true
+        viewModel.outputDateLocation.lazyBind { [weak self] city in
+            guard let self, let city else {return}
+            self.addScheduleFirstView.inAddScheduleFirstView.updateDateLocation(text: city)
+            isValidNextBtn()
         }
     }
     
@@ -426,10 +420,10 @@ extension AddScheduleFirstViewController: LocationFilterDelegate {
     func didSelectCity(_ country: LocationModel.Country, _ city: LocationModel.City) {
         print("selected country : \(country.rawValue)")
         print("Selected city: \(city.rawValue)")
-        viewModel.dateLocation.value = city.rawValue
-        viewModel.satisfyDateLocation(str: city.rawValue)
-        viewModel.country = country.rawValue
-        viewModel.city = city.rawValue
+        var arr = Array(repeating: "", count: 2)
+        arr[0] = country.rawValue
+        arr[1] = city.rawValue
+        viewModel.inputDateLocation.value = arr
     }
     
 }

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/AddSchedule/Views/AddScheduleFirst/AddScheduleFirstViewController.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/AddSchedule/Views/AddScheduleFirst/AddScheduleFirstViewController.swift
@@ -91,6 +91,9 @@ final class AddScheduleFirstViewController: BaseNavBarViewController {
     
 }
 
+
+// MARK: - AddScheduleFirstVC Methods
+
 private extension AddScheduleFirstViewController {
     
     func bindViewModel() {
@@ -163,31 +166,31 @@ private extension AddScheduleFirstViewController {
         viewModel.dateName.bind { date in
             guard let text = date else {return}
             self.addScheduleFirstView.inAddScheduleFirstView.updateDateName(text: text)
-            self.viewModel.dateTitle = true
+            self.viewModel.addScheduleAmplitude.dateTitle = true
         }
         
         viewModel.visitDate.bind { date in
             guard let text = date else {return}
             self.addScheduleFirstView.inAddScheduleFirstView.updateVisitDate(text: text)
-            self.viewModel.dateDate = true
+            self.viewModel.addScheduleAmplitude.dateDate = true
         }
         
         viewModel.dateStartAt.bind { date in
             guard let text = date else {return}
             self.addScheduleFirstView.inAddScheduleFirstView.updatedateStartTime(text: text)
-            self.viewModel.dateTime = true
+            self.viewModel.addScheduleAmplitude.dateTime = true
         }
         
         viewModel.tagCount.bind { count in
             guard let count else {return}
             self.addScheduleFirstView.inAddScheduleFirstView.updateTagCount(count: count)
-            self.viewModel.dateTagNum = count
+            self.viewModel.addScheduleAmplitude.dateTagNum = count
         }
         
         viewModel.dateLocation.bind { date in
             guard let date else {return}
             self.addScheduleFirstView.inAddScheduleFirstView.updateDateLocation(text: date)
-            self.viewModel.dateArea = true
+            self.viewModel.addScheduleAmplitude.dateArea = true
         }
     }
     
@@ -238,7 +241,7 @@ private extension AddScheduleFirstViewController {
 extension AddScheduleFirstViewController {
     
     /// 일정등록 시 '불러오기' 여부 분기처리
-    /// 다른 파일에서 해당 함수 사용하기에 private 미사용
+    /// 다른 파일에서 해당 함수 사용하기에 private 미사용schedule1BackAmplitude
     func pastDateBindViewModel() {
         if !viewModel.isBroughtData {
             setRightBtnStyle()
@@ -253,11 +256,12 @@ extension AddScheduleFirstViewController {
     /// BaseNavBarViewController에서 backButtonTapped() 오버라이드
     @objc
     override func backButtonTapped() {
-        viewModel.schedule1BackAmplitude()
+        viewModel.addScheduleAmplitude.sendAmplitudeEvent(for: 1)
         super.backButtonTapped()
     }
     
 }
+
 
 //MARK: - AddScheduleFirstViewController: '일정등록 뷰1 프로퍼티' 관련 함수
 
@@ -277,7 +281,7 @@ private extension AddScheduleFirstViewController {
         guard let text = textField.text else {return}
         viewModel.dateName.value = text
         viewModel.satisfyDateName(str: text)
-        self.viewModel.dateTitle = !text.isEmpty ? true : false
+        self.viewModel.addScheduleAmplitude.dateTitle = !text.isEmpty ? true : false
     }
     
     /// '방문일자' 관련

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/AddSchedule/Views/AddScheduleFirst/AddScheduleFirstViewController.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/AddSchedule/Views/AddScheduleFirst/AddScheduleFirstViewController.swift
@@ -256,7 +256,7 @@ extension AddScheduleFirstViewController {
     /// BaseNavBarViewController에서 backButtonTapped() 오버라이드
     @objc
     override func backButtonTapped() {
-        viewModel.addScheduleAmplitude.sendAmplitudeEvent(for: 1)
+        viewModel.addScheduleAmplitude.sendAmplitudeEvent(step: 1)
         super.backButtonTapped()
     }
     

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/AddSchedule/Views/AddScheduleFirst/AddScheduleFirstViewController.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/AddSchedule/Views/AddScheduleFirst/AddScheduleFirstViewController.swift
@@ -222,18 +222,6 @@ private extension AddScheduleFirstViewController {
         addScheduleFirstView.inAddScheduleFirstView.datePlaceContainer.isUserInteractionEnabled = true
     }
     
-    /// 일정등록 시 '불러오기' 여부 분기처리
-    func pastDateBindViewModel() {
-        if !viewModel.isBroughtData {
-            setRightBtnStyle()
-            setRightButtonAction(target: self, action: #selector(didTapNavRightBtn))
-        } else {
-            self.showLoadingView(type: StringLiterals.AddCourseOrSchedule.addScheduleTitle)
-            self.viewModel.fetchPastDate()
-            AmplitudeManager.shared.trackEventWithProperties(StringLiterals.Amplitude.EventName.viewAddBringcourse, properties: [StringLiterals.Amplitude.Property.viewPath: viewModel.viewPath])
-        }
-    }
-    
     /// 우측 상단 '불러오기' 버튼 함수
     @objc
     func didTapNavRightBtn() {
@@ -248,6 +236,19 @@ private extension AddScheduleFirstViewController {
 //MARK: - AddScheduleFirstViewController: BaseNavBarViewController
 
 extension AddScheduleFirstViewController {
+    
+    /// 일정등록 시 '불러오기' 여부 분기처리
+    /// 다른 파일에서 접근하기에 private 미사용
+    func pastDateBindViewModel() {
+        if !viewModel.isBroughtData {
+            setRightBtnStyle()
+            setRightButtonAction(target: self, action: #selector(didTapNavRightBtn))
+        } else {
+            self.showLoadingView(type: StringLiterals.AddCourseOrSchedule.addScheduleTitle)
+            self.viewModel.fetchPastDate()
+            AmplitudeManager.shared.trackEventWithProperties(StringLiterals.Amplitude.EventName.viewAddBringcourse, properties: [StringLiterals.Amplitude.Property.viewPath: viewModel.viewPath])
+        }
+    }
     
     /// BaseNavBarViewController에서 backButtonTapped() 오버라이드
     @objc

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/AddSchedule/Views/AddScheduleFirst/AddScheduleFirstViewController.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/AddSchedule/Views/AddScheduleFirst/AddScheduleFirstViewController.swift
@@ -222,18 +222,6 @@ private extension AddScheduleFirstViewController {
         addScheduleFirstView.inAddScheduleFirstView.datePlaceContainer.isUserInteractionEnabled = true
     }
     
-    /// 일정등록 시 '불러오기' 여부 분기처리
-    func pastDateBindViewModel() {
-        if !viewModel.isBroughtData {
-            setRightBtnStyle()
-            setRightButtonAction(target: self, action: #selector(didTapNavRightBtn))
-        } else {
-            self.showLoadingView(type: StringLiterals.AddCourseOrSchedule.addScheduleTitle)
-            self.viewModel.fetchPastDate()
-            AmplitudeManager.shared.trackEventWithProperties(StringLiterals.Amplitude.EventName.viewAddBringcourse, properties: [StringLiterals.Amplitude.Property.viewPath: viewModel.viewPath])
-        }
-    }
-    
     /// 우측 상단 '불러오기' 버튼 함수
     @objc
     func didTapNavRightBtn() {
@@ -248,6 +236,19 @@ private extension AddScheduleFirstViewController {
 //MARK: - AddScheduleFirstViewController: BaseNavBarViewController
 
 extension AddScheduleFirstViewController {
+    
+    /// 일정등록 시 '불러오기' 여부 분기처리
+    /// 다른 파일에서 해당 함수 사용하기에 private 미사용
+    func pastDateBindViewModel() {
+        if !viewModel.isBroughtData {
+            setRightBtnStyle()
+            setRightButtonAction(target: self, action: #selector(didTapNavRightBtn))
+        } else {
+            self.showLoadingView(type: StringLiterals.AddCourseOrSchedule.addScheduleTitle)
+            self.viewModel.fetchPastDate()
+            AmplitudeManager.shared.trackEventWithProperties(StringLiterals.Amplitude.EventName.viewAddBringcourse, properties: [StringLiterals.Amplitude.Property.viewPath: viewModel.viewPath])
+        }
+    }
     
     /// BaseNavBarViewController에서 backButtonTapped() 오버라이드
     @objc

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/AddSchedule/Views/AddScheduleFirst/AddScheduleFirstViewController.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/AddSchedule/Views/AddScheduleFirst/AddScheduleFirstViewController.swift
@@ -138,14 +138,22 @@ private extension AddScheduleFirstViewController {
             guard let self, let value else {return}
             self.addScheduleFirstView.updateDateNameTextField(isPassValid: value)
             self.addScheduleFirstView.inAddScheduleFirstView.updateDateName(text: viewModel.inputDateName.value ?? "")
-            self.addScheduleFirstView.inAddScheduleFirstView.updateSixCheckButton(isValid: self.viewModel.isEnableNextButton())
+            isValidNextBtn()
         }
         
-        viewModel.isVisitDateVaild.bind { date in
-            guard let date else {return}
-            self.addScheduleFirstView.updateVisitDateTextField(isPassValid: date)
-            self.addScheduleFirstView.inAddScheduleFirstView.updateSixCheckButton(isValid: self.viewModel.isEnableNextButton())
+        viewModel.outputVisitDateVaild.bind { [weak self] value in
+            guard let self, let value,
+                  let date = self.viewModel.inputVisitDate.value
+            else {return}
+            
+            self.addScheduleFirstView.updateVisitDateTextField(isPassValid: value)
+            
+            let formattedDate = DateFormatterManager.shared.dateFormatter.string(from: date)
+            self.addScheduleFirstView.inAddScheduleFirstView.updateVisitDate(text: formattedDate)
+            isValidNextBtn()
         }
+        
+        // ㅡ여기부터 재시작ㅡ
         
         viewModel.isDateStartAtVaild.bind { _ in
             self.addScheduleFirstView.inAddScheduleFirstView.updateSixCheckButton(isValid: self.viewModel.isEnableNextButton())
@@ -157,12 +165,6 @@ private extension AddScheduleFirstViewController {
         
         viewModel.isDateLocationVaild.bind { _ in
             self.addScheduleFirstView.inAddScheduleFirstView.updateSixCheckButton(isValid: self.viewModel.isEnableNextButton())
-        }
-        
-        viewModel.visitDate.bind { date in
-            guard let text = date else {return}
-            self.addScheduleFirstView.inAddScheduleFirstView.updateVisitDate(text: text)
-            self.viewModel.addScheduleAmplitude.dateDate = true
         }
         
         viewModel.dateStartAt.bind { date in
@@ -201,7 +203,7 @@ private extension AddScheduleFirstViewController {
         
         addScheduleFirstView.inAddScheduleFirstView.sixCheckNextButton.addTarget(self, action: #selector(sixCheckBtnTapped), for: .touchUpInside)
         
-        let tapGesture1 = UITapGestureRecognizer(target: self, action: #selector(visitDate))
+        let tapGesture1 = UITapGestureRecognizer(target: self, action: #selector(visitDateTapped))
         addScheduleFirstView.inAddScheduleFirstView.visitDateContainer.addGestureRecognizer(tapGesture1)
         addScheduleFirstView.inAddScheduleFirstView.visitDateContainer.isUserInteractionEnabled = true
         
@@ -213,6 +215,10 @@ private extension AddScheduleFirstViewController {
         let tapGesture3 = UITapGestureRecognizer(target: self, action: #selector(datePlaceContainerTapped))
         addScheduleFirstView.inAddScheduleFirstView.datePlaceContainer.addGestureRecognizer(tapGesture3)
         addScheduleFirstView.inAddScheduleFirstView.datePlaceContainer.isUserInteractionEnabled = true
+    }
+    
+    func isValidNextBtn() {
+        self.addScheduleFirstView.inAddScheduleFirstView.updateSixCheckButton(isValid: self.viewModel.isEnableNextButton())
     }
     
     /// 우측 상단 '불러오기' 버튼 함수
@@ -273,7 +279,7 @@ private extension AddScheduleFirstViewController {
     
     /// '방문일자' 관련
     @objc
-    func visitDate() {
+    func visitDateTapped() {
         presentDatePicker(mode: .date)
     }
     
@@ -402,19 +408,19 @@ extension AddScheduleFirstViewController: DRBottomSheetDelegate {
         alertVC.dismissBottomSheet()
         
         if addSheetView.datePicker.datePickerMode == .date {
-            updateTextField(selectedDate: selectedDate, mode: .date)
+            updateTextField(selectedValue: selectedDate, mode: .date)
         } else {
-            updateTextField(selectedDate: selectedDate, mode: .time)
+            updateTextField(selectedValue: selectedDate, mode: .time)
         }
     }
     
     //'방문일자', '시작시간' 업데이트 함수
-    func updateTextField(selectedDate: Date, mode: DatePickerMode) {
+    func updateTextField(selectedValue: Date, mode: DatePickerMode) {
         switch mode {
         case .date:
-            viewModel.setVisitDate(selectedDate)
+            viewModel.inputVisitDate.value = selectedValue
         case .time:
-            viewModel.setDateStartAt(selectedDate)
+            viewModel.setDateStartAt(selectedValue)
         }
     }
     

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/AddSchedule/Views/AddScheduleFirst/AddScheduleFirstViewController.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/AddSchedule/Views/AddScheduleFirst/AddScheduleFirstViewController.swift
@@ -222,6 +222,18 @@ private extension AddScheduleFirstViewController {
         addScheduleFirstView.inAddScheduleFirstView.datePlaceContainer.isUserInteractionEnabled = true
     }
     
+    /// 일정등록 시 '불러오기' 여부 분기처리
+    func pastDateBindViewModel() {
+        if !viewModel.isBroughtData {
+            setRightBtnStyle()
+            setRightButtonAction(target: self, action: #selector(didTapNavRightBtn))
+        } else {
+            self.showLoadingView(type: StringLiterals.AddCourseOrSchedule.addScheduleTitle)
+            self.viewModel.fetchPastDate()
+            AmplitudeManager.shared.trackEventWithProperties(StringLiterals.Amplitude.EventName.viewAddBringcourse, properties: [StringLiterals.Amplitude.Property.viewPath: viewModel.viewPath])
+        }
+    }
+    
     /// 우측 상단 '불러오기' 버튼 함수
     @objc
     func didTapNavRightBtn() {
@@ -236,19 +248,6 @@ private extension AddScheduleFirstViewController {
 //MARK: - AddScheduleFirstViewController: BaseNavBarViewController
 
 extension AddScheduleFirstViewController {
-    
-    /// 일정등록 시 '불러오기' 여부 분기처리
-    /// 다른 파일에서 접근하기에 private 미사용
-    func pastDateBindViewModel() {
-        if !viewModel.isBroughtData {
-            setRightBtnStyle()
-            setRightButtonAction(target: self, action: #selector(didTapNavRightBtn))
-        } else {
-            self.showLoadingView(type: StringLiterals.AddCourseOrSchedule.addScheduleTitle)
-            self.viewModel.fetchPastDate()
-            AmplitudeManager.shared.trackEventWithProperties(StringLiterals.Amplitude.EventName.viewAddBringcourse, properties: [StringLiterals.Amplitude.Property.viewPath: viewModel.viewPath])
-        }
-    }
     
     /// BaseNavBarViewController에서 backButtonTapped() 오버라이드
     @objc

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/AddSchedule/Views/AddScheduleFirst/AddScheduleFirstViewController.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/AddSchedule/Views/AddScheduleFirst/AddScheduleFirstViewController.swift
@@ -137,30 +137,25 @@ private extension AddScheduleFirstViewController {
         viewModel.isDateNameVaild.bind { date in
             guard let date else {return}
             self.addScheduleFirstView.updateDateNameTextField(isPassValid: date)
-            let flag = self.viewModel.isOkSixBtn()
-            self.addScheduleFirstView.inAddScheduleFirstView.updateSixCheckButton(isValid: flag)
+            self.addScheduleFirstView.inAddScheduleFirstView.updateSixCheckButton(isValid: self.viewModel.isEnableNextButton())
         }
         
         viewModel.isVisitDateVaild.bind { date in
             guard let date else {return}
             self.addScheduleFirstView.updateVisitDateTextField(isPassValid: date)
-            let flag = self.viewModel.isOkSixBtn()
-            self.addScheduleFirstView.inAddScheduleFirstView.updateSixCheckButton(isValid: flag)
+            self.addScheduleFirstView.inAddScheduleFirstView.updateSixCheckButton(isValid: self.viewModel.isEnableNextButton())
         }
         
-        viewModel.isDateStartAtVaild.bind { date in
-            let flag = self.viewModel.isOkSixBtn()
-            self.addScheduleFirstView.inAddScheduleFirstView.updateSixCheckButton(isValid: flag)
+        viewModel.isDateStartAtVaild.bind { _ in
+            self.addScheduleFirstView.inAddScheduleFirstView.updateSixCheckButton(isValid: self.viewModel.isEnableNextButton())
         }
         
-        viewModel.isValidTag.bind { date in
-            let flag = self.viewModel.isOkSixBtn()
-            self.addScheduleFirstView.inAddScheduleFirstView.updateSixCheckButton(isValid: flag)
+        viewModel.isValidTag.bind { _ in
+            self.addScheduleFirstView.inAddScheduleFirstView.updateSixCheckButton(isValid: self.viewModel.isEnableNextButton())
         }
         
-        viewModel.isDateLocationVaild.bind { date in
-            let flag = self.viewModel.isOkSixBtn()
-            self.addScheduleFirstView.inAddScheduleFirstView.updateSixCheckButton(isValid: flag)
+        viewModel.isDateLocationVaild.bind { _ in
+            self.addScheduleFirstView.inAddScheduleFirstView.updateSixCheckButton(isValid: self.viewModel.isEnableNextButton())
         }
         
         viewModel.dateName.bind { date in
@@ -302,16 +297,18 @@ private extension AddScheduleFirstViewController {
         guard let tag = TendencyTag(rawValue: sender.tag)?.tag.english else { return }
         let maxTags = 3
         
-        if sender.isSelected {
-            // 이미 선택된 태그를 해제하는 로직
-            sender.isSelected = false
-            self.addScheduleFirstView.inAddScheduleFirstView.updateTag(button: sender, buttonType: UnselectedButton())
+        sender.isSelected ? self.addScheduleFirstView.inAddScheduleFirstView.updateTag(button: sender, buttonType: UnselectedButton()) :
+        self.addScheduleFirstView.inAddScheduleFirstView.updateTag(button: sender, buttonType: SelectedButton())
+        
+        if sender.isSelected { //해당 버튼이 이미 눌린 상태라면
+            sender.isSelected.toggle()
+//            self.addScheduleFirstView.inAddScheduleFirstView.updateTag(button: sender, buttonType: UnselectedButton())
             self.viewModel.countSelectedTag(isSelected: false, tag: tag)
-        } else {
+        } else { //해당 버튼이 안 눌린 상태라면
             // 새로 선택하는 태그가 최대 개수 이내일 때만 처리
             if self.viewModel.selectedTagData.count < maxTags {
-                sender.isSelected = true
-                self.addScheduleFirstView.inAddScheduleFirstView.updateTag(button: sender, buttonType: SelectedButton())
+                sender.isSelected.toggle()
+//                self.addScheduleFirstView.inAddScheduleFirstView.updateTag(button: sender, buttonType: SelectedButton())
                 self.viewModel.countSelectedTag(isSelected: true, tag: tag)
             }
         }

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/AddSchedule/Views/AddScheduleFirst/AddScheduleFirstViewController.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/AddSchedule/Views/AddScheduleFirst/AddScheduleFirstViewController.swift
@@ -31,14 +31,11 @@ final class AddScheduleFirstViewController: BaseNavBarViewController {
     
     let viewModel: AddScheduleViewModel
     
-    var viewPath: String
-    
     
     // MARK: - Initializer
     
-    init(viewModel: AddScheduleViewModel, viewPath: String) {
+    init(viewModel: AddScheduleViewModel) {
         self.viewModel = viewModel
-        self.viewPath = viewPath
         
         super.init(nibName: nil, bundle: nil)
     }
@@ -61,7 +58,7 @@ final class AddScheduleFirstViewController: BaseNavBarViewController {
         bindViewModel()
         setupKeyboardDismissRecognizer()
         pastDateBindViewModel()
-        AmplitudeManager.shared.trackEventWithProperties(StringLiterals.Amplitude.EventName.viewAddSchedule, properties: [StringLiterals.Amplitude.Property.viewPath: viewPath])
+        AmplitudeManager.shared.trackEventWithProperties(StringLiterals.Amplitude.EventName.viewAddSchedule, properties: [StringLiterals.Amplitude.Property.viewPath: viewModel.viewPath])
     }
     
     
@@ -321,7 +318,7 @@ extension AddScheduleFirstViewController {
         } else {
             self.showLoadingView(type: StringLiterals.AddCourseOrSchedule.addScheduleTitle)
             self.viewModel.fetchPastDate()
-            AmplitudeManager.shared.trackEventWithProperties(StringLiterals.Amplitude.EventName.viewAddBringcourse, properties: [StringLiterals.Amplitude.Property.viewPath: viewPath])
+            AmplitudeManager.shared.trackEventWithProperties(StringLiterals.Amplitude.EventName.viewAddBringcourse, properties: [StringLiterals.Amplitude.Property.viewPath: viewModel.viewPath])
         }
     }
     

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/AddSchedule/Views/AddScheduleFirst/AddScheduleFirstViewController.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/AddSchedule/Views/AddScheduleFirst/AddScheduleFirstViewController.swift
@@ -161,22 +161,17 @@ private extension AddScheduleFirstViewController {
             isValidNextBtn()
         }
         
-        // ㅡ여기부터 재시작ㅡ
-        
-        viewModel.isValidTag.bind { _ in
-            self.addScheduleFirstView.inAddScheduleFirstView.updateSixCheckButton(isValid: self.viewModel.isEnableNextButton())
+        viewModel.outputDateTag.bind { [weak self] bool in
+            guard let self else {return}
+            let count = viewModel.selectedTagData.count
+            self.addScheduleFirstView.inAddScheduleFirstView.updateTagCount(count: count)
+            isValidNextBtn()
         }
+        
+        // ㅡ여기부터 재시작ㅡ
         
         viewModel.isDateLocationVaild.bind { _ in
             self.addScheduleFirstView.inAddScheduleFirstView.updateSixCheckButton(isValid: self.viewModel.isEnableNextButton())
-        }
-        
-        
-        
-        viewModel.tagCount.bind { count in
-            guard let count else {return}
-            self.addScheduleFirstView.inAddScheduleFirstView.updateTagCount(count: count)
-            self.viewModel.addScheduleAmplitude.dateTagNum = count
         }
         
         viewModel.dateLocation.bind { date in
@@ -295,18 +290,15 @@ private extension AddScheduleFirstViewController {
         guard let tag = TendencyTag(rawValue: sender.tag)?.tag.english else { return }
         let maxTags = 3
         
-        sender.isSelected ? self.addScheduleFirstView.inAddScheduleFirstView.updateTag(button: sender, buttonType: UnselectedButton()) :
-        self.addScheduleFirstView.inAddScheduleFirstView.updateTag(button: sender, buttonType: SelectedButton())
-        
         if sender.isSelected { //해당 버튼이 이미 눌린 상태라면
             sender.isSelected.toggle()
-//            self.addScheduleFirstView.inAddScheduleFirstView.updateTag(button: sender, buttonType: UnselectedButton())
+            self.addScheduleFirstView.inAddScheduleFirstView.updateTag(button: sender, buttonType: UnselectedButton())
             self.viewModel.countSelectedTag(isSelected: false, tag: tag)
         } else { //해당 버튼이 안 눌린 상태라면
             // 새로 선택하는 태그가 최대 개수 이내일 때만 처리
             if self.viewModel.selectedTagData.count < maxTags {
                 sender.isSelected.toggle()
-//                self.addScheduleFirstView.inAddScheduleFirstView.updateTag(button: sender, buttonType: SelectedButton())
+                self.addScheduleFirstView.inAddScheduleFirstView.updateTag(button: sender, buttonType: SelectedButton())
                 self.viewModel.countSelectedTag(isSelected: true, tag: tag)
             }
         }
@@ -352,11 +344,10 @@ extension AddScheduleFirstViewController: UICollectionViewDelegateFlowLayout {
     
 }
 
-extension AddScheduleFirstViewController: UICollectionViewDelegate {
-    
-}
 
-extension AddScheduleFirstViewController: UICollectionViewDataSource {
+//MARK: - Tag CollectionView 세팅
+
+extension AddScheduleFirstViewController: UICollectionViewDelegate, UICollectionViewDataSource {
     
     func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
         return viewModel.tagData.count

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/AddSchedule/Views/AddScheduleFirst/AddScheduleFirstViewController.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/AddSchedule/Views/AddScheduleFirst/AddScheduleFirstViewController.swift
@@ -153,8 +153,8 @@ private extension AddScheduleFirstViewController {
             isValidNextBtn()
         }
         
-        viewModel.outputDateStartAtVaild.bind { [weak self] value in
-            guard let self, let value,
+        viewModel.outputDateStartAtVaild.bind { [weak self] _ in
+            guard let self,
                   let data = self.viewModel.inputDateStartAt.value
             else {return}
             self.addScheduleFirstView.inAddScheduleFirstView.updatedateStartTime(text: data)

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/AddSchedule/Views/AddScheduleSecond/AddScheduleSecondView.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/AddSchedule/Views/AddScheduleSecond/AddScheduleSecondView.swift
@@ -51,19 +51,20 @@ final class AddScheduleSecondView: BaseView {
     
     override func setLayout() {
         inAddScheduleSecondView.snp.makeConstraints {
-            $0.top.horizontalEdges.equalToSuperview()
+            $0.top.equalToSuperview()
+            $0.horizontalEdges.equalToSuperview().inset(16)
             $0.height.equalTo(153)
         }
         
         editButton.snp.makeConstraints {
             $0.top.equalTo(inAddScheduleSecondView.separatorLine.snp.bottom).offset(10)
-            $0.trailing.equalToSuperview()
+            $0.trailing.equalToSuperview().inset(16)
             $0.width.equalTo(59)
             $0.height.equalTo(30)
         }
         
         guideLabel.snp.makeConstraints {
-            $0.leading.equalToSuperview()
+            $0.leading.equalToSuperview().inset(16)
             $0.centerY.equalTo(editButton)
         }
         
@@ -75,7 +76,7 @@ final class AddScheduleSecondView: BaseView {
         
         nextBtn.snp.makeConstraints {
             $0.bottom.equalTo(self.safeAreaLayoutGuide).inset(6)
-            $0.horizontalEdges.equalToSuperview()
+            $0.horizontalEdges.equalToSuperview().inset(16)
             $0.height.equalTo(54)
         }
     }

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/AddSchedule/Views/AddScheduleSecond/AddScheduleSecondViewController.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/AddSchedule/Views/AddScheduleSecond/AddScheduleSecondViewController.swift
@@ -85,7 +85,7 @@ final class AddScheduleSecondViewController: BaseNavBarViewController {
 }
 
 
-// MARK: - ViewController Methods
+// MARK: - AddScheduleSecondVC Methods
 
 private extension AddScheduleSecondViewController {
     
@@ -106,23 +106,7 @@ private extension AddScheduleSecondViewController {
         }
     }
     
-    func pastDateBindViewModel() {
-        if viewModel.isBroughtData  {
-            for i in viewModel.pastDatePlaces {
-                if let doubleValue = Double(String(i.duration)) {
-                    let text = doubleValue.truncatingRemainder(dividingBy: 1) == 0 ?
-                    String(Int(doubleValue)) : String(doubleValue)
-                    viewModel.tapAddBtn(datePlace: i.title, timeRequire: "\(text) 시간")
-                } else {
-                    viewModel.tapAddBtn(datePlace: i.title, timeRequire: "\(String(i.duration)) 시간")
-                }
-            }
-            viewModel.pastDatePlaces.removeAll()
-            AmplitudeManager.shared.trackEvent(StringLiterals.Amplitude.EventName.viewAddBringcourse2)
-        } else {
-            AmplitudeManager.shared.trackEvent(StringLiterals.Amplitude.EventName.viewAddSchedule2)
-        }
-    }
+    
     
     func bindViewModel() {
         self.viewModel.isSuccessPostData.bind { [weak self] isSuccess in
@@ -179,7 +163,7 @@ private extension AddScheduleSecondViewController {
         viewModel.datePlace.bind { [weak self] date in
             guard let text = date else {return}
             self?.addScheduleSecondView.inAddScheduleSecondView.updateDatePlace(text: text)
-            self?.viewModel.dateDetailLocation = true
+            self?.viewModel.addScheduleAmplitude.dateDetailLocation = !(self?.viewModel.datePlace.value?.isEmpty ?? true)
             if let flag = self?.viewModel.isAbleAddBtn() {
                 self?.addScheduleSecondView.inAddScheduleSecondView.changeAddPlaceButtonState(flag: flag)
             }
@@ -188,7 +172,7 @@ private extension AddScheduleSecondViewController {
         viewModel.timeRequire.bind { [weak self] date in
             guard let date else {return}
             self?.addScheduleSecondView.inAddScheduleSecondView.updatetimeRequire(text: date)
-            self?.viewModel.dateDetailTime = true
+            self?.viewModel.addScheduleAmplitude.dateDetailTime = true
             if let flag = self?.viewModel.isAbleAddBtn() {
                 self?.addScheduleSecondView.inAddScheduleSecondView.changeAddPlaceButtonState(flag: flag)
             }
@@ -224,6 +208,50 @@ private extension AddScheduleSecondViewController {
         addScheduleSecondView.nextBtn.addTarget(self, action: #selector(didTapNextBtn), for: .touchUpInside)
     }
     
+    /// '등록 완료' 이후 tabBarVC를 통해 화면 전환
+    func goBackOriginVCForAddSchedule() {
+        let tabbarVC = TabBarController()
+        tabbarVC.selectedIndex = 2
+        navigationController?.popToPreviousViewController(ofType: AddScheduleFirstViewController.self, defaultViewController: tabbarVC)
+    }
+    
+}
+
+
+//MARK: - AddScheduleFirstViewController: BaseNavBarViewController
+
+extension AddScheduleSecondViewController {
+    
+    private func pastDateBindViewModel() {
+        if viewModel.isBroughtData  {
+            for i in viewModel.pastDatePlaces {
+                if let doubleValue = Double(String(i.duration)) {
+                    let text = doubleValue.truncatingRemainder(dividingBy: 1) == 0 ?
+                    String(Int(doubleValue)) : String(doubleValue)
+                    viewModel.tapAddBtn(datePlace: i.title, timeRequire: "\(text) 시간")
+                } else {
+                    viewModel.tapAddBtn(datePlace: i.title, timeRequire: "\(String(i.duration)) 시간")
+                }
+            }
+            viewModel.pastDatePlaces.removeAll()
+            AmplitudeManager.shared.trackEvent(StringLiterals.Amplitude.EventName.viewAddBringcourse2)
+        } else {
+            AmplitudeManager.shared.trackEvent(StringLiterals.Amplitude.EventName.viewAddSchedule2)
+        }
+    }
+    
+    @objc
+    override func backButtonTapped() {
+        viewModel.addScheduleAmplitude.sendAmplitudeEvent(for: 2)
+        super.backButtonTapped()
+    }
+    
+}
+
+
+//MARK: - AddScheduleSecondViewController: '일정등록 뷰2 프로퍼티' 관련 함수
+
+private extension AddScheduleSecondViewController {
     // 등록 완료 alertVC도 blurView 페이드인 적용 미정
     func successDone() {
         let customAlertVC = DRCustomAlertViewController(rightActionType: .none,
@@ -236,15 +264,17 @@ private extension AddScheduleSecondViewController {
         self.present(customAlertVC, animated: false)
     }
     
-    func goBackOriginVCForAddSchedule() {
-        let tabbarVC = TabBarController()
-        tabbarVC.selectedIndex = 2
-        navigationController?.popToPreviousViewController(ofType: AddScheduleFirstViewController.self, defaultViewController: tabbarVC)
-    }
-    
     
     // MARK: - @objc Methods
     
+    /// '완료' 버튼 관련
+    @objc
+    func didTapNextBtn() {
+        addScheduleSecondView.nextBtn.isUserInteractionEnabled = false
+        viewModel.postAddScheduel()
+    }
+    
+    /// '소요시간' 관련
     @objc
     func textFieldTapped(_ textField: UITextField) {
         let alertVC = AddScheduleBottomSheetViewController(viewModel: viewModel)
@@ -258,44 +288,15 @@ private extension AddScheduleSecondViewController {
         }
     }
     
+    /// '장소 등록 +' 버튼 관련
     @objc
     func tapAddPlaceBtn() {
         viewModel.tapAddBtn(datePlace: viewModel.datePlace.value ?? "", timeRequire: viewModel.timeRequire.value ?? "")
     }
     
-    @objc
-    func didTapNextBtn() {
-        addScheduleSecondView.nextBtn.isUserInteractionEnabled = false
-        viewModel.postAddScheduel()
-    }
-    
-    @objc
-    func removeCell(sender: UIButton) {
-        guard let cell = sender.superview?.superview as? AddSecondViewCollectionViewCell,
-              let indexPath = addScheduleSecondView.addPlaceCollectionView.indexPath(for: cell) else { return }
-        
-        viewModel.addPlaceCollectionViewDataSource.remove(at: indexPath.item)
-        addScheduleSecondView.addPlaceCollectionView.deleteItems(at: [indexPath])
-        viewModel.isSourceMoreThanOne()
-        
-        //여기서 datasource가 1개 미만이면
-        let dataSourceCnt = viewModel.addPlaceCollectionViewDataSource.count
-        if dataSourceCnt < 1 {
-            cell.updateEditMode(flag: false)
-            addScheduleSecondView.updateEditBtnText(flag: false)
-            addScheduleSecondView.editBtnState(isAble: false)
-            viewModel.isEditMode = false
-        }
-    }
-    
-    @objc
-    func moveCell(sender: UIButton) {
-        // Move cell logic here
-    }
-    
+    /// '편집' 버튼 관련
     @objc
     func toggleEditMode() {
-        print("EditButton 눌림")
         viewModel.isEditMode.toggle()
         let collectionView = addScheduleSecondView.addPlaceCollectionView
         
@@ -320,14 +321,29 @@ private extension AddScheduleSecondViewController {
         }
     }
     
-}
-
-extension AddScheduleSecondViewController {
-    
+    /// 장소 리스트 'X' 버튼 관련: list에 있는 장소 삭제
     @objc
-    override func backButtonTapped() {
-        viewModel.schedule2BackAmplitude()
-        super.backButtonTapped()
+    func removeCell(sender: UIButton) {
+        guard let cell = sender.superview?.superview as? AddSecondViewCollectionViewCell,
+              let indexPath = addScheduleSecondView.addPlaceCollectionView.indexPath(for: cell) else { return }
+        
+        viewModel.addPlaceCollectionViewDataSource.remove(at: indexPath.item)
+        addScheduleSecondView.addPlaceCollectionView.deleteItems(at: [indexPath])
+        viewModel.isSourceMoreThanOne()
+        
+        //여기서 datasource가 1개 미만이면
+        let dataSourceCnt = viewModel.addPlaceCollectionViewDataSource.count
+        if dataSourceCnt < 1 {
+            cell.updateEditMode(flag: false)
+            addScheduleSecondView.updateEditBtnText(flag: false)
+            addScheduleSecondView.editBtnState(isAble: false)
+            viewModel.isEditMode = false
+        }
+    }
+    
+    /// '=' 버튼 관련
+    @objc
+    func moveCell(sender: UIButton) {
     }
     
 }

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/AddSchedule/Views/AddScheduleSecond/AddScheduleSecondViewController.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/AddSchedule/Views/AddScheduleSecond/AddScheduleSecondViewController.swift
@@ -50,7 +50,7 @@ final class AddScheduleSecondViewController: BaseNavBarViewController {
         setDelegate()
         registerCell()
         bindViewModel()
-        pastDateBindViewModel()
+        broughtDataHandling()
         setupKeyboardDismissRecognizer()
     }
     
@@ -106,10 +106,8 @@ private extension AddScheduleSecondViewController {
         }
     }
     
-    
-    
     func bindViewModel() {
-        self.viewModel.isSuccessPostData.bind { [weak self] isSuccess in
+        self.viewModel.outputIsSuccessPostData.bind { [weak self] isSuccess in
             guard let isSuccess else { return }
             if isSuccess {
                 self?.successDone()
@@ -147,7 +145,8 @@ private extension AddScheduleSecondViewController {
         self.viewModel.onReissueSuccess.bind { [weak self] onSuccess in
             guard let onSuccess else { return }
             if onSuccess {
-                self?.viewModel.postAddScheduel()
+                self?.viewModel.inputPreparePostSchedule.value = true
+//                self?.viewModel.postAddScheduel()
             } else {
                 self?.navigationController?.pushViewController(SplashViewController(splashViewModel: SplashViewModel()), animated: false)
             }
@@ -170,28 +169,17 @@ private extension AddScheduleSecondViewController {
             self?.checkAddPlaceBtnState()
         }
         
-        self.viewModel.isChange = { [weak self] in
-            guard let cnt = self?.viewModel.addPlaceCollectionViewDataSource.count else {return}
-            print(cnt)
-            
-            self?.viewModel.inputCheckEditBtnState.value = true
-//            self?.viewModel.isDataSourceNotEmpty()
-            
-            
-            
-//            let state = self?.viewModel.editBtnEnableState.value ?? false
-            
-//            self?.addScheduleSecondView.editBtnState(isAble: state)
-            
-            self?.addScheduleSecondView.inAddScheduleSecondView.finishAddPlace()
-            
-            self?.viewModel.isSourceMoreThanOne()
-            
-            self?.addScheduleSecondView.addPlaceCollectionView.reloadData()
+        viewModel.outputSuccessedAddPlcae.lazyBind { [weak self] _ in
+            guard let self else {return}
+            self.viewModel.inputCheckEditBtnState.value = true
+            self.addScheduleSecondView.inAddScheduleSecondView.finishAddPlace()
+            self.viewModel.inputValidateRegisterBtn.value = true
+//            self.viewModel.isSourceMoreThanOne()
+//            self.addScheduleSecondView.addPlaceCollectionView.reloadData()
         }
         
-        self.viewModel.isValidOfSecondNextBtn.bind { [weak self] date in
-            self?.addScheduleSecondView.changeNextBtnState(flag: date ?? false)
+        self.viewModel.outputIstValidateRegisterBtn.bind { [weak self] isValid in
+            self?.addScheduleSecondView.changeNextBtnState(flag: isValid ?? false)
         }
     }
     
@@ -222,22 +210,8 @@ private extension AddScheduleSecondViewController {
 
 extension AddScheduleSecondViewController {
     
-    private func pastDateBindViewModel() {
-        if viewModel.isBroughtData  {
-            for i in viewModel.pastDatePlaces {
-                if let doubleValue = Double(String(i.duration)) {
-                    let text = doubleValue.truncatingRemainder(dividingBy: 1) == 0 ?
-                    String(Int(doubleValue)) : String(doubleValue)
-                    viewModel.tapAddBtn(datePlace: i.title, timeRequire: "\(text) 시간")
-                } else {
-                    viewModel.tapAddBtn(datePlace: i.title, timeRequire: "\(String(i.duration)) 시간")
-                }
-            }
-            viewModel.pastDatePlaces.removeAll()
-            AmplitudeManager.shared.trackEvent(StringLiterals.Amplitude.EventName.viewAddBringcourse2)
-        } else {
-            AmplitudeManager.shared.trackEvent(StringLiterals.Amplitude.EventName.viewAddSchedule2)
-        }
+    private func broughtDataHandling() {
+        viewModel.inputPrepareBroughtData.value = true
     }
     
     @objc
@@ -271,7 +245,8 @@ private extension AddScheduleSecondViewController {
     @objc
     func didTapNextBtn() {
         addScheduleSecondView.nextBtn.isUserInteractionEnabled = false
-        viewModel.postAddScheduel()
+        viewModel.inputPreparePostSchedule.value = true
+//        viewModel.postAddScheduel()
     }
     
     /// '소요시간' 관련
@@ -291,7 +266,7 @@ private extension AddScheduleSecondViewController {
     /// '장소 등록 +' 버튼 관련
     @objc
     func tapAddPlaceBtn() {
-        viewModel.tapAddBtn(datePlace: viewModel.outputDatePlace.value ?? "", timeRequire: viewModel.outputTimeRequire.value ?? "")
+        viewModel.inputValidateAddPlcae.value = true
     }
     
     /// '편집' 버튼 관련
@@ -321,18 +296,20 @@ private extension AddScheduleSecondViewController {
         }
     }
     
+    ////얘도 뷰모델로
     /// 장소 리스트 'X' 버튼 관련: list에 있는 장소 삭제
     @objc
     func removeCell(sender: UIButton) {
         guard let cell = sender.superview?.superview as? AddSecondViewCollectionViewCell,
               let indexPath = addScheduleSecondView.addPlaceCollectionView.indexPath(for: cell) else { return }
         
-        viewModel.addPlaceCollectionViewDataSource.remove(at: indexPath.item)
+        viewModel.dataSourceOfAddPlaceCollectionView.value?.remove(at: indexPath.item)
         addScheduleSecondView.addPlaceCollectionView.deleteItems(at: [indexPath])
-        viewModel.isSourceMoreThanOne()
+        viewModel.inputValidateRegisterBtn.value = true
+//        viewModel.isSourceMoreThanOne()
         
         //여기서 datasource가 1개 미만이면
-        let dataSourceCnt = viewModel.addPlaceCollectionViewDataSource.count
+        let dataSourceCnt = viewModel.dataSourceOfAddPlaceCollectionView.value?.count ?? 1
         if dataSourceCnt < 1 {
             cell.updateEditMode(flag: false)
             addScheduleSecondView.updateEditBtnText(flag: false)
@@ -371,13 +348,6 @@ extension AddScheduleSecondViewController: UITextFieldDelegate {
         let trimmedText = textField.text?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
         
         viewModel.inputDatePlace.value = trimmedText
-//        if let text = trimmedText, !text.isEmpty {
-//            viewModel.datePlace.value = text
-//            print(text)
-//        } else {
-//            viewModel.datePlace.value = ""
-//            print("공란")
-//        }
     }
     
 }
@@ -402,17 +372,20 @@ extension AddScheduleSecondViewController: UICollectionViewDelegate {
 extension AddScheduleSecondViewController: UICollectionViewDataSource {
     
     func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
-        return viewModel.addPlaceCollectionViewDataSource.count
+        return viewModel.dataSourceOfAddPlaceCollectionView.value?.count ?? 0
     }
     
     func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
         if collectionView == addScheduleSecondView.addPlaceCollectionView {
-            guard let cell = collectionView.dequeueReusableCell(
+            guard
+                let cell = collectionView.dequeueReusableCell(
                 withReuseIdentifier: AddSecondViewCollectionViewCell.cellIdentifier,
-                for: indexPath
-            ) as? AddSecondViewCollectionViewCell else { return UICollectionViewCell() }
+                for: indexPath)
+                    as? AddSecondViewCollectionViewCell,
+                let model = viewModel.dataSourceOfAddPlaceCollectionView.value
+            else { return UICollectionViewCell() }
             
-            cell.configure(model: viewModel.addPlaceCollectionViewDataSource[indexPath.item])
+            cell.configure(model: model[indexPath.item])
             cell.updateEditMode(flag: viewModel.isEditMode)
             cell.moveAbleButton.removeTarget(nil, action: nil, for: .allEvents)
             if viewModel.isEditMode {
@@ -434,7 +407,9 @@ extension AddScheduleSecondViewController: UICollectionViewDataSource {
 
 extension AddScheduleSecondViewController: UICollectionViewDropDelegate {
     
+    //들고있던 cell을 이동시켜 cell의 index가 바뀌었을 때 동작
     func collectionView(_ collectionView: UICollectionView, performDropWith coordinator: UICollectionViewDropCoordinator) {
+        print(#function, "케케몬몬몬")
         if collectionView == addScheduleSecondView.addPlaceCollectionView {
             var destinationIndexPath: IndexPath
             if let indexPath = coordinator.destinationIndexPath {
@@ -462,18 +437,23 @@ extension AddScheduleSecondViewController: UICollectionViewDropDelegate {
     private func reorderItems(coordinator: UICollectionViewDropCoordinator, destinationIndexPath: IndexPath, collectionView: UICollectionView) {
         if collectionView == addScheduleSecondView.addPlaceCollectionView {
             if let item = coordinator.items.first, let sourceIndexPath = item.sourceIndexPath {
+                guard let body = viewModel.dataSourceOfAddPlaceCollectionView.value else {return}
                 collectionView.performBatchUpdates({
-                    let temp = viewModel.addPlaceCollectionViewDataSource[sourceIndexPath.item]
-                    viewModel.addPlaceCollectionViewDataSource.remove(at: sourceIndexPath.item)
-                    viewModel.addPlaceCollectionViewDataSource.insert(temp, at: destinationIndexPath.item)
+                    
+                    let temp = body[sourceIndexPath.item]
+                    
+                    viewModel.dataSourceOfAddPlaceCollectionView.value?.remove(at: sourceIndexPath.item)
+                    viewModel.dataSourceOfAddPlaceCollectionView.value?.insert(temp, at: destinationIndexPath.item)
+                    
                     collectionView.deleteItems(at: [sourceIndexPath])
                     collectionView.insertItems(at: [destinationIndexPath])
-                }) { done in
+                    
+                })
+                { done in
                     //
                 }
                 coordinator.drop(item.dragItem, toItemAt: destinationIndexPath)
             }
-//            viewModel.updatePlaceCollectionView()
         }
     }
     
@@ -484,7 +464,9 @@ extension AddScheduleSecondViewController: UICollectionViewDropDelegate {
 
 extension AddScheduleSecondViewController: UICollectionViewDragDelegate {
     
+    //롱핸들프래스로 cell이 들렸을 때 동작
     func collectionView(_ collectionView: UICollectionView, itemsForBeginning session: UIDragSession, at indexPath: IndexPath) -> [UIDragItem] {
+        print(#function)
         return []
     }
     

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/AddSchedule/Views/AddScheduleSecond/AddScheduleSecondViewController.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/AddSchedule/Views/AddScheduleSecond/AddScheduleSecondViewController.swift
@@ -146,7 +146,6 @@ private extension AddScheduleSecondViewController {
             guard let onSuccess else { return }
             if onSuccess {
                 self?.viewModel.inputPreparePostSchedule.value = true
-//                self?.viewModel.postAddScheduel()
             } else {
                 self?.navigationController?.pushViewController(SplashViewController(splashViewModel: SplashViewModel()), animated: false)
             }
@@ -175,8 +174,6 @@ private extension AddScheduleSecondViewController {
             self.addScheduleSecondView.inAddScheduleSecondView.finishAddPlace()
             self.viewModel.inputValidateRegisterBtn.value = true
             self.addScheduleSecondView.addPlaceCollectionView.reloadData()
-//            self.viewModel.isSourceMoreThanOne()
-//            self.addScheduleSecondView.addPlaceCollectionView.reloadData()
         }
         
         self.viewModel.outputIstValidateRegisterBtn.bind { [weak self] isValid in
@@ -247,7 +244,6 @@ private extension AddScheduleSecondViewController {
     func didTapNextBtn() {
         addScheduleSecondView.nextBtn.isUserInteractionEnabled = false
         viewModel.inputPreparePostSchedule.value = true
-//        viewModel.postAddScheduel()
     }
     
     /// '소요시간' 관련
@@ -297,7 +293,6 @@ private extension AddScheduleSecondViewController {
         }
     }
     
-    ////얘도 뷰모델로
     /// 장소 리스트 'X' 버튼 관련: list에 있는 장소 삭제
     @objc
     func removeCell(sender: UIButton) {
@@ -307,7 +302,6 @@ private extension AddScheduleSecondViewController {
         viewModel.dataSourceOfAddPlaceCollectionView.value?.remove(at: indexPath.item)
         addScheduleSecondView.addPlaceCollectionView.deleteItems(at: [indexPath])
         viewModel.inputValidateRegisterBtn.value = true
-//        viewModel.isSourceMoreThanOne()
         
         //여기서 datasource가 1개 미만이면
         let dataSourceCnt = viewModel.dataSourceOfAddPlaceCollectionView.value?.count ?? 1

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/AddSchedule/Views/AddScheduleSecond/AddScheduleSecondViewController.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/AddSchedule/Views/AddScheduleSecond/AddScheduleSecondViewController.swift
@@ -158,10 +158,9 @@ private extension AddScheduleSecondViewController {
             self?.addScheduleSecondView.editBtnState(isAble: enableState)
         }
         
-        viewModel.datePlace.bind { [weak self] date in
-            guard let text = date else {return}
-            self?.addScheduleSecondView.inAddScheduleSecondView.updateDatePlace(text: text)
-            self?.viewModel.addScheduleAmplitude.dateDetailLocation = !(self?.viewModel.datePlace.value?.isEmpty ?? true)
+        viewModel.outputDatePlace.lazyBind { [weak self] value in
+            guard let value else {return}
+            self?.addScheduleSecondView.inAddScheduleSecondView.updateDatePlace(text: value)
             self?.checkAddPlaceBtnState()
         }
         
@@ -292,7 +291,7 @@ private extension AddScheduleSecondViewController {
     /// '장소 등록 +' 버튼 관련
     @objc
     func tapAddPlaceBtn() {
-        viewModel.tapAddBtn(datePlace: viewModel.datePlace.value ?? "", timeRequire: viewModel.outputTimeRequire.value ?? "")
+        viewModel.tapAddBtn(datePlace: viewModel.outputDatePlace.value ?? "", timeRequire: viewModel.outputTimeRequire.value ?? "")
     }
     
     /// '편집' 버튼 관련
@@ -369,15 +368,16 @@ extension AddScheduleSecondViewController: UITextFieldDelegate {
     }
     
     func textFieldDidEndEditing(_ textField: UITextField) {
-        let trimmedText = textField.text?.trimmingCharacters(in: .whitespacesAndNewlines)
+        let trimmedText = textField.text?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
         
-        if let text = trimmedText, !text.isEmpty {
-            viewModel.datePlace.value = text
-            print(text)
-        } else {
-            viewModel.datePlace.value = ""
-            print("공란")
-        }
+        viewModel.inputDatePlace.value = trimmedText
+//        if let text = trimmedText, !text.isEmpty {
+//            viewModel.datePlace.value = text
+//            print(text)
+//        } else {
+//            viewModel.datePlace.value = ""
+//            print("공란")
+//        }
     }
     
 }

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/AddSchedule/Views/AddScheduleSecond/AddScheduleSecondViewController.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/AddSchedule/Views/AddScheduleSecond/AddScheduleSecondViewController.swift
@@ -68,7 +68,7 @@ final class AddScheduleSecondViewController: BaseNavBarViewController {
         
         addScheduleSecondView.snp.makeConstraints {
             $0.top.equalToSuperview().offset(4)
-            $0.horizontalEdges.equalToSuperview().inset(16)
+            $0.horizontalEdges.equalToSuperview()
             $0.bottom.equalTo(view.safeAreaLayoutGuide).inset(4)
         }
     }
@@ -401,6 +401,17 @@ extension AddScheduleSecondViewController: UICollectionViewDataSource {
 // MARK: - UICollectionViewDropDelegate Methods
 
 extension AddScheduleSecondViewController: UICollectionViewDropDelegate {
+    
+    //드래그 cell Preview
+    func collectionView(_ collectionView: UICollectionView,
+                        dragPreviewParametersForItemAt indexPath: IndexPath) -> UIDragPreviewParameters? {
+        print(#function)
+        
+        let parameters = UIDragPreviewParameters()
+        parameters.visiblePath = UIBezierPath(roundedRect: collectionView.cellForItem(at: indexPath)?.bounds ?? .zero,
+                                              cornerRadius: 14) // 원하는 cornerRadius 적용
+        return parameters
+    }
     
     //들고있던 cell을 이동시켜 cell의 index가 바뀌었을 때 동작
     func collectionView(_ collectionView: UICollectionView, performDropWith coordinator: UICollectionViewDropCoordinator) {

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/AddSchedule/Views/AddScheduleSecond/AddScheduleSecondViewController.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/AddSchedule/Views/AddScheduleSecond/AddScheduleSecondViewController.swift
@@ -242,7 +242,7 @@ extension AddScheduleSecondViewController {
     
     @objc
     override func backButtonTapped() {
-        viewModel.addScheduleAmplitude.sendAmplitudeEvent(for: 2)
+        viewModel.addScheduleAmplitude.sendAmplitudeEvent(step: 2)
         super.backButtonTapped()
     }
     

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/AddSchedule/Views/AddScheduleSecond/AddScheduleSecondViewController.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/AddSchedule/Views/AddScheduleSecond/AddScheduleSecondViewController.swift
@@ -174,6 +174,7 @@ private extension AddScheduleSecondViewController {
             self.viewModel.inputCheckEditBtnState.value = true
             self.addScheduleSecondView.inAddScheduleSecondView.finishAddPlace()
             self.viewModel.inputValidateRegisterBtn.value = true
+            self.addScheduleSecondView.addPlaceCollectionView.reloadData()
 //            self.viewModel.isSourceMoreThanOne()
 //            self.addScheduleSecondView.addPlaceCollectionView.reloadData()
         }
@@ -437,25 +438,21 @@ extension AddScheduleSecondViewController: UICollectionViewDropDelegate {
     private func reorderItems(coordinator: UICollectionViewDropCoordinator, destinationIndexPath: IndexPath, collectionView: UICollectionView) {
         if collectionView == addScheduleSecondView.addPlaceCollectionView {
             if let item = coordinator.items.first, let sourceIndexPath = item.sourceIndexPath {
-                guard let body = viewModel.dataSourceOfAddPlaceCollectionView.value else {return}
-                collectionView.performBatchUpdates({
-                    
-                    let temp = body[sourceIndexPath.item]
-                    
-                    viewModel.dataSourceOfAddPlaceCollectionView.value?.remove(at: sourceIndexPath.item)
-                    viewModel.dataSourceOfAddPlaceCollectionView.value?.insert(temp, at: destinationIndexPath.item)
-                    
-                    collectionView.deleteItems(at: [sourceIndexPath])
-                    collectionView.insertItems(at: [destinationIndexPath])
-                    
-                })
-                { done in
-                    //
+                guard var body = viewModel.dataSourceOfAddPlaceCollectionView.value else { return }
+                
+                let movedItem = body.remove(at: sourceIndexPath.item)
+                body.insert(movedItem, at: destinationIndexPath.item)
+                viewModel.dataSourceOfAddPlaceCollectionView.value = body
+                
+                collectionView.performBatchUpdates {
+                    collectionView.moveItem(at: sourceIndexPath, to: destinationIndexPath)
                 }
+                
                 coordinator.drop(item.dragItem, toItemAt: destinationIndexPath)
             }
         }
     }
+
     
 }
 

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/AddSchedule/Views/AddScheduleSecond/AddScheduleSecondViewController.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/AddSchedule/Views/AddScheduleSecond/AddScheduleSecondViewController.swift
@@ -164,18 +164,13 @@ private extension AddScheduleSecondViewController {
             guard let text = date else {return}
             self?.addScheduleSecondView.inAddScheduleSecondView.updateDatePlace(text: text)
             self?.viewModel.addScheduleAmplitude.dateDetailLocation = !(self?.viewModel.datePlace.value?.isEmpty ?? true)
-            if let flag = self?.viewModel.isAbleAddBtn() {
-                self?.addScheduleSecondView.inAddScheduleSecondView.changeAddPlaceButtonState(flag: flag)
-            }
+            self?.checkAddPlaceBtnState()
         }
         
-        viewModel.timeRequire.bind { [weak self] date in
-            guard let date else {return}
-            self?.addScheduleSecondView.inAddScheduleSecondView.updatetimeRequire(text: date)
-            self?.viewModel.addScheduleAmplitude.dateDetailTime = true
-            if let flag = self?.viewModel.isAbleAddBtn() {
-                self?.addScheduleSecondView.inAddScheduleSecondView.changeAddPlaceButtonState(flag: flag)
-            }
+        viewModel.outputTimeRequire.lazyBind { [weak self] value in
+            guard let value else {return}
+            self?.addScheduleSecondView.inAddScheduleSecondView.updatetimeRequire(text: value)
+            self?.checkAddPlaceBtnState()
         }
         
         self.viewModel.isChange = { [weak self] in
@@ -206,6 +201,11 @@ private extension AddScheduleSecondViewController {
         addScheduleSecondView.inAddScheduleSecondView.addPlaceButton.addTarget(self, action: #selector(tapAddPlaceBtn), for: .touchUpInside)
         
         addScheduleSecondView.nextBtn.addTarget(self, action: #selector(didTapNextBtn), for: .touchUpInside)
+    }
+    
+    func checkAddPlaceBtnState() {
+        let flag = self.viewModel.isAbleAddBtn()
+        self.addScheduleSecondView.inAddScheduleSecondView.changeAddPlaceButtonState(flag: flag)
     }
     
     /// '등록 완료' 이후 tabBarVC를 통해 화면 전환
@@ -291,7 +291,7 @@ private extension AddScheduleSecondViewController {
     /// '장소 등록 +' 버튼 관련
     @objc
     func tapAddPlaceBtn() {
-        viewModel.tapAddBtn(datePlace: viewModel.datePlace.value ?? "", timeRequire: viewModel.timeRequire.value ?? "")
+        viewModel.tapAddBtn(datePlace: viewModel.datePlace.value ?? "", timeRequire: viewModel.outputTimeRequire.value ?? "")
     }
     
     /// '편집' 버튼 관련
@@ -472,7 +472,7 @@ extension AddScheduleSecondViewController: UICollectionViewDropDelegate {
                 }
                 coordinator.drop(item.dragItem, toItemAt: destinationIndexPath)
             }
-            viewModel.updatePlaceCollectionView()
+//            viewModel.updatePlaceCollectionView()
         }
     }
     

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/AddSchedule/Views/AddScheduleSecond/AddScheduleSecondViewController.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/AddSchedule/Views/AddScheduleSecond/AddScheduleSecondViewController.swift
@@ -153,11 +153,9 @@ private extension AddScheduleSecondViewController {
             }
         }
         
-        viewModel.isDataSourceNotEmpty()
-        
-        viewModel.editBtnEnableState.bind { [weak self] date in
-            guard let date else {return}
-            self?.addScheduleSecondView.editBtnState(isAble: date)
+        viewModel.outputEditBtnEnableState.bind { [weak self] enableState in
+            guard let enableState else {return}
+            self?.addScheduleSecondView.editBtnState(isAble: enableState)
         }
         
         viewModel.datePlace.bind { [weak self] date in
@@ -177,11 +175,14 @@ private extension AddScheduleSecondViewController {
             guard let cnt = self?.viewModel.addPlaceCollectionViewDataSource.count else {return}
             print(cnt)
             
-            self?.viewModel.isDataSourceNotEmpty()
+            self?.viewModel.inputCheckEditBtnState.value = true
+//            self?.viewModel.isDataSourceNotEmpty()
             
-            let state = self?.viewModel.editBtnEnableState.value ?? false
             
-            self?.addScheduleSecondView.editBtnState(isAble: state)
+            
+//            let state = self?.viewModel.editBtnEnableState.value ?? false
+            
+//            self?.addScheduleSecondView.editBtnState(isAble: state)
             
             self?.addScheduleSecondView.inAddScheduleSecondView.finishAddPlace()
             

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/Commons/LocationFilter/Models/LocationModel.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/Commons/LocationFilter/Models/LocationModel.swift
@@ -101,7 +101,7 @@ enum LocationModel {
             
             case namyangjuUijeongbu = "남양주/의정부"
             
-            case gwangjuIcheonYeoju = "과천/이천/여주"
+            case gwangjuIcheonYeoju = "광주/이천/여주"
             
             case gapyeongYangpyeong = "가평/양평"
             
@@ -239,7 +239,7 @@ struct LocationModelCityKorToEng {
                 self = .POCHEON_YANGJU
             case "남양주/의정부":
                 self = .NAMYANGJU_UIJEONGBU
-            case "과천/이천/여주":
+            case "광주/이천/여주":
                 self = .GWANGJU_ICHEON_YEOJU
             case "가평/양평":
                 self = .GAPYEONG_YANGPYEONG
@@ -420,7 +420,7 @@ struct LocationModelCityEngToKor {
             case .NAMYANGJU_UIJEONGBU:
                 return "남양주/의정부"
             case .GWANGJU_ICHEON_YEOJU:
-                return "과천/이천/여주"
+                return "광주/이천/여주"
             case .GAPYEONG_YANGPYEONG:
                 return "가평/양평"
             case .GUNPO_UIWANG:

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/CourseDetail/Views/CourseDetailViewController.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/CourseDetail/Views/CourseDetailViewController.swift
@@ -434,14 +434,11 @@ private extension CourseDetailViewController {
     func didTapMySchedule() {
         let courseId = courseDetailViewModel.courseId
         let courseDetailViewModel = CourseDetailViewModel(courseId: courseId)
-        let addScheduleViewModel = AddScheduleViewModel(viewPath: StringLiterals.Amplitude.ViewPath.courseDetail)
         
+        let addScheduleViewModel = AddScheduleViewModel(viewPath: StringLiterals.Amplitude.ViewPath.viewedCourse, isBroughtData: true)
         addScheduleViewModel.viewedDateCourseByMeData = courseDetailViewModel
-        addScheduleViewModel.isBroughtData = true
         
         let vc = AddScheduleFirstViewController(viewModel: addScheduleViewModel)
-        // 데이터를 바인딩합니다.
-        vc.pastDateBindViewModel()
         self.navigationController?.pushViewController(vc, animated: false)
     }
     

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/CourseDetail/Views/CourseDetailViewController.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/CourseDetail/Views/CourseDetailViewController.swift
@@ -434,12 +434,12 @@ private extension CourseDetailViewController {
     func didTapMySchedule() {
         let courseId = courseDetailViewModel.courseId
         let courseDetailViewModel = CourseDetailViewModel(courseId: courseId)
-        let addScheduleViewModel = AddScheduleViewModel()
+        let addScheduleViewModel = AddScheduleViewModel(viewPath: StringLiterals.Amplitude.ViewPath.courseDetail)
         
         addScheduleViewModel.viewedDateCourseByMeData = courseDetailViewModel
         addScheduleViewModel.isBroughtData = true
         
-        let vc = AddScheduleFirstViewController(viewModel: addScheduleViewModel, viewPath: StringLiterals.Amplitude.ViewPath.courseDetail)
+        let vc = AddScheduleFirstViewController(viewModel: addScheduleViewModel)
         // 데이터를 바인딩합니다.
         vc.pastDateBindViewModel()
         self.navigationController?.pushViewController(vc, animated: false)

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/DateSchedule/View/UpcomingDateScheduleViewController.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/DateSchedule/View/UpcomingDateScheduleViewController.swift
@@ -188,7 +188,7 @@ extension UpcomingDateScheduleViewController: DRCustomAlertDelegate {
             self.present(customAlertVC, animated: false)
         } else {
             print("push to 일정등록하기")
-            let vc = AddScheduleFirstViewController(viewModel: AddScheduleViewModel(), viewPath: StringLiterals.Amplitude.ViewPath.dateSchedule)
+            let vc = AddScheduleFirstViewController(viewModel: AddScheduleViewModel(viewPath: StringLiterals.Amplitude.ViewPath.dateSchedule))
             self.navigationController?.pushViewController(vc, animated: false)
         }
         AmplitudeManager.shared.trackEvent(StringLiterals.Amplitude.EventName.clickAddSchedule)

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/DateSchedule/View/UpcomingDateScheduleViewController.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/DateSchedule/View/UpcomingDateScheduleViewController.swift
@@ -188,7 +188,7 @@ extension UpcomingDateScheduleViewController: DRCustomAlertDelegate {
             self.present(customAlertVC, animated: false)
         } else {
             print("push to 일정등록하기")
-            let vc = AddScheduleFirstViewController(viewModel: AddScheduleViewModel(viewPath: StringLiterals.Amplitude.ViewPath.dateSchedule))
+            let vc = AddScheduleFirstViewController(viewModel: AddScheduleViewModel(viewPath: StringLiterals.Amplitude.ViewPath.dateSchedule, isBroughtData: false))
             self.navigationController?.pushViewController(vc, animated: false)
         }
         AmplitudeManager.shared.trackEvent(StringLiterals.Amplitude.EventName.clickAddSchedule)

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/MyCourse/Views/NavViewedCourseViewController.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/MyCourse/Views/NavViewedCourseViewController.swift
@@ -213,15 +213,12 @@ extension NavViewedCourseViewController : UICollectionViewDataSource {
         
         if indexPath != nil {
             guard let courseId = viewedCourseViewModel.viewedCourseData.value?[indexPath?.item ?? 0].courseId else {return}
-            
             let courseDetailViewModel = CourseDetailViewModel(courseId: courseId)
-            let addScheduleViewModel = AddScheduleViewModel(viewPath: StringLiterals.Amplitude.ViewPath.viewedCourse)
+            
+            let addScheduleViewModel = AddScheduleViewModel(viewPath: StringLiterals.Amplitude.ViewPath.viewedCourse, isBroughtData: true)
             addScheduleViewModel.viewedDateCourseByMeData = courseDetailViewModel
-            addScheduleViewModel.isBroughtData = true
             
             let vc = AddScheduleFirstViewController(viewModel: addScheduleViewModel)
-            // 데이터를 바인딩합니다.
-            vc.pastDateBindViewModel()
             self.navigationController?.pushViewController(vc, animated: false)
         }
     }

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/MyCourse/Views/NavViewedCourseViewController.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/MyCourse/Views/NavViewedCourseViewController.swift
@@ -215,11 +215,11 @@ extension NavViewedCourseViewController : UICollectionViewDataSource {
             guard let courseId = viewedCourseViewModel.viewedCourseData.value?[indexPath?.item ?? 0].courseId else {return}
             
             let courseDetailViewModel = CourseDetailViewModel(courseId: courseId)
-            let addScheduleViewModel = AddScheduleViewModel()
+            let addScheduleViewModel = AddScheduleViewModel(viewPath: StringLiterals.Amplitude.ViewPath.viewedCourse)
             addScheduleViewModel.viewedDateCourseByMeData = courseDetailViewModel
             addScheduleViewModel.isBroughtData = true
             
-            let vc = AddScheduleFirstViewController(viewModel: addScheduleViewModel, viewPath: StringLiterals.Amplitude.ViewPath.viewedCourse)
+            let vc = AddScheduleFirstViewController(viewModel: addScheduleViewModel)
             // 데이터를 바인딩합니다.
             vc.pastDateBindViewModel()
             self.navigationController?.pushViewController(vc, animated: false)


### PR DESCRIPTION
# 🔥*Pull requests*

## ⛳ **작업한 브랜치**
- #282 

<br>

## 👷 **작업한 내용**
<!-- 작업한 내용을 적어주세요. -->
### `일정등록`
  - [x] `ObservablePattern` `lazyBind()`추가
  - [x] AddSchedule(일정 등록) 화면 관련 vc, vm 코드 리펙토링
  - [x] addSchedule Amplitude 관련 코드 리펙토링
### Fix 관련
- [x] 1️⃣ '코스 둘러보기' [광주/이천/여주] 필터링 시 에러 현상 개선
- [x] 2️⃣ '일정 등록 2 화면' cell 이동 시 placeTitle.text 겹침 현상 개선
- [x] 3️⃣ '일정 등록 2 화면' cell 드래그 시작 시 cell 모양 미적용 현상 개선

<br>

## 🚨 참고 사항
<!-- 참고할 사항이 있다면 적어주세요. -->
#### `ObservablePattern` 속 `lazyBind()` 추가
  ```
  func lazyBind(_ listener: @escaping (T?) -> Void) {
      self.listener = listener
  }
  ```
  - ObservablePattern 타입 value의 초깃값을 bind로 다루고 싶지 않을 때에 활용할 함수로 lazyBind를 추가하였습니다.

<br>

## 📸 스크린샷
### 1️⃣ '코스 둘러보기' [광주/이천/여주] 필터링 시 에러 현상 개선
|GIF|스크린샷|GIF|스크린샷|
|:--:|:--:|:--:|:--:|
|개선 이전|<img src = "https://github.com/user-attachments/assets/357895b9-e7ce-4847-82e8-b39b25a9af17" width ="220">|개선 이후|<img src = "https://github.com/user-attachments/assets/d56b5d64-5139-4a53-a630-01cafae3d17c" width ="220">|
  > 지역 매핑 중 오탈자가 있어 수정하였습니다.


### 2️⃣ '일정 등록 2 화면' cell 이동 시 placeTitle.text 겹침 현상 개선
|GIF|스크린샷|GIF|스크린샷|
|:--:|:--:|:--:|:--:|
|개선 이전|<img src = "https://github.com/user-attachments/assets/33fc8441-6b7c-416c-b37b-b807efbfbbce" width ="220">|개선 이후|<img src = "https://github.com/user-attachments/assets/8db388e5-f5cf-49f2-b855-3e552f0d68af" width ="220">|
  > 기존의 remove와 insert 로직이 아닌, moveItem 함수를 사용하였습니다.

### 3️⃣ '일정 등록 2 화면' cell 드래그 시작 시 cell 모양 미적용 현상 개선
|GIF|스크린샷|GIF|스크린샷|
|:--:|:--:|:--:|:--:|
|개선 이전|<img src = "https://github.com/user-attachments/assets/8db388e5-f5cf-49f2-b855-3e552f0d68af" width ="220">|개선 이후|<img src = "https://github.com/user-attachments/assets/e4bdfbb5-02b4-430e-93b5-806e53473e3b" width ="220">|
  > cell 드래그 시 Preview를 다룰 수 있는 함수를 활용하였습니다.

<br>

## 📟 관련 이슈
- Resolved: #282 

<br>

- 추후 해야할 것
  - Input/Output 나눈 기반을 토대로 다시 리펙 및 뷰 재구성
  - 비밀..