### PR TITLE
[FEAT] 코스 상세, 일정 장세 장소 API 연결 및 반영 (#303)

### DIFF
--- a/DATEROAD-iOS/DATEROAD-iOS/Global/UIComponents/DRTimelineCollectionViewCell.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Global/UIComponents/DRTimelineCollectionViewCell.swift
@@ -22,6 +22,7 @@ final class DRTimelineCollectionViewCell: BaseCollectionViewCell {
     
     var type: TimelineType
     
+    
     // MARK: - LifeCycle
     
     override init(frame: CGRect) {
@@ -65,11 +66,11 @@ final class DRTimelineCollectionViewCell: BaseCollectionViewCell {
 extension DRTimelineCollectionViewCell {
     
     func dataBind(_ timelineData: TimelineModel) {
-        self.sequenceLabel.text = self.type == .course ? "\(timelineData.sequence)" : "\(timelineData.sequence+1)"
+        // TODO: '가깔나는 영종도 데이트 코스' 만 타임라인 인덱스가 0부터 오고 나머지는 다 1부터 와서 +1 안해도 될 것 같음 
+        self.sequenceLabel.text = self.type == .course ? "\(timelineData.sequence + 1)" : "\(timelineData.sequence + 1)"
         timelineView.do {
             $0.locationLabel.text = timelineData.title
-            // TODO: 주소, abbreviatedString 메소드 사용
-            $0.addressLabel.text = "아직 못 불러옴".abbreviatedString(20)
+            $0.addressLabel.text = timelineData.address.abbreviatedString(20)
             $0.timeLabel.text = "\(timelineData.duration)시간"
         }
     }

--- a/DATEROAD-iOS/DATEROAD-iOS/Network/CourseDetail/CourseDetailTargetType.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Network/CourseDetail/CourseDetailTargetType.swift
@@ -22,13 +22,21 @@ enum CourseDetailTargetType {
 extension CourseDetailTargetType: BaseTargetType {
     
     var utilPath: String {
-        return "api/v1/"
+        switch self {
+        case .getCourseDetailInfo(let courseId):
+            return "api/v2/"
+            
+        case .deleteCourse, .getBannerDetail:
+            return "api/v1/"
+        }
+        
     }
     
     var method: Moya.Method {
         switch self {
         case .getCourseDetailInfo, .getBannerDetail:
             return .get
+            
         case .deleteCourse:
             return .delete
         }
@@ -38,18 +46,17 @@ extension CourseDetailTargetType: BaseTargetType {
         switch self {
         case .getCourseDetailInfo(let courseId):
             return utilPath+"courses/\(courseId)"
+            
         case .deleteCourse(let courseId):
             return utilPath+"courses/\(courseId)"
+            
         case .getBannerDetail(let advertismentId):
             return utilPath + "advertisements/\(advertismentId)"
         }
     }
     
     var parameter: [String : Any]? {
-        switch self {
-        default:
-                .none
-        }
+        return .none
     }
     
     var task: Task {

--- a/DATEROAD-iOS/DATEROAD-iOS/Network/CourseDetail/DTO/GetCourseDetailResponse.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Network/CourseDetail/DTO/GetCourseDetailResponse.swift
@@ -73,6 +73,8 @@ struct GetCourseDetailPlace: Codable {
     
     let duration: Float
     
+    let address: String?
+    
 }
 
 

--- a/DATEROAD-iOS/DATEROAD-iOS/Network/DateSchedule/DTO/GetDateDetailResponse.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Network/DateSchedule/DTO/GetDateDetailResponse.swift
@@ -44,6 +44,8 @@ struct Place: Codable {
     
     let sequence: Int
     
+    let address: String?
+    
 }
 
 

--- a/DATEROAD-iOS/DATEROAD-iOS/Network/DateSchedule/DateScheduleTargetType.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Network/DateSchedule/DateScheduleTargetType.swift
@@ -22,13 +22,20 @@ enum DateScheduleTargetType {
 extension DateScheduleTargetType: BaseTargetType {
     
     var utilPath: String {
-        return "api/v1/"
+        switch self {
+        case .getDateSchedule, .deleteDateSchedule:
+            return "api/v1/"
+            
+        case .getDateDetail:
+            return "api/v2/"
+        }
     }
     
     var method: Moya.Method {
         switch self {
         case .getDateSchedule, .getDateDetail:
             return .get
+            
         case .deleteDateSchedule:
             return .delete
         }
@@ -38,8 +45,10 @@ extension DateScheduleTargetType: BaseTargetType {
         switch self {
         case .getDateSchedule:
             return utilPath + "dates"
+            
         case .getDateDetail(let dateID):
             return utilPath + "dates/\(dateID)"
+        
         case .deleteDateSchedule(let dateID):
             return utilPath + "dates/\(dateID)"
         }
@@ -49,8 +58,10 @@ extension DateScheduleTargetType: BaseTargetType {
         switch self {
         case .getDateSchedule(let time):
             return ["time" : time]
+        
         case .getDateDetail(let dateID):
             return ["dateId" : dateID]
+        
         case .deleteDateSchedule(let dateID):
             return ["dateId" : dateID]
         }

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/CourseDetail/Models/CourseDetailModel.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/CourseDetail/Models/CourseDetailModel.swift
@@ -69,13 +69,21 @@ struct MainContentsModel: Equatable {
 
 struct TimelineModel: Equatable {
     
+    let address: String
+    
     let sequence: Int
     
     let title: String
     
     let duration: String
     
-    init(sequence: Int, title: String, duration: String) {
+    init(
+        address: String,
+        sequence: Int,
+        title: String,
+        duration: String
+    ) {
+        self.address = address
         self.sequence = sequence
         self.title = title
         self.duration = duration

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/CourseDetail/ViewModels/CourseDetailViewModel.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/CourseDetail/ViewModels/CourseDetailViewModel.swift
@@ -130,12 +130,14 @@ extension CourseDetailViewModel {
             case .success(let data):
                 dump(data)
                 
-                let newConditionalData = ConditionalModel(courseId: self.courseId,
-                                                          isCourseMine: data.isCourseMine,
-                                                          isAccess: data.isAccess,
-                                                          free: data.free,
-                                                          totalPoint: data.totalPoint,
-                                                          isUserLiked: data.isUserLiked)
+                let newConditionalData = ConditionalModel(
+                    courseId: self.courseId,
+                    isCourseMine: data.isCourseMine,
+                    isAccess: data.isAccess,
+                    free: data.free,
+                    totalPoint: data.totalPoint,
+                    isUserLiked: data.isUserLiked
+                )
                 if self.currentConditionalData != newConditionalData {
                     self.currentConditionalData = newConditionalData
                     self.conditionalData.value = newConditionalData
@@ -163,11 +165,13 @@ extension CourseDetailViewModel {
                     self.updateConditionalData.value = true
                 }
                 
-                let newTitleHeaderData = TitleHeaderModel(date: data.date,
-                                                          title: data.title,
-                                                          cost: data.totalCost,
-                                                          totalTime: data.totalTime,
-                                                          city: data.city)
+                let newTitleHeaderData = TitleHeaderModel(
+                    date: data.date,
+                    title: data.title,
+                    cost: data.totalCost,
+                    totalTime: data.totalTime,
+                    city: data.city
+                )
                 if self.currentTitleHeaderData != newTitleHeaderData {
                     self.currentTitleHeaderData = newTitleHeaderData
                     self.titleHeaderData.value = newTitleHeaderData
@@ -182,9 +186,13 @@ extension CourseDetailViewModel {
                 }
                 
                 let newTimelineData = data.places.map { place in
-                    TimelineModel(sequence: place.sequence,
-                                  title: place.title,
-                                  duration: (place.duration).formatFloatTime()) }
+                    TimelineModel(
+                        address: place.address ?? "",
+                        sequence: place.sequence,
+                        title: place.title,
+                        duration: (place.duration).formatFloatTime()
+                    )
+                }
                 if self.currentTimelineData != newTimelineData {
                     self.currentTimelineData = newTimelineData
                     self.timelineData.value = newTimelineData

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/DateSchedule/ViewModel/DateDetailViewModel.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/DateSchedule/ViewModel/DateDetailViewModel.swift
@@ -73,17 +73,24 @@ extension DateDetailViewModel {
                 }
                 
                 let datePlaceInfo: [TimelineModel] = data.places.map { place in
-                    TimelineModel(sequence: place.sequence, title: place.title, duration: (place.duration).formatFloatTime())
+                    TimelineModel(
+                        address: place.address ?? "",
+                        sequence: place.sequence,
+                        title: place.title,
+                        duration: (place.duration).formatFloatTime()
+                    )
                 }
                 
-                let newDateDetailData = DateDetailModel(dateID: data.dateID,
-                                                        title: data.title,
-                                                        startAt: data.startAt,
-                                                        city: data.city,
-                                                        tags: tagsInfo,
-                                                        date: data.date.formatDateFromString(inputFormat: "yyyy.MM.dd", outputFormat: "yyyy년 M월 d일") ?? "",
-                                                        places: datePlaceInfo,
-                                                        dDay: data.dDay)
+                let newDateDetailData = DateDetailModel(
+                    dateID: data.dateID,
+                    title: data.title,
+                    startAt: data.startAt,
+                    city: data.city,
+                    tags: tagsInfo,
+                    date: data.date.formatDateFromString(inputFormat: "yyyy.MM.dd", outputFormat: "yyyy년 M월 d일") ?? "",
+                    places: datePlaceInfo,
+                    dDay: data.dDay
+                )
                 
                 // 기존 데이터와 비교 이후 동작
                 if self.currentDateDetailData != newDateDetailData {


### PR DESCRIPTION
# 🔥*Pull requests*

## ⛳ **작업한 브랜치**
- feature/#303 

## 👷 **작업한 내용**
<!-- 작업한 내용을 적어주세요. -->
- [x] 코스 상세 장소 API 연결 및 반영
- [x] 일정 장세 장소 API 연결 및 반영

## 🚨 참고 사항
<!-- 참고할 사항이 있다면 적어주세요. -->
### 타임라인 인덱스
현재 '가깔나는 영종도 데이트 코스' 만 타임라인 인덱스가 0부터 오고 나머지는 다 1부터 오는 것 같아서 굳이 인덱스에 +1 안해도 될 것 같아요
이게 개발 서버에서만 그런건지 확인 해봐야 할 것 같긴 한데, 확인해보고 수정해두도록 하겠습니다! 

### 주소 nil인 경우
기존에 등록되어 있던 코스나 일정의 경우에는 주소가 등록되어 있지 않기 때문에 우선 빈값으로 두었습니다

## 📸 스크린샷
|기능|스크린샷|기능|스크린샷|
|:--:|:--:|:--:|:--:|
|아이폰15Pro|<img src = "https://github.com/user-attachments/assets/20360c9d-3b77-4f81-ac6a-e59f932f1a72" width ="250">|아이폰se|<img src = "https://github.com/user-attachments/assets/6dc3d750-1e69-4b39-9fd7-9a77001f00dc" width ="250">|

## 📟 관련 이슈
- Resolved: #303 
