### PR TITLE
[FIX] 3차 스프린트 1차 QA 적용 (#310)

### DIFF
--- a/DATEROAD-iOS/DATEROAD-iOS/Global/Literals/StringLiterals.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Global/Literals/StringLiterals.swift
@@ -209,7 +209,7 @@ enum StringLiterals {
             
             static let contentTitleLabelOfCourse = "어떤 코스로 이동하셨나요?"
             
-            static let contentTitleLabelOfSchedul = "어떤 코스를 계획하셨나요?"
+            static let contentTitleLabelOfSchedule = "어떤 코스를 계획하셨나요?"
             
             static let subTitleLabel = "장소와 소요시간을 입력하여 코스를 추가해 주세요"
             

--- a/DATEROAD-iOS/DATEROAD-iOS/Global/Literals/StringLiterals.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Global/Literals/StringLiterals.swift
@@ -175,7 +175,7 @@ enum StringLiterals {
         
         static let addCourseTitle = "코스 등록하기"
         
-        static let addScheduleTitle = "일정 등록하기"
+        static let addScheduleTitle = "일정 계획하기"
         
         enum AddFirstView {
             
@@ -188,6 +188,8 @@ enum StringLiterals {
             static let dateStartTimeLabel = "데이트 시작 시간을 선택해 주세요 (필수)"
             
             static let tagTitle = "데이트코스와 어울리는 태그를 선택해 주세요 (0/3)"
+            
+            static let tagTitleOnSchedule = "예정된 데이트와 어울리는 태그를 선택해주세요 (0/3)"
             
             static let datePlaceLabel = "데이트 지역을 선택해 주세요 (필수)"
             
@@ -207,7 +209,7 @@ enum StringLiterals {
             
             static let contentTitleLabelOfCourse = "어떤 코스로 이동하셨나요?"
             
-            static let contentTitleLabelOfSchedul = "어떤 코스로 이동하시나요?"
+            static let contentTitleLabelOfSchedul = "어떤 코스를 계획하셨나요?"
             
             static let subTitleLabel = "장소와 소요시간을 입력하여 코스를 추가해 주세요"
             

--- a/DATEROAD-iOS/DATEROAD-iOS/Global/Protocols/DRButtonType.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Global/Protocols/DRButtonType.swift
@@ -140,7 +140,7 @@ struct DateScheduleTagButton: DRButtonType {
     
     var fontColor: UIColor = UIColor(resource: .drBlack)
     
-    var font: UIFont = UIFont.suit(.body_semi_15)
+    var font: UIFont = UIFont.suit(.body_med_13)
     
     var cornerRadius: CGFloat = 15
     
@@ -164,7 +164,7 @@ struct PastDateScheduleTagButton: DRButtonType {
     
     var fontColor: UIColor = UIColor(resource: .drBlack)
     
-    var font: UIFont = UIFont.suit(.body_semi_13)
+    var font: UIFont = UIFont.suit(.body_med_13)
     
     var cornerRadius: CGFloat = 14
     

--- a/DATEROAD-iOS/DATEROAD-iOS/Global/UIComponents/CustomAlert/DRCustomAlertView.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Global/UIComponents/CustomAlert/DRCustomAlertView.swift
@@ -71,7 +71,7 @@ final class DRCustomAlertView: BaseView {
         
         descriptionLabel.snp.makeConstraints {
             $0.horizontalEdges.equalToSuperview()
-            $0.top.equalTo(titleLabel.snp.bottom).inset(5)
+            $0.top.equalTo(titleLabel.snp.bottom).offset(5)
             $0.height.equalTo(18)
         }
         

--- a/DATEROAD-iOS/DATEROAD-iOS/Global/UIComponents/CustomEmptyView.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Global/UIComponents/CustomEmptyView.swift
@@ -52,8 +52,6 @@ final class CustomEmptyView: BaseView {
         imageView.do {
             $0.clipsToBounds = true
             $0.contentMode = .scaleAspectFit
-            $0.layer.borderColor = UIColor.red.cgColor
-            $0.layer.borderWidth = 1
         }
     }
     

--- a/DATEROAD-iOS/DATEROAD-iOS/Global/UIComponents/CustomEmptyView.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Global/UIComponents/CustomEmptyView.swift
@@ -43,7 +43,7 @@ final class CustomEmptyView: BaseView {
         }
         
         titleLabel.snp.makeConstraints {
-            $0.top.equalTo(imageView.snp.bottom)
+            $0.top.equalTo(imageView.snp.bottom).offset(-40)
             $0.horizontalEdges.equalToSuperview()
         }
     }
@@ -52,6 +52,8 @@ final class CustomEmptyView: BaseView {
         imageView.do {
             $0.clipsToBounds = true
             $0.contentMode = .scaleAspectFit
+            $0.layer.borderColor = UIColor.red.cgColor
+            $0.layer.borderWidth = 1
         }
     }
     

--- a/DATEROAD-iOS/DATEROAD-iOS/Global/UIComponents/DRTimelineCollectionViewCell.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Global/UIComponents/DRTimelineCollectionViewCell.swift
@@ -65,8 +65,8 @@ final class DRTimelineCollectionViewCell: BaseCollectionViewCell {
 
 extension DRTimelineCollectionViewCell {
     
-    func dataBind(_ timelineData: TimelineModel) {
-        self.sequenceLabel.text = "\(timelineData.sequence)"
+    func dataBind(_ timelineData: TimelineModel, isCourseDetail: Bool = false) {
+        self.sequenceLabel.text = isCourseDetail ? "\(timelineData.sequence)" : "\(timelineData.sequence + 1)"
         timelineView.do {
             $0.locationLabel.text = timelineData.title
             $0.addressLabel.text = timelineData.address.abbreviatedString(20)

--- a/DATEROAD-iOS/DATEROAD-iOS/Global/Utils/Enums/DRTextFieldType.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Global/Utils/Enums/DRTextFieldType.swift
@@ -41,12 +41,11 @@ enum DRTextFieldType: Equatable {
             case .datePlace:
                 return .basic(placeholder: StringLiterals.AddCourseOrSchedule.AddSecondView.datePlacePlaceHolder,
                               cornerRadius: 14,
-                              font: UIFont.systemFont(ofSize: 13, weight: .semibold))
-                //TODO: 추후 장소 api 붙이면 이상한 글자 입력될 일 없으니 suit font 적용하기
+                              font: UIFont.suit(.body_semi_13))
             case .totalPrice:
                 return .basic(placeholder: StringLiterals.AddCourseOrSchedule.AddThirdView.priceTextFieldPlaceHolder,
                               cornerRadius: 14,
-                              font: .suit(.body_med_13))
+                              font: UIFont.suit(.body_semi_13))
             }
         case .profile:
             return .rightTextButton(placeholder: StringLiterals.Profile.nicknamePlaceholder,

--- a/DATEROAD-iOS/DATEROAD-iOS/Network/AddCourse/AddCourseTargetType.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Network/AddCourse/AddCourseTargetType.swift
@@ -60,7 +60,7 @@ extension AddCourseTargetType: BaseTargetType {
             
             // Add images
             for (index, image) in images.enumerated() {
-                if let imageData = image.jpegData(compressionQuality: 0.8) {
+                if let imageData = image.jpegData(compressionQuality: 0.6) {
                     formData.append(MultipartFormData(provider: .data(imageData), name: "images", fileName: "image\(index).jpg", mimeType: "image/jpeg"))
                 }
             }

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/AddCourse/Cells/AddCourseImageCollectionViewCell.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/AddCourse/Cells/AddCourseImageCollectionViewCell.swift
@@ -110,7 +110,10 @@ final class AddCourseImageCollectionViewCell: BaseCollectionViewCell {
             $0.layer.borderWidth = 2
         }
         
-        thumbnailTagView.backgroundColor = UIColor(resource: .purple600)
+        thumbnailTagView.do {
+            $0.backgroundColor = UIColor(resource: .purple600)
+            $0.layer.cornerRadius = 4
+        }
         
         emptyView.do {
             $0.backgroundColor = .gray100

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/AddCourse/Views/AddCourseSecond/AddCourseSecondView.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/AddCourse/Views/AddCourseSecond/AddCourseSecondView.swift
@@ -86,7 +86,7 @@ final class AddCourseSecondView: BaseView {
         
         editButton.snp.makeConstraints {
             $0.top.equalTo(addSecondView.separatorLine.snp.bottom).offset(10)
-            $0.trailing.equalToSuperview()
+            $0.trailing.equalToSuperview().offset(ScreenUtils.width * 16/375)
             $0.width.equalTo(59)
             $0.height.equalTo(30)
         }

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/AddCourse/Views/AddCourseThird/AddCourseThirdView.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/AddCourse/Views/AddCourseThird/AddCourseThirdView.swift
@@ -45,7 +45,7 @@ final class AddCourseThirdView: BaseView {
         
         addThirdDoneBtn.snp.makeConstraints {
             $0.height.equalTo(54)
-            $0.horizontalEdges.equalToSuperview()
+            $0.horizontalEdges.equalToSuperview().inset(16)
             $0.bottom.equalTo(safeAreaLayoutGuide)
         }
         
@@ -61,7 +61,7 @@ final class AddCourseThirdView: BaseView {
         
         addThirdView.snp.makeConstraints {
             $0.top.equalTo(collectionView.snp.bottom).offset(7)
-            $0.horizontalEdges.equalToSuperview()
+            $0.horizontalEdges.equalToSuperview().inset(16)
             $0.bottom.equalToSuperview()
         }
     }

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/AddCourse/Views/AddCourseThird/AddCourseThirdViewController.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/AddCourse/Views/AddCourseThird/AddCourseThirdViewController.swift
@@ -84,7 +84,7 @@ final class AddCourseThirdViewController: BaseNavBarViewController {
         
         addCourseThirdView.snp.makeConstraints {
             $0.top.equalToSuperview().offset(4)
-            $0.horizontalEdges.equalToSuperview().inset(16)
+            $0.horizontalEdges.equalToSuperview()
             $0.bottom.equalTo(view.safeAreaLayoutGuide).inset(4)
         }
     }

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/AddCourse/Views/AddCourseThird/AddCourseThirdViewController.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/AddCourse/Views/AddCourseThird/AddCourseThirdViewController.swift
@@ -194,7 +194,7 @@ private extension AddCourseThirdViewController {
     func successDone() {
         let customAlertVC = DRCustomAlertViewController(
             rightActionType: .none,
-            alertTextType: .hasDecription,
+            alertTextType: .noDescription,
             titleText: StringLiterals.AddCourseOrSchedule.AddCourseAlert.alertTitleLabel,
             descriptionText: StringLiterals.AddCourseOrSchedule.AddCourseAlert.alertSubTitleLabel,
             longButton: DRTextButton(title: StringLiterals.AddCourseOrSchedule.AddCourseAlert.doneButton, buttonName: .bold_purple_10)

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/AddCourse/Views/AddCourseThird/AddCourseThirdViewController.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/AddCourse/Views/AddCourseThird/AddCourseThirdViewController.swift
@@ -194,7 +194,7 @@ private extension AddCourseThirdViewController {
     func successDone() {
         let customAlertVC = DRCustomAlertViewController(
             rightActionType: .none,
-            alertTextType: .noDescription,
+            alertTextType: .hasDecription,
             titleText: StringLiterals.AddCourseOrSchedule.AddCourseAlert.alertTitleLabel,
             descriptionText: StringLiterals.AddCourseOrSchedule.AddCourseAlert.alertSubTitleLabel,
             longButton: DRTextButton(title: StringLiterals.AddCourseOrSchedule.AddCourseAlert.doneButton, buttonName: .bold_purple_10)

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/AddCourse/Views/AddCourseThird/AddCourseThirdViewController.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/AddCourse/Views/AddCourseThird/AddCourseThirdViewController.swift
@@ -291,9 +291,10 @@ extension AddCourseThirdViewController: UITextViewDelegate {
 
 extension AddCourseThirdViewController: UITextFieldDelegate {
     
-    func textFieldShouldBeginEditing(_ textField: UITextField) -> Bool {
+    func textFieldDidChangeSelection(_ textField: UITextField) {
         textField.font = UIFont.suit(.body_med_13)
-        return true
+        let money = textField.text?.filter { $0.isNumber }
+        viewModel.priceText.value = Int(money ?? "0")
     }
     
     func textFieldDidBeginEditing(_ textField: UITextField) {
@@ -318,9 +319,9 @@ extension AddCourseThirdViewController: UITextFieldDelegate {
             }
             self.view.layoutIfNeeded() // 레이아웃 즉시 갱신
         }
-        // textField 값이 변경된 경우 ',' 제거한 값으로 처리
-        let money = textField.text?.filter { $0.isNumber }
-        viewModel.priceText.value = Int(money ?? "0")
+//        // textField 값이 변경된 경우 ',' 제거한 값으로 처리
+//        let money = textField.text?.filter { $0.isNumber }
+//        viewModel.priceText.value = Int(money ?? "0")
     }
     
 }

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/AddCourse/Views/AddSheetView.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/AddCourse/Views/AddSheetView.swift
@@ -126,6 +126,7 @@ extension AddSheetView {
         if isDatePicker {
             datePicker.datePickerMode = .date
         } else {
+            datePicker.minuteInterval = 5
             datePicker.datePickerMode = .time
         }
     }

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/AddSchedule/ViewModels/AddScheduleViewModel.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/AddSchedule/ViewModels/AddScheduleViewModel.swift
@@ -196,9 +196,9 @@ final class AddScheduleViewModel: Serviceable, TimeRequireViewModel {
                     if let doubleValue = Double(String(i.duration)) {
                         let text = doubleValue.truncatingRemainder(dividingBy: 1) == 0 ?
                         String(Int(doubleValue)) : String(doubleValue)
-                        tapAddBtn(datePlace: i.title, address: "주소넣어주기", timeRequire: "\(text) 시간")
+                        tapAddBtn(datePlace: i.title, address: i.address, timeRequire: "\(text) 시간")
                     } else {
-                        tapAddBtn(datePlace: i.title, address: "주소넣어주기", timeRequire: "\(String(i.duration)) 시간")
+                        tapAddBtn(datePlace: i.title, address: i.address, timeRequire: "\(String(i.duration)) 시간")
                     }
                 }
                 pastDatePlaces.removeAll()

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/AddSchedule/Views/AddScheduleBottomSheetView.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/AddSchedule/Views/AddScheduleBottomSheetView.swift
@@ -130,6 +130,7 @@ extension AddScheduleBottomSheetView {
         if isDatePicker {
             datePicker.datePickerMode = .date
         } else {
+            datePicker.minuteInterval = 5
             datePicker.datePickerMode = .time
         }
     }

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/AddSchedule/Views/AddScheduleFirst/InAddScheduleFirstView.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/AddSchedule/Views/AddScheduleFirst/InAddScheduleFirstView.swift
@@ -23,7 +23,7 @@ final class InAddScheduleFirstView: BaseView {
     private let tagContainer = UIView()
     
     private let tagTitleLabel: DRTextLabel = DRTextLabel(
-        title: StringLiterals.AddCourseOrSchedule.AddFirstView.tagTitle,
+        title: StringLiterals.AddCourseOrSchedule.AddFirstView.tagTitleOnSchedule,
         textLabelType: .clear(.semi15_black),
         alignment: .left
     )
@@ -149,7 +149,7 @@ extension InAddScheduleFirstView {
     }
     
     func updateTagCount(count: Int) {
-        tagTitleLabel.text = "데이트 코스와 어울리는 태그를 선택해 주세요 (\(count)/3)"
+        tagTitleLabel.text = "예정된 데이트와 어울리는 태그를 선택해주세요 (\(count)/3)"
     }
     
     func updateTag(button: UIButton, buttonType: DRButtonType) {

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/AddSchedule/Views/AddScheduleSecond/AddScheduleSecondViewController.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/AddSchedule/Views/AddScheduleSecond/AddScheduleSecondViewController.swift
@@ -294,7 +294,7 @@ private extension AddScheduleSecondViewController {
     // 등록 완료 alertVC도 blurView 페이드인 적용 미정
     func successDone() {
         let customAlertVC = DRCustomAlertViewController(rightActionType: .none,
-                                                        alertTextType: .hasDecription,
+                                                        alertTextType: .noDescription,
                                                         titleText: StringLiterals.AddCourseOrSchedule.AddCourseAlert.alertScheduelTitleLabel,
                                                         longButton: DRTextButton(title: StringLiterals.AddCourseOrSchedule.AddCourseAlert.doneButton, buttonName: .bold_purple_10))
         customAlertVC.delegate = self

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/AddSchedule/Views/AddScheduleSecond/InAddScheduleSecondView.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/AddSchedule/Views/AddScheduleSecond/InAddScheduleSecondView.swift
@@ -15,7 +15,7 @@ final class InAddScheduleSecondView: BaseView {
     // MARK: - UI Properties
     
     private let contentTitleLabel: DRTextLabel = DRTextLabel(
-        title: StringLiterals.AddCourseOrSchedule.AddSecondView.contentTitleLabelOfCourse,
+        title: StringLiterals.AddCourseOrSchedule.AddSecondView.contentTitleLabelOfSchedul,
         textLabelType: .clear(.bold17_black),
         alignment: .left
     )

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/AddSchedule/Views/AddScheduleSecond/InAddScheduleSecondView.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/AddSchedule/Views/AddScheduleSecond/InAddScheduleSecondView.swift
@@ -15,7 +15,7 @@ final class InAddScheduleSecondView: BaseView {
     // MARK: - UI Properties
     
     private let contentTitleLabel: DRTextLabel = DRTextLabel(
-        title: StringLiterals.AddCourseOrSchedule.AddSecondView.contentTitleLabelOfSchedul,
+        title: StringLiterals.AddCourseOrSchedule.AddSecondView.contentTitleLabelOfSchedule,
         textLabelType: .clear(.bold17_black),
         alignment: .left
     )

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/Base/BaseNavBarViewController.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/Base/BaseNavBarViewController.swift
@@ -25,7 +25,7 @@ class BaseNavBarViewController: UIViewController {
     
     private var rightButton = UIButton()
     
-    var titleLabel: DRTextLabel = DRTextLabel(textLabelType: .clear(.bold20_black), hidden: true)
+    var titleLabel: DRTextLabel = DRTextLabel(textLabelType: .clear(.bold18_black), hidden: true)
     
     private let backgroundView: UIView = UIView()
     

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/CourseDetail/Views/CourseDetailViewController.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/CourseDetail/Views/CourseDetailViewController.swift
@@ -554,7 +554,11 @@ extension CourseDetailViewController: UICollectionViewDelegate, UICollectionView
         guard let cell = collectionView.dequeueReusableCell(withReuseIdentifier: DRTimelineCollectionViewCell.cellIdentifier, for: indexPath) as? DRTimelineCollectionViewCell else {
             return UICollectionViewCell() }
         cell.type = .course
-        cell.dataBind(data)
+        if courseDetailViewModel.titleHeaderData.value?.title == "기깔나는 영종도 데이트 코스" {
+            cell.dataBind(data)
+        } else {
+            cell.dataBind(data, isCourseDetail: true)
+        }
         return cell
     }
     

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/DateSchedule/View/DateDetailContentView.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/DateSchedule/View/DateDetailContentView.swift
@@ -144,8 +144,6 @@ final class DateDetailContentView: BaseView {
         }
         
         kakaoShareButton.snp.makeConstraints {
-            //            $0.centerX.equalToSuperview()
-//            $0.horizontalEdges.equalToSuperview().inset(78)
             $0.horizontalEdges.equalToSuperview().inset(ScreenUtils.width / 375 * 73)
             $0.height.equalTo(ScreenUtils.width * 0.1386667)
             $0.bottom.equalToSuperview().inset(ScreenUtils.height * 0.04802956)
@@ -171,8 +169,10 @@ final class DateDetailContentView: BaseView {
                 $0.setButtonStatus(buttonType: tagButtonType)
             }
         }
-        secondTagButton.isHidden = true
-        thirdTagButton.isHidden = true
+        
+        [secondTagButton, thirdTagButton].forEach { i in
+            i.isHidden = true
+        }
         
         dateDetailView.do {
             $0.backgroundColor = UIColor(resource: .drWhite)

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/DateSchedule/View/DateDetailContentView.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/DateSchedule/View/DateDetailContentView.swift
@@ -45,7 +45,7 @@ final class DateDetailContentView: BaseView {
     
     var kakaoShareButton = UIButton()
     
-    var courseShareButton = DRTextButton(title: StringLiterals.DateSchedule.courseShare, buttonName: .bold_purple_25)
+    var courseShareButton = UIButton()
     
     static var dateTimeLineCollectionViewLayout = UICollectionViewFlowLayout()
     
@@ -145,7 +145,8 @@ final class DateDetailContentView: BaseView {
         
         kakaoShareButton.snp.makeConstraints {
             //            $0.centerX.equalToSuperview()
-            $0.horizontalEdges.equalToSuperview().inset(78)
+//            $0.horizontalEdges.equalToSuperview().inset(78)
+            $0.horizontalEdges.equalToSuperview().inset(ScreenUtils.width / 375 * 73)
             $0.height.equalTo(ScreenUtils.width * 0.1386667)
             $0.bottom.equalToSuperview().inset(ScreenUtils.height * 0.04802956)
         }
@@ -197,6 +198,21 @@ final class DateDetailContentView: BaseView {
             config.baseForegroundColor = UIColor(resource: .drWhite)
             config.cornerStyle = .capsule
             config.imagePadding = 12
+            config.titleTextAttributesTransformer = UIConfigurationTextAttributesTransformer { incoming in
+                var outgoing = incoming
+                outgoing.font = UIFont.suit(.body_bold_15)
+                return outgoing
+            }
+            $0.configuration = config
+        }
+        
+        courseShareButton.do {
+            $0.isHidden = true
+            var config = UIButton.Configuration.plain()
+            config.title = StringLiterals.DateSchedule.courseShare
+            config.background.backgroundColor = UIColor(resource: .purple600)
+            config.baseForegroundColor = UIColor(resource: .drWhite)
+            config.cornerStyle = .capsule
             config.titleTextAttributesTransformer = UIConfigurationTextAttributesTransformer { incoming in
                 var outgoing = incoming
                 outgoing.font = UIFont.suit(.body_bold_15)

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/DateSchedule/View/DateDetailContentView.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/DateSchedule/View/DateDetailContentView.swift
@@ -16,9 +16,9 @@ final class DateDetailContentView: BaseView {
     private var dateLabel: DRTextLabel = DRTextLabel(textLabelType: .clear(.semi15_black))
     
     var dDayLabel: DRTextLabel = DRTextLabel(textLabelType: .background(.bold11_white, .purple600_10), hidden: true)
-
+    
     // TODO: - UILabel로 변경
-        
+    
     private var firstTagButton = UIButton()
     
     private var secondTagButton = UIButton()
@@ -144,7 +144,8 @@ final class DateDetailContentView: BaseView {
         }
         
         kakaoShareButton.snp.makeConstraints {
-            $0.centerX.equalToSuperview()
+            //            $0.centerX.equalToSuperview()
+            $0.horizontalEdges.equalToSuperview().inset(78)
             $0.height.equalTo(ScreenUtils.width * 0.1386667)
             $0.bottom.equalToSuperview().inset(ScreenUtils.height * 0.04802956)
         }
@@ -161,52 +162,22 @@ final class DateDetailContentView: BaseView {
             $0.contentMode = .scaleAspectFill
             $0.clipsToBounds = true
         }
-                
+        
         dDayLabel.setPadding(top: 2, left: 10, bottom: 2, right: 10)
         
-        firstTagButton.do {
-            $0.setButtonStatus(buttonType: tagButtonType)
-            $0.titleLabel?.lineBreakMode = .byClipping
-            $0.titleLabel?.adjustsFontSizeToFitWidth = true
-            $0.titleLabel?.minimumScaleFactor = 0.5
-            $0.titleLabel?.numberOfLines = 1
-            $0.titleLabel?.textAlignment = .center
-            $0.contentEdgeInsets = UIEdgeInsets(top: 4, left: 10, bottom: 4, right: 10)
-            $0.isEnabled = false
-            $0.adjustsImageWhenDisabled = false
+        [firstTagButton, secondTagButton, thirdTagButton].forEach { i in
+            i.do {
+                $0.setButtonStatus(buttonType: tagButtonType)
+            }
         }
-        
-        secondTagButton.do {
-            $0.isHidden = true
-            $0.titleLabel?.lineBreakMode = .byClipping
-            $0.titleLabel?.adjustsFontSizeToFitWidth = true
-            $0.titleLabel?.minimumScaleFactor = 0.5
-            $0.titleLabel?.numberOfLines = 1
-            $0.titleLabel?.textAlignment = .center
-            $0.setButtonStatus(buttonType: tagButtonType)
-            $0.contentEdgeInsets = UIEdgeInsets(top: 4, left: 10, bottom: 4, right: 10)
-            $0.isEnabled = false
-            $0.adjustsImageWhenDisabled = false
-        }
-        
-        thirdTagButton.do {
-            $0.isHidden = true
-            $0.titleLabel?.lineBreakMode = .byClipping
-            $0.titleLabel?.adjustsFontSizeToFitWidth = true
-            $0.titleLabel?.minimumScaleFactor = 0.5
-            $0.titleLabel?.numberOfLines = 1
-            $0.titleLabel?.textAlignment = .center
-            $0.setButtonStatus(buttonType: tagButtonType)
-            $0.contentEdgeInsets = UIEdgeInsets(top: 4, left: 10, bottom: 4, right: 10)
-            $0.isEnabled = false
-            $0.adjustsImageWhenDisabled = false
-        }
+        secondTagButton.isHidden = true
+        thirdTagButton.isHidden = true
         
         dateDetailView.do {
             $0.backgroundColor = UIColor(resource: .drWhite)
             $0.roundCorners(cornerRadius: 20, maskedCorners: [.layerMinXMinYCorner, .layerMaxXMinYCorner])
         }
-                
+        
         dateTimeLineCollectionView.do {
             $0.backgroundColor = UIColor(resource: .drWhite)
             $0.isPagingEnabled = false
@@ -219,17 +190,21 @@ final class DateDetailContentView: BaseView {
         
         kakaoShareButton.do {
             $0.isHidden = true
-            $0.backgroundColor = UIColor(resource: .purple600)
-            $0.setImage(UIImage(resource: .kakaoShare), for: .normal)
-            $0.setTitle(StringLiterals.DateSchedule.kakaoShare, for: .normal)
-            $0.setTitleColor(UIColor(resource: .drWhite), for: .normal)
-            $0.titleLabel?.font = UIFont.suit(.body_bold_15)
-            $0.contentEdgeInsets = UIEdgeInsets(top: 0, left: 24, bottom: 0, right: 24)
-            $0.imageEdgeInsets = UIEdgeInsets(top: 14, left: -6, bottom: 14, right: 6)
-            $0.titleEdgeInsets = UIEdgeInsets(top: 15.5, left: 6, bottom: 15.5, right: -6)
-            $0.roundedButton(cornerRadius: 25, maskedCorners: [.layerMaxXMaxYCorner, .layerMaxXMinYCorner, .layerMinXMaxYCorner, .layerMinXMinYCorner])
+            var config = UIButton.Configuration.plain()
+            config.image = UIImage(resource: .kakaoShare)
+            config.title = StringLiterals.DateSchedule.kakaoShare
+            config.background.backgroundColor = UIColor(resource: .purple600)
+            config.baseForegroundColor = UIColor(resource: .drWhite)
+            config.cornerStyle = .capsule
+            config.imagePadding = 12
+            config.titleTextAttributesTransformer = UIConfigurationTextAttributesTransformer { incoming in
+                var outgoing = incoming
+                outgoing.font = UIFont.suit(.body_bold_15)
+                return outgoing
+            }
+            $0.configuration = config
         }
-                
+        
         DateDetailContentView.dateTimeLineCollectionViewLayout.do {
             $0.scrollDirection = .vertical
             $0.minimumLineSpacing = 12
@@ -278,8 +253,19 @@ extension DateDetailContentView {
     func updateTagButton(title: String, button: UIButton) {
         guard let tendencyTag = TendencyTag.getTag(byEnglish: title) else { return }
         button.do {
-            $0.setImage(tendencyTag.tag.tagIcon, for: .normal)
-            $0.setTitle(" \(tendencyTag.tag.tagTitle)", for: .normal)
+            var config = UIButton.Configuration.plain()
+            config.image = tendencyTag.tag.tagIcon
+            config.title = " \(tendencyTag.tag.tagTitle)"
+            config.titleLineBreakMode = .byClipping
+            config.titleAlignment = .center
+            config.contentInsets = NSDirectionalEdgeInsets(top: 4, leading: 10, bottom: 4, trailing: 10)
+            config.baseForegroundColor = .drBlack
+            config.titleTextAttributesTransformer = UIConfigurationTextAttributesTransformer { incoming in
+                var outgoing = incoming
+                outgoing.font = UIFont.suit(.body_med_13)
+                return outgoing
+            }
+            $0.configuration = config
         }
     }
     

--- a/DATEROAD-iOS/DATEROAD-iOS/Presentation/PointDetail/Views/PointShortageViewController.swift
+++ b/DATEROAD-iOS/DATEROAD-iOS/Presentation/PointDetail/Views/PointShortageViewController.swift
@@ -15,7 +15,7 @@ final class PointShortageViewController: BaseViewController {
     
     private let bottomSheetView: UIView = UIView()
     
-    private let noPointLabel: DRTextLabel = DRTextLabel(title: StringLiterals.PointDetail.noPoint, textLabelType: .clear(.bold17_black))
+    private let noPointLabel: DRTextLabel = DRTextLabel(title: StringLiterals.PointDetail.collectPoint, textLabelType: .clear(.bold17_black))
     
     private let xButton: DRImageButton = DRImageButton(image: UIImage(resource: .btnClose), buttonName: .clear_clear_0)
     


### PR DESCRIPTION
# 🔥*Pull requests*

## ⛳ **작업한 브랜치**
- #310 

## 👷 **작업한 내용**
<!-- 작업한 내용을 적어주세요. -->
#### 공통
  - [x] NavTitle Font size 수정
  - [x] TimeLineCell sequence Index 분기처리
  - [x] 코스 및 일정 등록 alertTextType 수정
  - [x] 코스 및 일정 등록 `데이트 시작 시간` 5분 단위로 변경

#### 코스 등록
  - [x] 뷰3 사진 레이아웃 수정
  - [x] 뷰3 가격 numberFormatted 실시간 적용
  - [x] 코스 등록 사진 용량 초과 대비 하기
  - [x] 썸네일 태그  radius 적용

#### 일정 등록
  - [x] 뷰2 '불러온 일정 데이트 주소' 데이터 바인딩

#### 데이트 일정 상세보기
  - [x] 태그 버튼, 카카오톡  공유 버튼, 코스 등록하러가기 버튼 등 buttonConfiguration 적용

#### 포인트 내역
  - [x] '포인트가 부족해요!' text 수정
  - [x] emptyView titleLabel 위치 수정


## 📸 스크린샷

|    화면    |    Gif    |    화면    |    Gif    |
|:--:|:--:|:--:|:--:|
|일정 계획하기|<img src = "https://github.com/user-attachments/assets/c4c38641-4633-4b2e-94b4-c44c8b1666ee" width ="220">|코스 등록하기|<img src = "https://github.com/user-attachments/assets/c3d0dec6-81b6-48a7-b079-13ddafb05b10" width ="220">

|    화면    |    Gif    |    화면    |    Gif    |
|:--:|:--:|:--:|:--:|
|데이트 일정 상세|<img src = "https://github.com/user-attachments/assets/e6340cb5-bc9b-4b3f-83bb-74323f9d01ce" width ="220">|포인트 내역|<img src = "https://github.com/user-attachments/assets/cdfd75f7-3dd3-4046-ace6-8cc0d53e3eb7" width ="220">

## 📟 관련 이슈
- Resolved: #310 
